### PR TITLE
feat(code): the sandbox is the preferred placement for external sessions only

### DIFF
--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -433,7 +433,7 @@ async fn web_follow_ups_and_recovery_keep_a_slack_session_in_its_sandbox() {
             .register(Arc::new(crate::scripted_harness::ScriptedAdapter::new(
                 crate::scripted_harness::plain_text_script(),
             )));
-        runtime.with_sandbox_only_execution()
+        runtime
     })
     .await;
     let addr = serve(router).await;
@@ -573,6 +573,92 @@ async fn web_follow_ups_and_recovery_keep_a_slack_session_in_its_sandbox() {
         .unwrap()
         .iter()
         .any(|message| message.interrupt));
+}
+
+/// A configured runtime places an external session in the sandbox and leaves
+/// a desktop session on the same app on the machine, with a host worktree.
+#[tokio::test]
+async fn a_runtime_places_only_external_sessions_in_the_sandbox() {
+    let (router, _fake, runtime, repo_id, token, dir) = external_app_built(|mut runtime| {
+        runtime
+            .adapters
+            .register(Arc::new(crate::scripted_harness::ScriptedAdapter::new(
+                crate::scripted_harness::plain_text_script(),
+            )));
+        runtime
+    })
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C-place/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session_id = bound_session_id(&runtime, &owner, "T1/C-place/1.1").await;
+    let snapshot = client
+        .get(format!("http://{addr}/code/sessions/{session_id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(snapshot.status(), reqwest::StatusCode::OK);
+    let snapshot: serde_json::Value = snapshot.json().await.unwrap();
+    assert_eq!(snapshot["execution_location"], "sandbox");
+    assert_eq!(
+        runtime
+            .get_session(&owner, session_id)
+            .await
+            .unwrap()
+            .execution_location,
+        tidebreak_core::ExecutionLocation::Sandbox
+    );
+
+    let repo = super::code::init_git_repo(dir.path());
+    let (_repo, workspace) =
+        super::code::register_and_workspace(&client, addr, &token, &repo).await;
+    let desktop = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            super::code::json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "harness": "claude_code" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(desktop.status(), reqwest::StatusCode::CREATED);
+    let desktop: serde_json::Value = desktop.json().await.unwrap();
+    assert_eq!(desktop["execution_location"], "machine");
+    let desktop_id: tidebreak_core::SessionId =
+        desktop["id"].as_str().unwrap().parse().expect("session id");
+    assert_eq!(
+        runtime
+            .get_session(&owner, desktop_id)
+            .await
+            .unwrap()
+            .execution_location,
+        tidebreak_core::ExecutionLocation::Machine
+    );
+    assert!(runtime.has_worker(desktop_id));
+    let files = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/files",
+            super::code::json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(files.status(), reqwest::StatusCode::OK);
 }
 
 /// The whole adapter surface over HTTP: bad tokens refuse, get-or-create

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -631,12 +631,18 @@ async fn a_runtime_places_only_external_sessions_in_the_sandbox() {
             super::code::json_id(&workspace)
         ))
         .bearer_auth(&token)
-        .json(&serde_json::json!({ "harness": "claude_code" }))
+        .json(&serde_json::json!({ "harness": "claude_code", "permission_mode": "plan" }))
         .send()
         .await
         .unwrap();
-    assert_eq!(desktop.status(), reqwest::StatusCode::CREATED);
-    let desktop: serde_json::Value = desktop.json().await.unwrap();
+    let desktop_status = desktop.status();
+    let desktop_body = desktop.text().await.unwrap();
+    assert_eq!(
+        desktop_status,
+        reqwest::StatusCode::CREATED,
+        "{desktop_body}"
+    );
+    let desktop: serde_json::Value = serde_json::from_str(&desktop_body).unwrap();
     assert_eq!(desktop["execution_location"], "machine");
     let desktop_id: tidebreak_core::SessionId =
         desktop["id"].as_str().unwrap().parse().expect("session id");

--- a/crates/tidebreak-server-api/src/tests/code_hosted_execution.rs
+++ b/crates/tidebreak-server-api/src/tests/code_hosted_execution.rs
@@ -1,11 +1,11 @@
-//! Hosted deployments refuse host scripts and terminals before side effects.
+//! Remote workspaces refuse host restore and retry; machine workspaces stay on the host.
 
 use super::code::{init_git_repo, serve};
 use super::*;
 
 use crate::code::CodeRuntime;
 use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
-use tidebreak_core::db::code::{insert_repo, list_workspaces, save_repo, save_workspace};
+use tidebreak_core::db::code::{insert_repo, save_repo, save_workspace};
 use tidebreak_core::{CodeRepo, CodeWorkspace, CodeWorkspaceStatus, OwnerId, QuickAction, RepoId};
 use tidebreak_harness::AdapterRegistry;
 
@@ -52,7 +52,7 @@ async fn hosted_fixture() -> (
         auto_run_on_create: true,
     }];
     save_repo(&db, &repo).await.unwrap();
