### PR TITLE
feat(ui): the rail groups Slack DM and channel sessions apart from local ones

### DIFF
--- a/crates/tidebreak-desktop/ui/src/CommandPaletteDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/CommandPaletteDialog.tsx
@@ -126,6 +126,7 @@ export function CommandPaletteDialog() {
       repos,
       workspaces,
       digests,
+      sessions,
     );
     const workspace = workspaces.find((entry) => entry.id === workspaceId);
     const repo = repos.find((entry) => entry.id === workspace?.repo_id);

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -576,6 +576,96 @@ describe("CodeSidebar", () => {
     );
   });
 
+  it("groups local, Slack DM, and Slack channel sessions as three named origins", async () => {
+    client.listCodeWorkspaces.mockResolvedValueOnce([
+      {
+        id: "ws-local",
+        repo_id: "repo-1",
+        title: "Local thread",
+        worktree_path: "/tmp/app/.worktrees/local",
+        branch_name: "tidebreak/local",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-15T00:00:00.000Z",
+      },
+      {
+        id: "ws-dm",
+        repo_id: "repo-1",
+        title: "Slack DM thread",
+        worktree_path: "/tmp/app/.worktrees/dm",
+        branch_name: "tidebreak/dm",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-16T00:00:00.000Z",
+      },
+      {
+        id: "ws-channel",
+        repo_id: "repo-1",
+        title: "Slack channel thread",
+        worktree_path: "/tmp/app/.worktrees/channel",
+        branch_name: "tidebreak/channel",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-17T00:00:00.000Z",
+      },
+    ]);
+    const idle = {
+      visibility: "private" as const,
+      kind: "interactive" as const,
+      harness_kind: "claude_code" as const,
+      execution_location: "machine" as const,
+      permission_mode: "ask" as const,
+      fast_mode: false,
+      lifecycle: "idle" as const,
+      attention: {
+        state: { type: "working" as const },
+        source: "lifecycle" as const,
+      },
+      unrecognized_event_count: 0,
+      created_at: "2026-08-15T00:00:00.000Z",
+    };
+    useCodeCatalogStore.getState().rememberSession({
+      ...idle,
+      id: "sess-local",
+      workspace_id: "ws-local",
+    });
+    useCodeCatalogStore.getState().rememberSession({
+      ...idle,
+      id: "sess-dm",
+      workspace_id: "ws-dm",
+      external_origin: {
+        channel_kind: "slack",
+        external_key: "T0400000:D0898765:dm2",
+      },
+    });
+    useCodeCatalogStore.getState().rememberSession({
+      ...idle,
+      id: "sess-channel",
+      workspace_id: "ws-channel",
+      external_origin: {
+        channel_kind: "slack",
+        external_key: "T0400000:C0812345:1724900000.123456",
+      },
+    });
+
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+
+    const groups = await screen.findAllByTestId("rail-origin-group");
+    expect(groups.map((group) => group.getAttribute("data-origin"))).toEqual([
+      "local",
+      "slack:channel",
+      "slack:dm",
+    ]);
+    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.getByText("Slack DM")).toBeInTheDocument();
+    expect(screen.getByText("Slack channel")).toBeInTheDocument();
+  });
+
   it("opens and clears selection on an unmodified click", async () => {
     const { router } = await renderWithRouter(
       <AppContextProvider value={app}>

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -129,7 +129,13 @@ export function CodeSidebar() {
 
   useEffect(() => connectCodeUpdates(client), [client]);
 
-  const groups = arrangeWorkspaces(prefs.sortMode, repos, workspaces, digests);
+  const groups = arrangeWorkspaces(
+    prefs.sortMode,
+    repos,
+    workspaces,
+    digests,
+    sessions,
+  );
   const canOpenWorktree = canOpenLocalCodeWorktree();
   const selectedWorkspaceIds = useCodeUiStore(
     (state) => state.selectedWorkspaceIds,
@@ -266,7 +272,20 @@ export function CodeSidebar() {
         }}
       >
         {groups.map((group) => (
-          <div key={group.key} className="flex flex-col gap-1">
+          <div
+            key={group.key}
+            className="flex flex-col gap-1"
+            data-testid={
+              group.key === "local" || group.key.includes(":")
+                ? "rail-origin-group"
+                : undefined
+            }
+            data-origin={
+              group.key === "local" || group.key.includes(":")
+                ? group.key
+                : undefined
+            }
+          >
             {group.label &&
               (isWorkspaceStatusRank(group.key) ? (
                 <div className="flex items-center gap-1.5 px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90">

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { externalThreadUrl } from "./SessionOriginBanner";
+import {
+  externalThreadUrl,
+  sessionOriginGroupLabel,
+  slackConversationKind,
+} from "./SessionOriginBanner";
 
 describe("externalThreadUrl", () => {
   it("derives the Slack permalink from a thread key", () => {
@@ -38,6 +42,25 @@ describe("externalThreadUrl", () => {
     expect(
       externalThreadUrl({ channel_kind: "slack", external_key }),
     ).toBeNull();
+  });
+
+  it("names Slack DM and channel groups from the same key the banner splits", () => {
+    expect(slackConversationKind("T0400000:D0898765:dm2")).toBe("dm");
+    expect(slackConversationKind("T0400000:C0812345:1724900000.123456")).toBe(
+      "channel",
+    );
+    expect(
+      sessionOriginGroupLabel({
+        channel_kind: "slack",
+        external_key: "T0400000:D0898765:dm2",
+      }),
+    ).toBe("Slack DM");
+    expect(
+      sessionOriginGroupLabel({
+        channel_kind: "slack",
+        external_key: "T0400000:C0812345:1724900000.123456",
+      }),
+    ).toBe("Slack channel");
   });
 
   it("yields no link for another channel family", () => {

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
@@ -8,8 +8,32 @@ import type {
   SessionExternalOrigin as CodeSessionExternalOrigin,
 } from "../generated/wire";
 
-function channelLabel(kind: string): string {
+export function channelLabel(kind: string): string {
   return kind === "slack" ? "Slack" : kind;
+}
+
+/** Slack conversation id from a colon- or slash-delimited external key. */
+export function slackChannelId(externalKey: string): string {
+  const parts = externalKey.split(externalKey.includes(":") ? ":" : "/");
+  return parts[1] ?? "";
+}
+
+/**
+ * Slack DM ids start with `D`. Everything else is a channel (including
+ * private groups).
+ */
+export function slackConversationKind(externalKey: string): "dm" | "channel" {
+  return /^D/i.test(slackChannelId(externalKey)) ? "dm" : "channel";
+}
+
+/** Rail group name: channel family plus DM or channel. */
+export function sessionOriginGroupLabel(
+  origin: CodeSessionExternalOrigin,
+): string {
+  const name = channelLabel(origin.channel_kind);
+  return slackConversationKind(origin.external_key) === "dm"
+    ? `${name} DM`
+    : `${name} channel`;
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
@@ -34,12 +34,17 @@ export function stepWorkspaceId(
 
 /** The rail's workspaces in the order it draws them, groups flattened. */
 export function railWorkspaceIds(): string[] {
-  const { repos, workspaces } = useCodeCatalogStore.getState();
+  const { repos, workspaces, sessionsByWorkspace } =
+    useCodeCatalogStore.getState();
   const { sortMode } = useCodeUiStore.getState().railPrefs;
   const digests = workspaceDigests(useCodeUpdatesStore.getState());
-  return arrangeWorkspaces(sortMode, repos, workspaces, digests).flatMap(
-    (group) => group.workspaces.map((workspace) => workspace.id),
-  );
+  return arrangeWorkspaces(
+    sortMode,
+    repos,
+    workspaces,
+    digests,
+    sessionsByWorkspace,
+  ).flatMap((group) => group.workspaces.map((workspace) => workspace.id));
 }
 
 /** The workspace a rail step lands on, or `null` when there is nowhere to go. */

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -4,6 +4,7 @@ import type {
   Attention,
   CodeRepoSnapshot,
   CodeSessionDigest,
+  CodeSessionSnapshot,
   CodeWorkspaceSnapshot,
 } from "../api/types";
 import {
@@ -296,7 +297,58 @@ describe("arrangeWorkspaces", () => {
       ),
     ).toEqual(["needs_you", "idle"]);
   });
+
+  it("groups Slack DM and channel sessions apart from local ones", () => {
+    const rows = [
+      workspace("ws-local", "app", "active", "2026-08-14T00:00:00.000Z"),
+      workspace("ws-dm", "app", "active", "2026-08-16T00:00:00.000Z"),
+      workspace("ws-channel", "app", "active", "2026-08-17T00:00:00.000Z"),
+    ];
+    const sessions: Record<string, CodeSessionSnapshot> = {
+      "ws-dm": sessionOn("ws-dm", {
+        channel_kind: "slack",
+        external_key: "T0400000:D0898765:dm2",
+      }),
+      "ws-channel": sessionOn("ws-channel", {
+        channel_kind: "slack",
+        external_key: "T0400000:C0812345:1724900000.123456",
+      }),
+    };
+    const groups = arrangeWorkspaces("by-created", repos, rows, {}, sessions);
+    expect(
+      groups.map((group) => [
+        group.key,
+        group.label,
+        group.workspaces.map((item) => item.id),
+      ]),
+    ).toEqual([
+      ["local", "Local", ["ws-local"]],
+      ["slack:channel", "Slack channel", ["ws-channel"]],
+      ["slack:dm", "Slack DM", ["ws-dm"]],
+    ]);
+  });
 });
+
+function sessionOn(
+  workspaceId: string,
+  external_origin: CodeSessionSnapshot["external_origin"],
+): CodeSessionSnapshot {
+  return {
+    visibility: "private",
+    id: `sess-${workspaceId}`,
+    workspace_id: workspaceId,
+    kind: "interactive",
+    harness_kind: "claude_code",
+    execution_location: "machine",
+    permission_mode: "ask",
+    fast_mode: false,
+    lifecycle: "idle",
+    attention: working,
+    unrecognized_event_count: 0,
+    created_at: "2026-08-15T00:00:00.000Z",
+    ...(external_origin ? { external_origin } : {}),
+  };
+}
 
 describe("workspaceStatusRank", () => {
   it("ranks archived last even when a digest is noisy", () => {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -2,10 +2,15 @@ import type {
   Attention,
   CodeRepoSnapshot,
   CodeSessionDigest,
+  CodeSessionSnapshot,
   CodeWorkspaceSnapshot,
   CodeWorkspaceStatus,
 } from "../api/types";
 import { attentionLabel, LIFECYCLE_LABELS } from "./labels";
+import {
+  sessionOriginGroupLabel,
+  slackConversationKind,
+} from "./SessionOriginBanner";
 import {
   prCompactStatusLabel,
   pullRequestLifecycle,
@@ -311,8 +316,62 @@ export function arrangeWorkspaces(
   repos: readonly CodeRepoSnapshot[],
   workspaces: readonly CodeWorkspaceSnapshot[],
   digests: Readonly<Record<string, CodeSessionDigest | undefined>>,
+  sessions: Readonly<Record<string, CodeSessionSnapshot | undefined>> = {},
 ): ArrangedWorkspaceGroup[] {
-  return arrangeLiveWorkspaces(mode, repos, workspaces, digests);
+  const live = workspaces.filter((workspace) => !isPutAway(workspace));
+  const originKeys = new Set(
+    live.map((workspace) => originGroupKey(sessions[workspace.id])),
+  );
+  const usesOriginGroups =
+    originKeys.size > 1 || (originKeys.size === 1 && !originKeys.has("local"));
+  if (!usesOriginGroups) {
+    return arrangeLiveWorkspaces(mode, repos, workspaces, digests);
+  }
+  const buckets = new Map<string, CodeWorkspaceSnapshot[]>();
+  for (const workspace of live) {
+    const key = originGroupKey(sessions[workspace.id]);
+    const listed = buckets.get(key);
+    if (listed) listed.push(workspace);
+    else buckets.set(key, [workspace]);
+  }
+  const groups: ArrangedWorkspaceGroup[] = [];
+  for (const key of orderedOriginKeys(buckets.keys())) {
+    const listed = buckets.get(key);
+    if (!listed || listed.length === 0) continue;
+    groups.push({
+      key,
+      label: originGroupHeader(key, sessions[listed[0]!.id]),
+      workspaces: arrangeLiveWorkspaces(mode, repos, listed, digests).flatMap(
+        (group) => group.workspaces,
+      ),
+    });
+  }
+  return groups;
+}
+
+function originGroupKey(session: CodeSessionSnapshot | undefined): string {
+  const origin = session?.external_origin;
+  if (!origin) return "local";
+  return `${origin.channel_kind}:${slackConversationKind(origin.external_key)}`;
+}
+
+function originGroupHeader(
+  key: string,
+  session: CodeSessionSnapshot | undefined,
+): string {
+  if (key === "local") return "Local";
+  if (session?.external_origin) {
+    return sessionOriginGroupLabel(session.external_origin);
+  }
+  return key;
+}
+
+function orderedOriginKeys(keys: Iterable<string>): string[] {
+  return [...keys].sort((left, right) => {
+    if (left === "local") return -1;
+    if (right === "local") return 1;
+    return left.localeCompare(right);
+  });
 }
 
 function arrangeLiveWorkspaces(

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -878,6 +878,26 @@ export const Rail: Story = {
   ),
 };
 
+function OriginGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1" data-testid="rail-origin-group">
+      <div
+        className="truncate px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90"
+        title={label}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
 function StatusGroup({
   rank,
   count,
@@ -987,6 +1007,79 @@ export const GroupedByStatus: Story = {
           workspace={{ ...codeWorkspace, id: "ws-e", title: "Empty workspace" }}
         />
       </StatusGroup>
+    </div>
+  ),
+};
+
+/** Local, Slack DM, and Slack channel sessions as three rail groups. */
+export const RailLocalDmAndChannel: Story = {
+  render: (args) => (
+    <div className="flex flex-col">
+      <OriginGroup label="Local">
+        <WorkspaceCard
+          {...args}
+          workspace={{
+            ...codeWorkspace,
+            id: "ws-local",
+            title: "Local thread",
+          }}
+        />
+      </OriginGroup>
+      <OriginGroup label="Slack channel">
+        <WorkspaceCard
+          {...args}
+          workspace={{
+            ...codeWorkspace,
+            id: "ws-channel",
+            title: "Channel thread",
+          }}
+          session={{
+            ...codeSession,
+            workspace_id: "ws-channel",
+            external_origin: {
+              channel_kind: "slack",
+              external_key: "T0400000:C0812345:1724900000.123456",
+            },
+          }}
+        />
+      </OriginGroup>
+      <OriginGroup label="Slack DM">
+        <WorkspaceCard
+          {...args}
+          workspace={{ ...codeWorkspace, id: "ws-dm", title: "DM thread" }}
+          session={{
+            ...codeSession,
+            workspace_id: "ws-dm",
+            external_origin: {
+              channel_kind: "slack",
+              external_key: "T0400000:D0898765:dm2",
+            },
+          }}
+        />
+      </OriginGroup>
+    </div>
+  ),
+};
+
+/** An empty rail has no origin groups. */
+export const RailEmpty: Story = {
+  render: () => (
+    <div className="flex min-h-0 flex-col gap-1 px-1 py-2">
+      <p className="text-muted-foreground px-2 py-3 text-sm">
+        No workspaces yet.
+      </p>
+    </div>
+  ),
+};
+
+/** One local session stays a single unlabeled list. */
+export const RailSingleGroup: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-1">
+      <WorkspaceCard
+        {...args}
+        workspace={{ ...codeWorkspace, title: "Only local thread" }}
+      />
     </div>
   ),
 };


### PR DESCRIPTION
## What changed

You now see Slack-started workspaces grouped on the code rail by origin. Local sessions stay first. Slack DMs and Slack channels each get their own group, with the origin named on the header. A DM thread and a channel thread no longer read as one list.

The session origin banner still names the origin on the session itself. You derive DM versus channel from the same Slack external key the banner already splits.

When every live row is local, you keep the existing sort (by repo, status, or created). Origin groups only appear when at least one remembered session carries `external_origin`.

## Why

A DM session and a channel session started from Slack sat in the same rail list as local work, with no way to tell them apart.

## Validation

- `pnpm exec biome check` on touched files
- `pnpm exec tsc --noEmit -p tsconfig.json`
- `pnpm exec vitest run` for `workspaceCards.test.ts`, `SessionOriginBanner.test.ts`, and `CodeSidebar.dom.test.tsx` (three sessions render as three groups with the origin named)
- `pnpm storybook:build`

This sandbox has no `pnpm` on `PATH`. Those checks ran through `npx pnpm` after `CI=true pnpm install --frozen-lockfile`. CI is the proof if a lane disagrees.

Storybook covers a mixed local/DM/channel rail, an empty rail, and a single local group.

## Risk

Low. You do not change the server. Grouping reads the remembered session snapshot. Rows stay plain; the group header is the only new chrome. Keyboard rail order follows the same groups.

Closes #3231