-    let runtime = Arc::new(runtime.with_sandbox_only_execution());
+    let runtime = Arc::new(runtime);
     let mut state = AppState::new(
         Config::desktop(dir.path()),
         db,
@@ -66,202 +66,6 @@ async fn hosted_fixture() -> (
     );
     state.code = Some(runtime.clone());
     (state, runtime, repo, workspace, dir)
-}
-
-async fn assert_hosted_refusal(response: reqwest::Response) {
-    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
-    let body: serde_json::Value = response.json().await.unwrap();
-    assert_eq!(body["kind"], "sandbox_session_required");
-}
-
-#[tokio::test]
-async fn sandbox_only_workspace_lifecycle_refuses_before_scripts_or_checkout_changes() {
-    let (state, runtime, repo, mut workspace, _dir) = hosted_fixture().await;
-    let token = state.token.clone();
-    let addr = serve(app(state)).await;
-    let client = reqwest::Client::new();
-    let path = std::path::PathBuf::from(&workspace.worktree_path);
-    let marker = path.join("hosted-script-ran");
-    let rows_before = list_workspaces(&runtime.db, &workspace.owner, Some(repo.id))
-        .await
-        .unwrap();
-    assert_hosted_refusal(
-        client
-            .post(format!("http://{addr}/code/workspaces"))
-            .bearer_auth(&token)
-            .json(&serde_json::json!({"repo_id": repo.id, "title": "forbidden"}))
-            .send()
-            .await
-            .unwrap(),
-    )
-    .await;
-    assert_eq!(
-        list_workspaces(&runtime.db, &workspace.owner, Some(repo.id))
-            .await
-            .unwrap()
-            .len(),
-        rows_before.len()
-    );
-    for action in ["archive", "actions/probe"] {
-        assert_hosted_refusal(
-            client
-                .post(format!(
-                    "http://{addr}/code/workspaces/{}/{action}",
-                    workspace.id
-                ))
-                .bearer_auth(&token)
-                .json(&serde_json::json!({"force": true}))
-                .send()
-                .await
-                .unwrap(),
-        )
-        .await;
-        assert_eq!(
-            runtime
-                .get_workspace(&workspace.owner, workspace.id)
-                .await
-                .unwrap()
-                .status,
-            CodeWorkspaceStatus::Active
-        );
-        assert!(path.join("README.md").exists());
-        assert!(!marker.exists());
-    }
-    workspace.status = CodeWorkspaceStatus::SetupFailed;
-    save_workspace(&runtime.db, &workspace).await.unwrap();
-    assert_hosted_refusal(
-        client
-            .post(format!(
-                "http://{addr}/code/workspaces/{}/retry-setup",
-                workspace.id
-            ))
-            .bearer_auth(&token)
-            .json(&serde_json::json!({}))
-            .send()
-            .await
-            .unwrap(),
-    )
-    .await;
-    assert_eq!(
-        runtime
-            .get_workspace(&workspace.owner, workspace.id)
-            .await
-            .unwrap()
-            .status,
-        CodeWorkspaceStatus::SetupFailed
-    );
-    assert!(!marker.exists());
-
-    assert!(std::process::Command::new("git")
-        .args(["worktree", "remove", "--force", &workspace.worktree_path])
-        .current_dir(&repo.root_path)
-        .status()
-        .unwrap()
-        .success());
-    workspace.status = CodeWorkspaceStatus::Archived;
-    workspace.archived_at = Some(chrono::Utc::now());
-    save_workspace(&runtime.db, &workspace).await.unwrap();
-    assert_hosted_refusal(
-        client
-            .post(format!(
-                "http://{addr}/code/workspaces/{}/restore",
-                workspace.id
-            ))
-            .bearer_auth(&token)
-            .json(&serde_json::json!({}))
-            .send()
-            .await
-            .unwrap(),
-    )
-    .await;
-    assert_eq!(
-        runtime
-            .get_workspace(&workspace.owner, workspace.id)
-            .await
-            .unwrap()
-            .status,
-        CodeWorkspaceStatus::Archived
-    );
-    assert!(!path.exists());
-}
-
-#[tokio::test]
-async fn sandbox_only_terminals_refuse_execution_but_allow_read_and_close() {
-    let (state, _runtime, _repo, workspace, _dir) = hosted_fixture().await;
-    let token = state.token.clone();
-    let terminal = state
-        .terminals
-        .open(
-            &workspace.owner,
-            workspace.id,
-            std::path::Path::new(&workspace.worktree_path),
-            Some(80),
-            Some(24),
-        )
-        .unwrap();
-    let addr = serve(app(state.clone())).await;
-    let client = reqwest::Client::new();
-    let base = format!("http://{addr}/code/workspaces/{}/terminals", workspace.id);
-    assert_hosted_refusal(
-        client
-            .post(&base)
-            .bearer_auth(&token)
-            .json(&serde_json::json!({}))
-            .send()
-            .await
-            .unwrap(),
-    )
-    .await;
-    assert_eq!(state.terminals.list(workspace.id).len(), 1);
-    use base64::Engine;
-    let bytes =
-        base64::engine::general_purpose::STANDARD.encode("echo terminal > hosted-terminal-ran\n");
-    assert_hosted_refusal(
-        client
-            .post(format!("{base}/{}/write", terminal.id))
-            .bearer_auth(&token)
-            .json(&serde_json::json!({"bytes": bytes}))
-            .send()
-            .await
-            .unwrap(),
-    )
-    .await;
-    assert_hosted_refusal(
-        client
-            .post(format!("{base}/{}/resize", terminal.id))
-            .bearer_auth(&token)
-            .json(&serde_json::json!({"cols": 100, "rows": 30}))
-            .send()
-            .await
-            .unwrap(),
-    )
-    .await;
-    let unchanged = state.terminals.list(workspace.id);
-    assert_eq!((unchanged[0].cols, unchanged[0].rows), (80, 24));
-    assert_eq!(
-        client
-            .get(format!("{base}/{}/read?cursor=0", terminal.id))
-            .bearer_auth(&token)
-            .send()
-            .await
-            .unwrap()
-            .status(),
-        reqwest::StatusCode::OK
-    );
-    assert_eq!(
-        client
-            .delete(format!("{base}/{}", terminal.id))
-            .bearer_auth(&token)
-            .send()
-            .await
-            .unwrap()
-            .status(),
-        reqwest::StatusCode::NO_CONTENT
-    );
-    assert!(state.terminals.close_workspace_and_wait(workspace.id).await);
-    assert!(!std::path::Path::new(&workspace.worktree_path)
-        .join("hosted-terminal-ran")
-        .exists());
 }
 
 #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -205,8 +205,6 @@ pub struct CodeRuntime {
     /// runtime endpoint (`docs/slack-sessions.md`). `None` everywhere else;
     /// remote workspaces then refuse turns rather than half-running.
     remote: Option<Arc<super::remote::service::RemoteSessions>>,
-    /// Hosted execution keeps untrusted engines outside this server process.
-    sandbox_only_execution: bool,
     /// The mode a channel-bound session takes on this machine's engine when
     /// the channel names none, and the most permissive mode a channel may
     /// name (decision 88). Both default to `ask`.
@@ -478,7 +476,6 @@ impl CodeRuntime {
             harness_llm,
             gateway_runtime: None,
             remote: None,
-            sandbox_only_execution: false,
             external_permission: ExternalPermissionPolicy::default(),
             grant_revocations: Arc::new(super::grants::GrantRevocations::default()),
             loopback_base: Mutex::new(None),
@@ -640,7 +637,6 @@ impl CodeRuntime {
             harness_llm: None,
             gateway_runtime: None,
             remote: None,
-            sandbox_only_execution: false,
             external_permission: ExternalPermissionPolicy::default(),
             grant_revocations: Arc::new(super::grants::GrantRevocations::default()),
             loopback_base: Mutex::new(None),
@@ -751,21 +747,6 @@ impl CodeRuntime {
     #[must_use]
     pub fn external_permission_policy(&self) -> ExternalPermissionPolicy {
         self.external_permission
-    }
-
-    pub fn with_sandbox_only_execution(mut self) -> Self {
-        self.sandbox_only_execution = true;
-        self
-    }
-
-    fn require_machine_execution(&self) -> Result<(), ServerError> {
-        if self.sandbox_only_execution {
-            return Err(ServerError::conflict_kind(
-                "sandbox_session_required",
-                "this hosted deployment runs agents in isolated sandboxes; start a new sandbox session",
-            ));
-        }
-        Ok(())
     }
 
     /// The remote-session context, when this deployment configured one.

--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -222,8 +222,7 @@ impl CodeRuntime {
                 !matches!(
                     session.lifecycle,
                     SessionLifecycle::Ended | SessionLifecycle::Fenced
-                ) && !self.sandbox_only_execution
-                    && session.execution_location == tidebreak_core::ExecutionLocation::Machine
+                ) && session.execution_location == tidebreak_core::ExecutionLocation::Machine
                     && !self
                         .workers
                         .lock()

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -342,7 +342,8 @@ impl CodeRuntime {
 
     /// Where an external session runs on this deployment (decision 0088):
     /// a gateway sandbox when a sandbox runtime is configured, else the
-    /// machine's own engine. The machine is the floor, not an interim path.
+    /// machine's own engine. Desktop, mobile, and `agent-mcp` sessions do
+    /// not use this default. The machine is the floor, not an interim path.
     #[must_use]
     pub fn external_execution_location(&self) -> ExecutionLocation {
         if self.remote.is_some() {
@@ -741,7 +742,6 @@ impl CodeRuntime {
         }
         let session = self.get_session(owner, session_id).await?;
         if session.execution_location == ExecutionLocation::Machine {
-            self.require_machine_execution()?;
             if let Some(external) = self
                 .harness_llm
                 .as_ref()

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -201,7 +201,6 @@ impl CodeRuntime {
                 )
                 .await;
         }
-        self.require_machine_execution()?;
         if workspace
             .as_ref()
             .is_some_and(|workspace| workspace.is_remote())
@@ -512,9 +511,6 @@ impl CodeRuntime {
         paused: bool,
     ) -> Result<(), ServerError> {
         let session = self.get_session(owner, id).await?;
-        if !paused && session.execution_location == tidebreak_core::ExecutionLocation::Machine {
-            self.require_machine_execution()?;
-        }
         tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, paused).await?;
         if !paused {
             self.wake_queue_for_location(&session);
@@ -527,9 +523,6 @@ impl CodeRuntime {
     /// pause, move the row first, stop the live turn, then this.
     pub async fn send_queued_now(&self, owner: &OwnerId, id: SessionId) -> Result<(), ServerError> {
         let session = self.get_session(owner, id).await?;
-        if session.execution_location == tidebreak_core::ExecutionLocation::Machine {
-            self.require_machine_execution()?;
-        }
         tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, false).await?;
         self.wake_queue_for_location(&session);
         Ok(())

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -153,7 +153,6 @@ impl CodeRuntime {
                 "this session runs in a sandbox and cannot attach a local worker",
             ));
         }
-        self.require_machine_execution()?;
         let mut session = session;
         let workspace = self.session_workspace(&session).await?;
         if workspace
@@ -677,50 +676,6 @@ mod tests {
         let recovered = runtime.get_session(&owner, session.id).await.unwrap();
         assert_eq!(recovered.spawn_epoch, session.spawn_epoch);
         assert_eq!(recovered.lifecycle, SessionLifecycle::Idle);
-    }
-
-    #[tokio::test]
-    async fn sandbox_only_execution_refuses_existing_machine_sessions() {
-        let tmp = tempfile::tempdir().unwrap();
-        let runtime = scripted_runtime(tmp.path())
-            .await
-            .with_sandbox_only_execution();
-        let owner = OwnerId::local();
-        let mut session = workspaceless_session(&owner, HarnessKind::ClaudeCode);
-        session.lifecycle = SessionLifecycle::Idle;
-        insert_session(&runtime.db, &session).await.unwrap();
-
-        let error = runtime
-            .attach_and_spawn_worker(session.clone())
-            .await
-            .unwrap_err();
-        assert_eq!(error.kind(), "sandbox_session_required");
-        let outcome = runtime
-            .submit_turn(
-                &owner,
-                session.id,
-                "run locally".into(),
-                None,
-                None,
-                Vec::new(),
-                None,
-            )
-            .await;
-        let error = match outcome {
-            Err(error) => error,
-            Ok(_) => panic!("a hosted machine session accepted local execution"),
-        };
-        assert_eq!(error.kind(), "sandbox_session_required");
-        runtime.recover().await.unwrap();
-        assert!(!runtime.has_worker(session.id));
-        assert_eq!(
-            runtime
-                .get_session(&owner, session.id)
-                .await
-                .unwrap()
-                .execution_location,
-            tidebreak_core::ExecutionLocation::Machine
-        );
     }
 
     /// A worker still on another file than the channel selects is respawned

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -1666,7 +1666,6 @@ impl CodeRuntime {
                 "this workspace's engine runs in a remote sandbox; there is no host worktree",
             ));
         }
-        self.require_machine_execution()?;
         if !std::path::Path::new(&workspace.worktree_path).exists() {
             return Err(ServerError::not_found("workspace worktree is gone"));
         }

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -48,7 +48,6 @@ impl CodeRuntime {
         base_ref: Option<String>,
         lender: Option<&dyn crate::obo_gateway::GitCredentialLender>,
     ) -> Result<CodeWorkspace, ServerError> {
-        self.require_machine_execution()?;
         let repo = self.get_repo(owner, repo_id).await?;
         Self::refuse_removed_repo(&repo)?;
         let explicit_title = title
@@ -294,9 +293,6 @@ impl CodeRuntime {
         terminals: &crate::code::terminal::TerminalHub,
     ) -> Result<CodeWorkspace, ServerError> {
         let mut workspace = self.get_workspace(owner, id).await?;
-        if !workspace.is_remote() {
-            self.require_machine_execution()?;
-        }
         if workspace.status == CodeWorkspaceStatus::Archived {
             return Ok(workspace);
         }
@@ -399,9 +395,6 @@ impl CodeRuntime {
         force: bool,
         terminals: &crate::code::terminal::TerminalHub,
     ) -> Result<CodeWorkspace, ServerError> {
-        if !workspace.is_remote() {
-            self.require_machine_execution()?;
-        }
         if !terminals.close_workspace_and_wait(workspace.id).await {
             return Err(ServerError::conflict_kind(
                 "terminal_shutdown_timeout",
@@ -676,9 +669,6 @@ impl CodeRuntime {
         let lifecycle = self.workspace_lifecycle_lock(id);
         let _lifecycle_guard = lifecycle.lock().await;
         let mut workspace = self.get_workspace(owner, id).await?;
-        if !workspace.is_remote() {
-            self.require_machine_execution()?;
-        }
         if workspace.status == CodeWorkspaceStatus::Active {
             return Ok(workspace);
         }
@@ -809,9 +799,6 @@ impl CodeRuntime {
         let lifecycle = self.workspace_lifecycle_lock(id);
         let _lifecycle_guard = lifecycle.lock().await;
         let mut workspace = self.get_workspace(owner, id).await?;
-        if !workspace.is_remote() {
-            self.require_machine_execution()?;
-        }
         if workspace.status == CodeWorkspaceStatus::Active {
             return Ok(workspace);
         }

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1349,11 +1349,6 @@ async fn bind_inner(
                     .with_external_delegations(db.clone()),
             )
             .map_err(|error| AgentError::config(format!("sandbox runtime client: {error}")))?;
-            let runtime = if state.config.profile == Profile::SelfHost {
-                runtime.with_sandbox_only_execution()
-            } else {
-                runtime
-            };
             runtime.with_remote_sessions(code::remote::service::RemoteSessions::new(
                 Arc::new(provisioner),
                 code::remote::service::configured_settings(profile, &state.config),

--- a/docs/decisions/0088-a-slack-session-runs-where-the-deployment-can-run-it.md
+++ b/docs/decisions/0088-a-slack-session-runs-where-the-deployment-can-run-it.md
@@ -82,3 +82,18 @@ sandbox deployment anything but `allow` is refused
 placement's boundary. `Allow` on the machine therefore stays an
 operator's decision per deployment, taken once at boot, and a channel can
 only ask within it.
+
+## Amendment 2026-09-08: placement defaults for external sessions only
+
+The deployment default (sandbox when a runtime is configured, else
+machine) applies at external get-or-create only. Desktop, mobile, and
+`agent-mcp` sessions on the same machine keep machine execution and the
+utilities that go with it: terminal, diffs, scripts, previews. A
+configured runtime is not a server-wide sandbox-only switch.
+
+`execution_location` on the session is the only dispatch rule after
+create. Turns, queue drain, worker attach, and recovery read that
+column. They do not re-derive placement from the workspace or from a
+process-wide flag. A message typed on the web into a sandbox session
+reaches the sandbox lease (or a typed conflict if the lease is gone),
+never a local engine spawn.

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -477,15 +477,19 @@ A session runs where the deployment can run it
 The machine chooses an execution location once, at external
 get-or-create, from what it has: a gateway sandbox when a sandbox
 runtime is configured, else its own engine on a worktree under its
-worktree root. The location is stored on the session, reported on the
-snapshot and the external event stream, and never changes. The machine
-engine is the floor, not an interim path: a deployment without a
-gateway, and a gateway deployment without a configured runtime, runs
-Slack sessions the way it already runs desktop, mobile, and `agent-mcp`
-sessions. An earlier version of this page refused to ship Slack on the
-machine engine; the refusal rested on the sandbox being the only thing
-that made unattended `Allow` safe, and the answer is not to withhold
-sessions but to withhold `Allow`.
+worktree root. That default is for external sessions only. Desktop,
+mobile, and `agent-mcp` sessions on the same machine keep machine
+execution. The location is stored on the session, reported on the
+snapshot and the external event stream, and never changes. After
+create, `execution_location` is the only dispatch rule: a later
+message, including one typed on the web, follows the stored location.
+The machine engine is the floor, not an interim path: a deployment
+without a gateway, and a gateway deployment without a configured
+runtime, runs Slack sessions the way it already runs desktop, mobile,
+and `agent-mcp` sessions. An earlier version of this page refused to
+ship Slack on the machine engine; the refusal rested on the sandbox
+being the only thing that made unattended `Allow` safe, and the answer
+is not to withhold sessions but to withhold `Allow`.
 
 Permission mode follows the location. Inside a sandbox the engine is
 `Allow`; confinement is the permission boundary


### PR DESCRIPTION
## What changed

You pick execution location for an external session once, at get-or-create, from what the deployment has: a sandbox when a runtime is configured, else the machine. Desktop, mobile, and `agent-mcp` sessions on that same machine stay on the machine and keep the terminal, diffs, scripts, and previews.

You no longer flip the whole process to sandbox-only when a runtime is present. `with_sandbox_only_execution` and `require_machine_execution` are gone. After create, the session's `execution_location` is the only dispatch rule for turns, queue drain, worker attach, and recovery. A message typed on the web into a sandbox session follows that stored location (the #3216 failure).

Decision 0088 now states this rule. `docs/slack-sessions.md` Execution matches it.

## Why

#3228 made a configured runtime switch every session, including desktop ones on the hosted machine, onto sandbox-only execution. Placement belongs on the external session, not the process.

## Identity on sandbox spawn

`thet/session-acts-as` has not landed on `origin/main`. This change does not define a second `ActsAs`. The sandbox spawn will carry the session's identity choice once that change lands, so a bot-owned channel session never borrows a person's token.

## Validation

- `cargo fmt --all`
- `cargo clippy -p tidebreak-core -p tidebreak-server-core -p tidebreak-server --all-targets -- -D warnings -A clippy::too_many_arguments`
- `cargo test -p tidebreak-server-core --lib a_sandbox_session_never_attaches`
- HTTP integration tests in `code_external.rs` (`a_runtime_places_only_external_sessions_in_the_sandbox`, `web_follow_ups_and_recovery_keep_a_slack_session_in_its_sandbox`) and `code_hosted_execution.rs` did not complete here: connecting to the test server on `127.0.0.1` timed out (`os error 110`). CI should run them.
- You could not run UI checks: `pnpm` is not on PATH, and `node_modules` was not used.

## Risk

Existing Slack sessions keep their stored location. Desktop sessions on a hosted machine with a runtime regain machine utilities; that is the point. Remote workspaces still refuse host restore, retry, and files.

Closes #3230
Closes #3216