### PR TITLE
feat(code): external sessions carry approvals, questions, and plans, and contributors decide them

### DIFF
--- a/crates/tidebreak-core/src/chat_journal.rs
+++ b/crates/tidebreak-core/src/chat_journal.rs
@@ -77,6 +77,7 @@ pub fn journal_row(event: &AgentEvent) -> Event {
                 approval: *kind,
                 grant_scopes: grant_scopes.clone(),
                 preview: preview.clone(),
+                preview_truncated: false,
             }),
         },
         AgentEvent::ApprovalDecided { call_id, approved } => Event::ApprovalResolved {
@@ -187,6 +188,7 @@ pub fn chat_event(event: Event) -> Result<Option<AgentEvent>> {
                 approval,
                 grant_scopes,
                 preview,
+                preview_truncated: _,
             } => AgentEvent::ApprovalRequired {
                 auto_judging,
                 call_id: CallId(approval_id.0),

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -427,8 +427,63 @@ fn bound_preview_text(text: &str) -> (String, bool) {
     }
 }
 
+/// Whether a field the preview builder already clamped may have been cut.
+///
+/// `ToolActionPreview::build` clamps every field to `MAX_ACTION_FIELD_CHARS`
+/// and keeps no record of it, so by the time a card is projected the only
+/// trace of a cut is a field sitting exactly at the cap. Treating that as
+/// truncated is conservative: a field that happens to be exactly the cap's
+/// length reads as possibly cut, and the adapter falls back to the web link,
+/// which is the safe direction for a consent surface.
+fn at_field_cap(text: &str) -> bool {
+    text.chars().count() >= MAX_ACTION_FIELD_CHARS
+}
+
+fn any_at_field_cap<'a>(fields: impl IntoIterator<Item = &'a str>) -> bool {
+    fields.into_iter().any(at_field_cap)
+}
+
 fn bound_action_preview(preview: ToolActionPreview) -> (ToolActionPreview, bool) {
-    match preview {
+    let already_cut = match &preview {
+        ToolActionPreview::Exec {
+            command,
+            args,
+            cwd,
+            files,
+            summary,
+        } => any_at_field_cap(
+            [command.as_str(), cwd.as_str()]
+                .into_iter()
+                .chain(args.iter().map(String::as_str))
+                .chain(files.iter().map(String::as_str))
+                .chain(summary.as_deref()),
+        ),
+        ToolActionPreview::Search { query, summary } => {
+            any_at_field_cap([query.as_str()].into_iter().chain(summary.as_deref()))
+        }
+        ToolActionPreview::WebSearch {
+            query,
+            domains,
+            start_published_at,
+            end_published_at,
+            summary,
+        } => any_at_field_cap(
+            [query.as_str()]
+                .into_iter()
+                .chain(domains.iter().map(String::as_str))
+                .chain(start_published_at.as_deref())
+                .chain(end_published_at.as_deref())
+                .chain(summary.as_deref()),
+        ),
+        ToolActionPreview::WebExtract { url, summary } => {
+            any_at_field_cap([url.as_str()].into_iter().chain(summary.as_deref()))
+        }
+        ToolActionPreview::WriteFile { path, summary } => {
+            any_at_field_cap([path.as_str()].into_iter().chain(summary.as_deref()))
+        }
+        ToolActionPreview::DelegateAgent { .. } => false,
+    };
+    let (preview, truncated) = match preview {
         ToolActionPreview::Exec {
             command,
             args,
@@ -480,7 +535,8 @@ fn bound_action_preview(preview: ToolActionPreview) -> (ToolActionPreview, bool)
             (ToolActionPreview::WriteFile { path, summary }, truncated)
         }
         other => (other, false),
-    }
+    };
+    (preview, truncated || already_cut)
 }
 
 fn tool_name_for_preview(preview: &ToolActionPreview) -> String {
@@ -782,6 +838,55 @@ mod tests {
     use crate::attention::FenceReason;
     use crate::code::HarnessKind;
     use uuid::Uuid;
+
+    #[test]
+    fn a_command_the_builder_clamped_projects_as_a_truncated_card() {
+        let turn_id = TurnId::new();
+        let long = crate::ToolActionPreview::build(
+            "exec",
+            &serde_json::json!({ "command": "x".repeat(600) }),
+        )
+        .expect("a command builds a preview");
+        let card = InternalApprovalRequest::from_kind(
+            &ApprovalKind::ToolUse {
+                preview: long,
+                offered_grants: Vec::new(),
+            },
+            turn_id,
+            false,
+        );
+        let InternalApprovalRequest::ToolUse {
+            preview_truncated, ..
+        } = card
+        else {
+            panic!("a tool use projects a tool-use card");
+        };
+        assert!(
+            preview_truncated,
+            "a command the builder cut to the cap is not the command being approved"
+        );
+
+        let short = crate::ToolActionPreview::build(
+            "exec",
+            &serde_json::json!({ "command": "cargo test" }),
+        )
+        .expect("a command builds a preview");
+        let card = InternalApprovalRequest::from_kind(
+            &ApprovalKind::ToolUse {
+                preview: short,
+                offered_grants: Vec::new(),
+            },
+            turn_id,
+            false,
+        );
+        let InternalApprovalRequest::ToolUse {
+            preview_truncated, ..
+        } = card
+        else {
+            panic!("a tool use projects a tool-use card");
+        };
+        assert!(!preview_truncated, "a short command is shown whole");
+    }
 
     #[test]
     fn a_multi_path_file_write_names_every_path_or_says_it_was_cut() {

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -378,19 +378,26 @@ impl InternalApprovalRequest {
                 }
             }
             ApprovalKind::FileWrite { paths } => {
+                // The person consents to every path, so the card names them
+                // all: the first as the path, the whole set in the summary.
+                // A set the summary cannot hold is a truncated preview, and
+                // the adapter falls back to the web link.
                 let path = paths.first().cloned().unwrap_or_default();
-                let (path, preview_truncated) = bound_preview_text(&path);
+                let (path, path_truncated) = bound_preview_text(&path);
+                let (summary, summary_truncated) = if paths.len() > 1 {
+                    let (joined, truncated) = bound_preview_text(&paths.join("\n"));
+                    (Some(format!("{} files:\n{joined}", paths.len())), truncated)
+                } else {
+                    (None, false)
+                };
                 Self::ToolUse {
                     auto_judging,
                     tool_name: "write_file".into(),
                     class: ApprovalClass::Workspace,
                     approval: ToolApprovalKind::WorkspaceMayModifyFiles,
                     grant_scopes: Vec::new(),
-                    preview: Some(ToolActionPreview::WriteFile {
-                        path,
-                        summary: None,
-                    }),
-                    preview_truncated,
+                    preview: Some(ToolActionPreview::WriteFile { path, summary }),
+                    preview_truncated: path_truncated || summary_truncated,
                 }
             }
             ApprovalKind::Network { summary } | ApprovalKind::Other { summary } => {
@@ -775,6 +782,41 @@ mod tests {
     use crate::attention::FenceReason;
     use crate::code::HarnessKind;
     use uuid::Uuid;
+
+    #[test]
+    fn a_multi_path_file_write_names_every_path_or_says_it_was_cut() {
+        let turn_id = TurnId::new();
+        let paths = vec!["a.rs".to_owned(), "b.rs".to_owned(), "c.rs".to_owned()];
+        let card =
+            InternalApprovalRequest::from_kind(&ApprovalKind::FileWrite { paths }, turn_id, false);
+        let InternalApprovalRequest::ToolUse {
+            preview: Some(ToolActionPreview::WriteFile { path, summary }),
+            preview_truncated,
+            ..
+        } = card
+        else {
+            panic!("a file write projects a write_file card");
+        };
+        assert_eq!(path, "a.rs");
+        assert_eq!(summary.as_deref(), Some("3 files:\na.rs\nb.rs\nc.rs"));
+        assert!(!preview_truncated, "three short paths fit the card");
+
+        let paths: Vec<String> = (0..64)
+            .map(|index| format!("{}/{index}.rs", "d".repeat(40)))
+            .collect();
+        let card =
+            InternalApprovalRequest::from_kind(&ApprovalKind::FileWrite { paths }, turn_id, false);
+        let InternalApprovalRequest::ToolUse {
+            preview_truncated, ..
+        } = card
+        else {
+            panic!("a file write projects a write_file card");
+        };
+        assert!(
+            preview_truncated,
+            "a set the summary cannot hold is a truncated preview"
+        );
+    }
 
     #[test]
     fn event_is_internally_tagged() {

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -12,10 +12,10 @@ use crate::attention::{AttentionSource, AttentionState};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-use super::{ApprovalId, HarnessKind, TurnId};
+use super::{ApprovalId, ApprovalKind, HarnessKind, TurnId};
 use crate::approval::{GrantScope, ToolApprovalKind};
 use crate::error::AgentErrorInfo;
-use crate::preview::{ToolActionPreview, ToolResultPreview};
+use crate::preview::{ToolActionPreview, ToolResultPreview, MAX_ACTION_FIELD_CHARS};
 use crate::provider::{RefusalOutcome, StopReason};
 use crate::tool::{ApprovalClass, ToolOutput};
 
@@ -320,6 +320,10 @@ pub enum InternalApprovalRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         preview: Option<ToolActionPreview>,
+        /// True when the preview was cut to the action-field bound so a
+        /// channel adapter can fall back to a web link for the rest.
+        #[serde(default, skip_serializing_if = "is_false")]
+        preview_truncated: bool,
     },
     /// A questions card parked the turn; the questions ride the row's kind.
     Questions {
@@ -331,6 +335,167 @@ pub enum InternalApprovalRequest {
         /// Turn that resumes after the decision commits.
         turn_id: TurnId,
     },
+}
+
+impl InternalApprovalRequest {
+    /// Card facts a channel can render without loading the approval row.
+    #[must_use]
+    pub fn from_kind(kind: &ApprovalKind, turn_id: TurnId, auto_judging: bool) -> Self {
+        match kind {
+            ApprovalKind::ToolUse {
+                preview,
+                offered_grants,
+            } => {
+                let (preview, preview_truncated) = bound_action_preview(preview.clone());
+                Self::ToolUse {
+                    auto_judging,
+                    tool_name: tool_name_for_preview(&preview),
+                    class: class_for_preview(&preview),
+                    approval: ToolApprovalKind::for_tool_name(&tool_name_for_preview(&preview)),
+                    grant_scopes: offered_grants.clone(),
+                    preview: Some(preview),
+                    preview_truncated,
+                }
+            }
+            ApprovalKind::Questions { .. } => Self::Questions { turn_id },
+            ApprovalKind::Plan { .. } => Self::Plan { turn_id },
+            ApprovalKind::Command { cmd, cwd } => {
+                let (command, preview_truncated) = bound_preview_text(cmd);
+                Self::ToolUse {
+                    auto_judging,
+                    tool_name: "exec".into(),
+                    class: ApprovalClass::Workspace,
+                    approval: ToolApprovalKind::ExecMayRunNetworkedCommand,
+                    grant_scopes: Vec::new(),
+                    preview: Some(ToolActionPreview::Exec {
+                        command,
+                        args: Vec::new(),
+                        cwd: cwd.clone().unwrap_or_else(|| ".".into()),
+                        files: Vec::new(),
+                        summary: None,
+                    }),
+                    preview_truncated,
+                }
+            }
+            ApprovalKind::FileWrite { paths } => {
+                let path = paths.first().cloned().unwrap_or_default();
+                let (path, preview_truncated) = bound_preview_text(&path);
+                Self::ToolUse {
+                    auto_judging,
+                    tool_name: "write_file".into(),
+                    class: ApprovalClass::Workspace,
+                    approval: ToolApprovalKind::WorkspaceMayModifyFiles,
+                    grant_scopes: Vec::new(),
+                    preview: Some(ToolActionPreview::WriteFile {
+                        path,
+                        summary: None,
+                    }),
+                    preview_truncated,
+                }
+            }
+            ApprovalKind::Network { summary } | ApprovalKind::Other { summary } => {
+                let (summary, preview_truncated) = bound_preview_text(summary);
+                Self::ToolUse {
+                    auto_judging,
+                    tool_name: "other".into(),
+                    class: ApprovalClass::Sensitive,
+                    approval: ToolApprovalKind::Unsupported,
+                    grant_scopes: Vec::new(),
+                    preview: Some(ToolActionPreview::WriteFile {
+                        path: summary,
+                        summary: None,
+                    }),
+                    preview_truncated,
+                }
+            }
+        }
+    }
+}
+
+fn bound_preview_text(text: &str) -> (String, bool) {
+    if text.chars().count() > MAX_ACTION_FIELD_CHARS {
+        (text.chars().take(MAX_ACTION_FIELD_CHARS).collect(), true)
+    } else {
+        (text.to_owned(), false)
+    }
+}
+
+fn bound_action_preview(preview: ToolActionPreview) -> (ToolActionPreview, bool) {
+    match preview {
+        ToolActionPreview::Exec {
+            command,
+            args,
+            cwd,
+            files,
+            summary,
+        } => {
+            let (command, truncated) = bound_preview_text(&command);
+            (
+                ToolActionPreview::Exec {
+                    command,
+                    args,
+                    cwd,
+                    files,
+                    summary,
+                },
+                truncated,
+            )
+        }
+        ToolActionPreview::Search { query, summary } => {
+            let (query, truncated) = bound_preview_text(&query);
+            (ToolActionPreview::Search { query, summary }, truncated)
+        }
+        ToolActionPreview::WebSearch {
+            query,
+            domains,
+            start_published_at,
+            end_published_at,
+            summary,
+        } => {
+            let (query, truncated) = bound_preview_text(&query);
+            (
+                ToolActionPreview::WebSearch {
+                    query,
+                    domains,
+                    start_published_at,
+                    end_published_at,
+                    summary,
+                },
+                truncated,
+            )
+        }
+        ToolActionPreview::WebExtract { url, summary } => {
+            let (url, truncated) = bound_preview_text(&url);
+            (ToolActionPreview::WebExtract { url, summary }, truncated)
+        }
+        ToolActionPreview::WriteFile { path, summary } => {
+            let (path, truncated) = bound_preview_text(&path);
+            (ToolActionPreview::WriteFile { path, summary }, truncated)
+        }
+        other => (other, false),
+    }
+}
+
+fn tool_name_for_preview(preview: &ToolActionPreview) -> String {
+    match preview {
+        ToolActionPreview::Exec { .. } => "exec".into(),
+        ToolActionPreview::Search { .. } => "search".into(),
+        ToolActionPreview::WebSearch { .. } => "web_search".into(),
+        ToolActionPreview::WebExtract { .. } => "web_extract".into(),
+        ToolActionPreview::WriteFile { .. } => "write_file".into(),
+        ToolActionPreview::DelegateAgent { .. } => crate::SPAWN_SANDBOX_AGENT_TOOL.into(),
+    }
+}
+
+fn class_for_preview(preview: &ToolActionPreview) -> ApprovalClass {
+    match preview {
+        ToolActionPreview::Exec { .. }
+        | ToolActionPreview::WriteFile { .. }
+        | ToolActionPreview::DelegateAgent { .. } => ApprovalClass::Workspace,
+        ToolActionPreview::Search { .. }
+        | ToolActionPreview::WebSearch { .. }
+        | ToolActionPreview::WebExtract { .. } => ApprovalClass::Sensitive,
+    }
 }
 
 /// One event in an external agent-engine session's journal.
@@ -451,8 +616,9 @@ pub enum Event {
     ApprovalRequested {
         /// Hint id; the row is the source of truth.
         approval_id: ApprovalId,
-        /// What the card asks, for the chat surface's replay. Internal
-        /// engine; absent on every row an external adapter writes.
+        /// What the card asks: tool name, class, consent kind, grant ladder,
+        /// and a size-capped preview. Written for machine sessions; absent
+        /// on sandbox sessions, which never park on these cards.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         request: Option<InternalApprovalRequest>,

--- a/crates/tidebreak-core/src/db/migration/one_approval_surface.rs
+++ b/crates/tidebreak-core/src/db/migration/one_approval_surface.rs
@@ -620,6 +620,7 @@ fn rewrite_event(payload: &serde_json::Value) -> Result<Event, String> {
                 grant_scopes: parse_optional::<Vec<GrantScope>>(payload, "grant_scopes")?
                     .unwrap_or_default(),
                 preview: parse_optional::<ToolActionPreview>(payload, "preview")?,
+                preview_truncated: false,
             }),
         },
         "tool_approval_decided" => Event::ApprovalResolved {

--- a/crates/tidebreak-core/src/db/ops/code/approval.rs
+++ b/crates/tidebreak-core/src/db/ops/code/approval.rs
@@ -97,7 +97,11 @@ pub async fn insert_approval_for_worker(
         .map_err(store_err)?;
     let event = Event::ApprovalRequested {
         approval_id: approval.id,
-        request: None,
+        request: Some(crate::code::InternalApprovalRequest::from_kind(
+            &approval.kind,
+            approval.turn_id,
+            approval.auto_judge_status.is_some(),
+        )),
     };
     let seq = append_event_on_locked(&transaction, owner, approval.session_id, &event).await?;
     transaction.commit().await.map_err(store_err)?;

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2938,10 +2938,7 @@ function parseInternalApprovalRequest(
 ): import("../generated/wire").InternalApprovalRequest | null {
   if (!isRecord(value)) return null;
   if (value.kind === "questions" || value.kind === "plan") {
-    if (
-      !onlyKeys(value, ["kind", "turn_id"]) ||
-      !wireId(value.turn_id)
-    ) {
+    if (!onlyKeys(value, ["kind", "turn_id"]) || !wireId(value.turn_id)) {
       return null;
     }
     return { kind: value.kind, turn_id: value.turn_id };
@@ -2961,7 +2958,8 @@ function parseInternalApprovalRequest(
     typeof value.tool_name !== "string" ||
     !APPROVAL_CLASSES.has(value.class as string) ||
     !TOOL_APPROVAL_KINDS.has(value.approval as string) ||
-    (value.auto_judging !== undefined && typeof value.auto_judging !== "boolean") ||
+    (value.auto_judging !== undefined &&
+      typeof value.auto_judging !== "boolean") ||
     (value.preview_truncated !== undefined &&
       typeof value.preview_truncated !== "boolean") ||
     (value.grant_scopes !== undefined && !Array.isArray(value.grant_scopes))

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -120,6 +120,7 @@ import type {
   CodeCheckLogsSnapshot,
   CodeForkTranscript,
 } from "../api/types";
+import { parseToolActionPreview } from "../api/parsers";
 import type {
   Event as WireCodeEvent,
   CodeRepoSnapshot as WireCodeRepoSnapshot,
@@ -2919,6 +2920,71 @@ export function parseTurnActor(
   };
 }
 
+const APPROVAL_CLASSES = new Set(["read_only", "workspace", "sensitive"]);
+const TOOL_APPROVAL_KINDS = new Set([
+  "search_may_share_query_and_excerpts",
+  "web_search_may_share_query",
+  "web_extract_may_fetch_url",
+  "exec_may_run_networked_command",
+  "external_mcp_may_call_server",
+  "workspace_may_modify_files",
+  "delegate_may_run_background_agent",
+  "computer_may_control_app",
+  "unsupported",
+]);
+
+function parseInternalApprovalRequest(
+  value: unknown,
+): import("../generated/wire").InternalApprovalRequest | null {
+  if (!isRecord(value)) return null;
+  if (value.kind === "questions" || value.kind === "plan") {
+    if (
+      !onlyKeys(value, ["kind", "turn_id"]) ||
+      !wireId(value.turn_id)
+    ) {
+      return null;
+    }
+    return { kind: value.kind, turn_id: value.turn_id };
+  }
+  if (value.kind !== "tool_use") return null;
+  if (
+    !onlyKeys(value, [
+      "kind",
+      "auto_judging",
+      "tool_name",
+      "class",
+      "approval",
+      "grant_scopes",
+      "preview",
+      "preview_truncated",
+    ]) ||
+    typeof value.tool_name !== "string" ||
+    !APPROVAL_CLASSES.has(value.class as string) ||
+    !TOOL_APPROVAL_KINDS.has(value.approval as string) ||
+    (value.auto_judging !== undefined && typeof value.auto_judging !== "boolean") ||
+    (value.preview_truncated !== undefined &&
+      typeof value.preview_truncated !== "boolean") ||
+    (value.grant_scopes !== undefined && !Array.isArray(value.grant_scopes))
+  ) {
+    return null;
+  }
+  const preview =
+    value.preview === undefined
+      ? undefined
+      : parseToolActionPreview(value.preview);
+  if (value.preview !== undefined && !preview) return null;
+  return {
+    kind: "tool_use",
+    ...(value.auto_judging ? { auto_judging: true } : {}),
+    tool_name: value.tool_name,
+    class: value.class as import("../generated/wire").ApprovalClass,
+    approval: value.approval as import("../generated/wire").ToolApprovalKind,
+    ...(value.grant_scopes ? { grant_scopes: value.grant_scopes } : {}),
+    ...(preview ? { preview } : {}),
+    ...(value.preview_truncated ? { preview_truncated: true } : {}),
+  };
+}
+
 const IMAGE_MEDIA_TYPES = new Set<import("../generated/wire").ImageMediaType>([
   "png",
   "jpeg",
@@ -3976,16 +4042,26 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
         message: value.message,
         remediation: value.remediation,
       };
-    case "approval_requested":
-      // The internal engine journals the card's request beside the id so
-      // the chat surface replays it; the code surface loads the row.
+    case "approval_requested": {
+      // Machine sessions journal the card's facts beside the id so a
+      // channel adapter can render it; sandbox sessions carry none.
       if (
         !onlyKeys(value, ["type", "approval_id", "request"]) ||
         !wireId(value.approval_id)
       ) {
         return null;
       }
-      return { type: "approval_requested", approval_id: value.approval_id };
+      if (value.request === undefined) {
+        return { type: "approval_requested", approval_id: value.approval_id };
+      }
+      const request = parseInternalApprovalRequest(value.request);
+      if (!request) return null;
+      return {
+        type: "approval_requested",
+        approval_id: value.approval_id,
+        request,
+      };
+    }
     case "approval_resolved": {
       if (
         !onlyKeys(value, ["type", "approval_id", "decision", "actor"]) ||

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2192,8 +2192,9 @@ diffstat: Diffstat, } | { "type": "approval_requested",
  */
 approval_id: ApprovalId,
 /**
- * What the card asks, for the chat surface's replay. Internal
- * engine; absent on every row an external adapter writes.
+ * What the card asks: tool name, class, consent kind, grant ladder,
+ * and a size-capped preview. Written for machine sessions; absent
+ * on sandbox sessions, which never park on these cards.
  */
 request?: InternalApprovalRequest, } | { "type": "approval_resolved",
 /**
@@ -3054,7 +3055,12 @@ grant_scopes?: Array<GrantScope>,
 /**
  * Closed projection of what the call will do, when its tool has one.
  */
-preview?: ToolActionPreview, } | { "kind": "questions",
+preview?: ToolActionPreview,
+/**
+ * True when the preview was cut to the action-field bound so a
+ * channel adapter can fall back to a web link for the rest.
+ */
+preview_truncated?: boolean, } | { "kind": "questions",
 /**
  * Turn that resumes after the answer commits.
  */

--- a/crates/tidebreak-server-api/fixtures/code-frames.json
+++ b/crates/tidebreak-server-api/fixtures/code-frames.json
@@ -1190,6 +1190,31 @@
   },
   {
     "kind": "event_frame",
+    "name": "event: approval_requested (truncated preview)",
+    "value": {
+      "event": {
+        "approval_id": "00000000-0000-0000-0000-000000000005",
+        "request": {
+          "approval": "exec_may_run_networked_command",
+          "class": "workspace",
+          "kind": "tool_use",
+          "preview": {
+            "args": [],
+            "command": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "cwd": ".",
+            "files": [],
+            "tool": "exec"
+          },
+          "preview_truncated": true,
+          "tool_name": "exec"
+        },
+        "type": "approval_requested"
+      },
+      "seq": 61
+    }
+  },
+  {
+    "kind": "event_frame",
     "name": "event: task_plan_updated (internal engine)",
     "value": {
       "event": {

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -491,6 +491,18 @@ pub fn app(state: AppState) -> Router {
             axum::routing::put(routes::code::external_session_access),
         )
         .route(
+            "/external/code/sessions/{id}/approvals/{call}/decision",
+            post(routes::code::external_approval_decision),
+        )
+        .route(
+            "/external/code/sessions/{id}/questions/{call}/decision",
+            post(routes::code::external_question_decision),
+        )
+        .route(
+            "/external/code/sessions/{id}/plans/{call}/decision",
+            post(routes::code::external_plan_decision),
+        )
+        .route(
             "/external/grants/rotate",
             post(routes::code::external_rotate),
         )

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -16,8 +16,8 @@ use axum::http::StatusCode;
 use axum::response::Response;
 
 use tidebreak_core::{
-    CodeExternalGrant, ExternalSessionResolution, GrantRotation, HarnessKind, PermissionMode,
-    RepoId, SessionId,
+    ApprovalId, CodeExternalGrant, ExternalSessionResolution, GrantRotation, HarnessKind,
+    PermissionMode, RepoId, SessionId,
 };
 
 use crate::code::runtime::{ExternalMessage, ExternalMessageOutcome, NewSessionSettings};
@@ -25,7 +25,10 @@ use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
 
-use super::types::{QueuedTurn, SessionEventsQuery, SessionSnapshot};
+use super::types::{
+    ApprovalDecision, ApprovalSnapshot, QueuedTurn, SessionEventsQuery, SessionSnapshot,
+};
+use crate::code::runtime::ApprovalDecisionRequest;
 
 /// The authenticated grant behind an adapter request.
 ///
@@ -557,4 +560,98 @@ pub async fn external_rotate(
             "the refresh token matches no live grant",
         )),
     }
+}
+
+#[derive(serde::Deserialize)]
+pub struct ExternalDecisionActor {
+    pub external_identity: String,
+    #[serde(default)]
+    pub display: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+pub struct ExternalDecisionBody {
+    pub decision: ApprovalDecision,
+    #[serde(default)]
+    pub feedback: Option<String>,
+    /// Workspace-grant messages name the person in the body. A person grant
+    /// omits this and the machine records the grant identity.
+    #[serde(default)]
+    pub actor: Option<ExternalDecisionActor>,
+}
+
+/// `POST /external/code/sessions/{id}/approvals/{call}/decision`
+pub async fn external_approval_decision(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path((id, call)): Path<(SessionId, ApprovalId)>,
+    Json(body): Json<ExternalDecisionBody>,
+) -> Result<Json<ApprovalSnapshot>, ServerError> {
+    external_decide(state, grant, id, call, body).await
+}
+
+/// `POST /external/code/sessions/{id}/questions/{call}/decision`
+pub async fn external_question_decision(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path((id, call)): Path<(SessionId, ApprovalId)>,
+    Json(body): Json<ExternalDecisionBody>,
+) -> Result<Json<ApprovalSnapshot>, ServerError> {
+    external_decide(state, grant, id, call, body).await
+}
+
+/// `POST /external/code/sessions/{id}/plans/{call}/decision`
+pub async fn external_plan_decision(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path((id, call)): Path<(SessionId, ApprovalId)>,
+    Json(body): Json<ExternalDecisionBody>,
+) -> Result<Json<ApprovalSnapshot>, ServerError> {
+    external_decide(state, grant, id, call, body).await
+}
+
+async fn external_decide(
+    state: AppState,
+    grant: CodeExternalGrant,
+    session_id: SessionId,
+    call: ApprovalId,
+    body: ExternalDecisionBody,
+) -> Result<Json<ApprovalSnapshot>, ServerError> {
+    let runtime = require_bound(&state, &grant, session_id).await?;
+    let approval = runtime.get_approval(&grant.owner, call).await?;
+    if approval.session_id != session_id {
+        return Err(ServerError::not_found("code session not found"));
+    }
+    let decision = match body.decision {
+        ApprovalDecision::Approve => ApprovalDecisionRequest::Approve,
+        ApprovalDecision::Deny => ApprovalDecisionRequest::Deny {
+            feedback: body.feedback,
+        },
+        ApprovalDecision::ApproveWithGrant { grant_index } => {
+            ApprovalDecisionRequest::ApproveWithGrant { grant_index }
+        }
+        ApprovalDecision::Answers { answers } => ApprovalDecisionRequest::Answers { answers },
+        ApprovalDecision::PlanDecision { approve } => ApprovalDecisionRequest::PlanDecision {
+            approve,
+            feedback: body.feedback,
+        },
+    };
+    let actor = match body.actor {
+        Some(actor) => tidebreak_core::TurnActor {
+            principal: None,
+            display: actor.display,
+            channel_kind: Some(grant.channel_kind.clone()),
+            external_identity: Some(actor.external_identity),
+        },
+        None => tidebreak_core::TurnActor {
+            principal: None,
+            display: None,
+            channel_kind: Some(grant.channel_kind.clone()),
+            external_identity: Some(grant.external_identity.clone()),
+        },
+    };
+    let settled = runtime
+        .decide_approval(&grant.owner, call, decision, Some(actor))
+        .await?;
+    Ok(Json(ApprovalSnapshot::from(settled)))
 }

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -51,7 +51,9 @@ pub(crate) use delivery::{
     resolve_repositories as resolve_delivery_repositories, run_detail as delivery_run_detail,
 };
 pub(crate) use external::{
-    external_approval_decision, external_events, external_get_or_create, external_interrupt, external_messages, external_plan_decision, external_question_decision, external_reap, external_rotate, external_session_access,
+    external_approval_decision, external_events, external_get_or_create, external_interrupt,
+    external_messages, external_plan_decision, external_question_decision, external_reap,
+    external_rotate, external_session_access,
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -51,8 +51,7 @@ pub(crate) use delivery::{
     resolve_repositories as resolve_delivery_repositories, run_detail as delivery_run_detail,
 };
 pub(crate) use external::{
-    external_events, external_get_or_create, external_interrupt, external_messages, external_reap,
-    external_rotate, external_session_access,
+    external_approval_decision, external_events, external_get_or_create, external_interrupt, external_messages, external_plan_decision, external_question_decision, external_reap, external_rotate, external_session_access,
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -709,12 +709,19 @@ async fn web_follow_ups_and_recovery_keep_a_slack_session_in_its_sandbox() {
     .await;
     assert_eq!(fake.spawns.lock().unwrap().len(), 1);
     assert!(!runtime.has_worker(session_id));
-    assert!(
-        tidebreak_core::db::code::list_queued_turns(&runtime.db, &owner, session_id)
+    // The queued turn drains after the send lands, so wait for it rather
+    // than reading the queue in the same instant.
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while !tidebreak_core::db::code::list_queued_turns(&runtime.db, &owner, session_id)
             .await
             .unwrap()
             .is_empty()
-    );
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the queued turn drains after the send lands");
     let interrupted = client
         .post(format!(
             "http://{addr}/code/sessions/{session_id}/interrupt"

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -2827,6 +2827,8 @@ async fn a_person_grant_refuses_a_body_actor() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
 fn long_command_approval_script() -> Vec<tidebreak_harness::HarnessEvent> {
     use tidebreak_harness::{HarnessApprovalRef, HarnessEvent};
     let cmd = "x".repeat(600);

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -2820,4 +2820,266 @@ async fn a_person_grant_refuses_a_body_actor() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+fn long_command_approval_script() -> Vec<tidebreak_harness::HarnessEvent> {
+    use tidebreak_harness::{HarnessApprovalRef, HarnessEvent};
+    let cmd = "x".repeat(600);
+    vec![
+        HarnessEvent::SessionStarted {
+            harness_kind: tidebreak_core::HarnessKind::ClaudeCode,
+            harness_version: "scripted".into(),
+            resume_ref: Some("scripted-session".into()),
+        },
+        HarnessEvent::TurnStarted,
+        HarnessEvent::ApprovalRequested {
+            harness_ref: HarnessApprovalRef::engine("toolu_scripted"),
+            raw: serde_json::json!({}),
+            kind: Some(tidebreak_core::ApprovalKind::Command {
+                cmd,
+                cwd: Some(".".into()),
+            }),
+        },
+        HarnessEvent::AssistantDelta {
+            text: "after the decision".into(),
+        },
+        HarnessEvent::TurnCompleted {
+            usage: Default::default(),
+        },
+    ]
+}
+
+/// A Default-mode machine session parks on a command; the external stream
+/// carries the card facts with a bounded preview; a contributor settles it
+/// and the journal names them; a second decision answers already_settled;
+/// standing grants stay off for this engine; a sandbox session emits none.
+#[tokio::test]
+async fn a_machine_session_parks_on_an_approval_a_contributor_can_settle() {
+    use std::time::Duration;
+    use tidebreak_core::{ApprovalState, HarnessKind};
+
+    let (router, runtime, repo_id, _dir) = machine_app_built(|mut runtime| {
+        runtime.adapters.register(Arc::new(
+            crate::scripted_harness::ScriptedAdapter::new(long_command_approval_script())
+                .with_kind(HarnessKind::ClaudeCode)
+                .with_approvals(tidebreak_core::CapLevel::Supported)
+                .with_plan_mode(tidebreak_core::CapLevel::Supported)
+                .with_auto_mode(tidebreak_core::CapLevel::Supported)
+                .with_allow_mode(tidebreak_core::CapLevel::Supported),
+        ));
+        runtime
+    })
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U7", "T1")
+        .await
+        .unwrap();
+
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "external_key": "T1/C-approve/1.1",
+            "repo_id": repo_id,
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session_id = bound_session_id(&runtime, &owner, "T1/C-approve/1.1").await;
+
+    let delivered = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/messages"
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "text": "run a command",
+            "event_id": "Ev-approve",
+            "channel_ts": "1.1",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(delivered.status(), reqwest::StatusCode::OK);
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let approval = loop {
+        let pending = runtime
+            .list_approvals(&owner, Some(ApprovalState::Pending), Some(session_id))
+            .await
+            .unwrap();
+        if let Some(row) = pending.into_iter().next() {
+            break row;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the machine session parks on an approval"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+
+    let mut request = format!("ws://{addr}/external/code/sessions/{session_id}/events")
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {}", pair.token).parse().unwrap(),
+    );
+    let (mut socket, _) = connect_async(request).await.unwrap();
+    let mut saw_card = false;
+    let ws_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while !saw_card {
+        let frame = tokio::time::timeout_at(ws_deadline, socket.next())
+            .await
+            .expect("the stream carries the approval card")
+            .expect("the stream stays open")
+            .unwrap();
+        let Ok(text) = frame.to_text() else { continue };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
+            continue;
+        };
+        if value["event"]["type"] == "approval_requested" {
+            let request = &value["event"]["request"];
+            assert_eq!(request["kind"], "tool_use");
+            assert_eq!(request["tool_name"], "exec");
+            assert_eq!(request["preview_truncated"], true);
+            let preview = request["preview"]["command"].as_str().unwrap();
+            assert_eq!(preview.chars().count(), 512);
+            assert!(
+                request["grant_scopes"].is_null()
+                    || request["grant_scopes"] == serde_json::json!([])
+            );
+            saw_card = true;
+        }
+    }
+
+    let grant_refused = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/approvals/{}/decision",
+            approval.id
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "decision": { "approve_with_grant": { "grant_index": 0 } },
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        grant_refused.status(),
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY
+    );
+    let grant_body: serde_json::Value = grant_refused.json().await.unwrap();
+    assert_eq!(grant_body["kind"], "standing_grants_unavailable");
+
+    let decided = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/approvals/{}/decision",
+            approval.id
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "decision": "approve",
+            "actor": { "external_identity": "U7", "display": "Ada" },
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        decided.status(),
+        reqwest::StatusCode::OK,
+        "{}",
+        decided.text().await.unwrap()
+    );
+
+    let page = tidebreak_core::db::code::list_events(
+        &runtime.db,
+        &owner,
+        session_id,
+        0,
+        tidebreak_core::db::code::MAX_REPLAY_EVENTS,
+    )
+    .await
+    .unwrap();
+    let resolved = page
+        .events
+        .iter()
+        .find_map(|sequenced| match &sequenced.event {
+            tidebreak_core::Event::ApprovalResolved { actor, .. } => actor.clone(),
+            _ => None,
+        });
+    let actor = resolved.expect("the journal names who decided");
+    assert_eq!(actor.external_identity.as_deref(), Some("U7"));
+    assert_eq!(actor.display.as_deref(), Some("Ada"));
+
+    let second = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/questions/{}/decision",
+            approval.id
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "decision": "approve" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.status(), reqwest::StatusCode::CONFLICT);
+    let second: serde_json::Value = second.json().await.unwrap();
+    assert_eq!(second["kind"], "already_settled");
+    assert_eq!(second["actor"]["external_identity"], "U7");
+    assert_eq!(second["actor"]["display"], "Ada");
+
+    let (router, _fake, runtime, repo_id, _dir) = external_app().await;
+    let addr = serve(router).await;
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U7", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "external_key": "T1/C-sandbox/1.1",
+            "repo_id": repo_id,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session_id = bound_session_id(&runtime, &owner, "T1/C-sandbox/1.1").await;
+    let _ = client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{session_id}/messages"
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "text": "run a command",
+            "event_id": "Ev-sandbox",
+            "channel_ts": "1.1",
+        }))
+        .send()
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let page = tidebreak_core::db::code::list_events(
+        &runtime.db,
+        &owner,
+        session_id,
+        0,
+        tidebreak_core::db::code::MAX_REPLAY_EVENTS,
+    )
+    .await
+    .unwrap();
+    assert!(
+        page.events.iter().all(|sequenced| {
+            !matches!(
+                sequenced.event,
+                tidebreak_core::Event::ApprovalRequested { .. }
+                    | tidebreak_core::Event::ApprovalResolved { .. }
+            )
+        }),
+        "a sandbox session carries none of these cards"
+    );
 }

--- a/crates/tidebreak-server-api/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server-api/src/wire_code_fixtures.rs
@@ -971,6 +971,7 @@ fn event_frames() -> Vec<Fixture> {
                             command: "cargo".to_owned(),
                         }],
                         preview: None,
+                        preview_truncated: false,
                     }),
                 },
             ),
@@ -992,6 +993,30 @@ fn event_frames() -> Vec<Fixture> {
                 Event::ApprovalRequested {
                     approval_id: approval_id(),
                     request: Some(InternalApprovalRequest::Plan { turn_id: turn_id() }),
+                },
+            ),
+        ),
+        (
+            "event: approval_requested (truncated preview)",
+            frame(
+                61,
+                Event::ApprovalRequested {
+                    approval_id: approval_id(),
+                    request: Some(InternalApprovalRequest::ToolUse {
+                        auto_judging: false,
+                        tool_name: "exec".to_owned(),
+                        class: ApprovalClass::Workspace,
+                        approval: ToolApprovalKind::ExecMayRunNetworkedCommand,
+                        grant_scopes: Vec::new(),
+                        preview: Some(tidebreak_core::ToolActionPreview::Exec {
+                            command: "x".repeat(512),
+                            args: Vec::new(),
+                            cwd: ".".to_owned(),
+                            files: Vec::new(),
+                            summary: None,
+                        }),
+                        preview_truncated: true,
+                    }),
                 },
             ),
         ),

--- a/crates/tidebreak-server/src/code/runtime/approvals.rs
+++ b/crates/tidebreak-server/src/code/runtime/approvals.rs
@@ -99,7 +99,7 @@ fn already_settled_error(approval: &Approval) -> ServerError {
         .unwrap_or("someone else");
     ServerError::conflict_kind_with(
         "already_settled",
-        format!("this card was already settled by {who}"),
+        format!("this card is no longer awaiting a decision: it was settled by {who}"),
         serde_json::json!({ "actor": approval.actor }),
     )
 }

--- a/crates/tidebreak-server/src/code/runtime/approvals.rs
+++ b/crates/tidebreak-server/src/code/runtime/approvals.rs
@@ -85,6 +85,25 @@ pub(super) fn resolve_decision_request(
     }
 }
 
+fn already_settled_error(approval: &Approval) -> ServerError {
+    let who = approval
+        .actor
+        .as_ref()
+        .and_then(|actor| {
+            actor
+                .display
+                .as_deref()
+                .or(actor.external_identity.as_deref())
+                .or(actor.principal.as_deref())
+        })
+        .unwrap_or("someone else");
+    ServerError::conflict_kind_with(
+        "already_settled",
+        format!("this card was already settled by {who}"),
+        serde_json::json!({ "actor": approval.actor }),
+    )
+}
+
 impl CodeRuntime {
     pub(super) fn approval_channel(
         &self,
@@ -292,13 +311,7 @@ impl CodeRuntime {
     ) -> Result<Approval, ServerError> {
         let initial = self.get_approval(owner, id).await?;
         if !initial.state.is_pending() {
-            return Err(ServerError::conflict_kind(
-                "approval_not_pending",
-                format!(
-                    "approval {id} is no longer awaiting a decision: it is {}",
-                    initial.state.as_str()
-                ),
-            ));
+            return Err(already_settled_error(&initial));
         }
         if initial.decision_claim.is_some() {
             return Err(ServerError::conflict_kind(
@@ -312,13 +325,7 @@ impl CodeRuntime {
         // Re-read every durable precondition after the gate is ours.
         let approval = self.get_approval(owner, id).await?;
         if !approval.state.is_pending() {
-            return Err(ServerError::conflict_kind(
-                "approval_not_pending",
-                format!(
-                    "approval {id} is no longer awaiting a decision: it is {}",
-                    approval.state.as_str()
-                ),
-            ));
+            return Err(already_settled_error(&approval));
         }
         if approval.decision_claim.is_some() {
             return Err(ServerError::conflict_kind(
@@ -363,15 +370,13 @@ impl CodeRuntime {
         .await?
         else {
             let current = self.get_approval(owner, id).await?;
-            let kind = if current.state.is_pending() && current.decision_claim.is_some() {
-                "approval_decision_in_progress"
-            } else {
-                "approval_not_pending"
-            };
-            return Err(ServerError::conflict_kind(
-                kind,
-                format!("approval {id} no longer accepts this decision"),
-            ));
+            if current.state.is_pending() && current.decision_claim.is_some() {
+                return Err(ServerError::conflict_kind(
+                    "approval_decision_in_progress",
+                    format!("approval {id} already has a decision in progress"),
+                ));
+            }
+            return Err(already_settled_error(&current));
         };
         let (reply, rx) = oneshot::channel();
         if handle

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -206,6 +206,7 @@ impl ServerError {
                 kind: kind.to_owned(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -16,6 +16,7 @@ use tidebreak_core::{AgentError, AgentErrorInfo};
 pub struct ServerError {
     status: StatusCode,
     info: AgentErrorInfo,
+    extra: Option<serde_json::Value>,
 }
 
 impl ServerError {
@@ -27,6 +28,7 @@ impl ServerError {
                 kind: "not_found".to_string(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -38,6 +40,7 @@ impl ServerError {
                 kind: "unauthorized".to_string(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -50,6 +53,7 @@ impl ServerError {
                 kind: "forbidden".to_string(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -62,6 +66,7 @@ impl ServerError {
                 kind: "not_implemented".to_string(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -76,6 +81,7 @@ impl ServerError {
                 kind: "bad_request".to_string(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -87,6 +93,7 @@ impl ServerError {
                 kind: kind.to_owned(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -99,6 +106,7 @@ impl ServerError {
                 kind: "payload_too_large".to_string(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -121,6 +129,7 @@ impl ServerError {
                 kind: "conflict".to_string(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -132,6 +141,23 @@ impl ServerError {
                 kind: kind.to_owned(),
                 message: message.into(),
             },
+            extra: None,
+        }
+    }
+
+    /// A conflict that also names who already acted.
+    pub fn conflict_kind_with(
+        kind: &'static str,
+        message: impl Into<String>,
+        extra: serde_json::Value,
+    ) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            info: AgentErrorInfo {
+                kind: kind.to_owned(),
+                message: message.into(),
+            },
+            extra: Some(extra),
         }
     }
 
@@ -143,6 +169,7 @@ impl ServerError {
                 kind: kind.to_owned(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -154,6 +181,7 @@ impl ServerError {
                 kind: kind.to_owned(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -165,6 +193,7 @@ impl ServerError {
                 kind: kind.to_owned(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -190,6 +219,7 @@ impl ServerError {
                 kind: "internal".to_string(),
                 message: message.into(),
             },
+            extra: None,
         }
     }
 
@@ -218,6 +248,7 @@ impl From<AgentError> for ServerError {
         Self {
             status,
             info: (&err).into(),
+            extra: None,
         }
     }
 }
@@ -254,7 +285,20 @@ impl From<tidebreak_core::MemoryError> for ServerError {
 
 impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
-        (self.status, Json(self.info)).into_response()
+        let mut body = serde_json::to_value(&self.info).unwrap_or_else(|_| {
+            serde_json::json!({
+                "kind": self.info.kind,
+                "message": self.info.message,
+            })
+        });
+        if let Some(extra) = self.extra {
+            if let (Some(object), Some(extra_object)) = (body.as_object_mut(), extra.as_object()) {
+                for (key, value) in extra_object {
+                    object.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        (self.status, Json(body)).into_response()
     }
 }
 

--- a/docs/decisions/0090-approvals-are-answerable-where-the-person-is.md
+++ b/docs/decisions/0090-approvals-are-answerable-where-the-person-is.md
@@ -1,0 +1,55 @@
+# 90. Approvals are answerable where the person is
+
+- Status: Accepted
+- Date: 2026-09-08
+- Owners: thet
+- Related: [0039](0039-allow-is-a-first-class-code-permission-mode.md); [0086](0086-session-access-is-separate-from-ownership.md); [0088](0088-a-slack-session-runs-where-the-deployment-can-run-it.md); `docs/slack-sessions.md`; tidebreak #3178 (track C), #3186
+- Supersedes: the "do not approve engine actions from Slack" paragraphs of `docs/slack-sessions.md`
+
+## Context
+
+A sandbox session is Allow and never asks. Decision 88 put machine sessions
+on the deployment's default mode, so Default and Plan park on approvals,
+questions, and plans. Slack is where the person is. The desktop already
+settles those cards through one path; the channel could not.
+
+## Decision
+
+You answer a parked card from the surface you are on. The external event
+stream carries the card's facts for a machine session — tool name, class,
+consent kind, grant ladder, a size-capped preview, and a flag when that
+preview was cut — and `ApprovalResolved` names who decided. A sandbox
+session still carries none of these events.
+
+You settle through the same path the desktop uses, on
+`POST /external/code/sessions/{id}/approvals/{call}/decision` (and the
+question and plan aliases), as a contributor. The actor is the grant's
+external identity, or the optional body `actor` a workspace grant will
+send. A card already settled elsewhere answers `already_settled` with who
+decided. Approve-and-remember is offered only for the internal engine.
+
+## Alternatives Considered
+
+**Keep Slack read-only for consent.** Rejected: a machine session in Ask
+would park with no one in the thread able to unpark it.
+
+**A second settlement path for the adapter.** Rejected: two writers on one
+row is how a card gets two answers.
+
+## Consequences
+
+The adapter can render a card and post a decision without loading the
+approval row. A truncated preview is a prompt to open the web link, not a
+reason to send the rest of the payload over the channel.
+
+Revisit if a channel needs the full preview in-thread, or if a sandbox
+placement ever parks on consent.
+
+## Validation
+
+- A Default-mode machine session parks on a shell command; a contributor
+  approves; the journal names them; a second decision answers
+  `already_settled`.
+- The stream's preview is size-capped and flags truncation.
+- A standing grant is refused for an engine that does not declare it.
+- A sandbox session emits none of these events.

--- a/docs/decisions/0091-approvals-are-answerable-where-the-person-is.md
+++ b/docs/decisions/0091-approvals-are-answerable-where-the-person-is.md
@@ -1,4 +1,4 @@
-# 90. Approvals are answerable where the person is
+# 91. Approvals are answerable where the person is
 
 - Status: Accepted
 - Date: 2026-09-08

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -99,5 +99,5 @@
 0088  0088-a-slack-session-runs-where-the-deployment-can-run-it.md
 0089  0089-service-principals.md
 0090  0090-a-session-acts-as-one-forge-identity.md
+0091  0091-approvals-are-answerable-where-the-person-is.md
 0092  0092-workspace-grants.md
-0090  0090-approvals-are-answerable-where-the-person-is.md

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -100,3 +100,4 @@
 0089  0089-service-principals.md
 0090  0090-a-session-acts-as-one-forge-identity.md
 0092  0092-workspace-grants.md
+0090  0090-approvals-are-answerable-where-the-person-is.md

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -813,7 +813,7 @@ cost, recorded so the gate is honest:
 - Approving engine actions from a Slack button on a sandbox session. The
   repository confirmation and the reap button stay session-lifecycle
   consent. A machine session's approval, question, and plan cards are in
-  scope (decision 90).
+  scope (decision 91).
 - Transcript-level resume for scratch sessions.
 
 ## Open questions

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -420,8 +420,9 @@ readable repository whose contents prompt-inject an engine holding the
 shared identity's forge credential. With the gate, a changed default
 cannot silently redirect anyone. Setting or changing a default also
 posts a visible notice naming who changed it. This confirmation is
-session-lifecycle consent, not an engine approval; the ban on approving
-engine actions from Slack stands.
+session-lifecycle consent, not an engine approval. You still approve
+engine actions from Slack when a machine session parks on a card; the
+repository gate is a different question.
 
 The GitHub App installation intersected with the person's access is the
 allowlist, refused with a human-readable rendering: outside the App
@@ -526,11 +527,12 @@ for with `/tidebreak mode`. A request above the ceiling is refused by
 name, `permission_mode_above_ceiling`, so the person learns the
 deployment's rule instead of getting a silently clamped session; a
 request for anything but `allow` on a sandbox deployment is refused as
-`permission_mode_unsupported`. The owner answers approvals from the
-desktop or the web, where the session is visible like any other, until
-the channel can carry them. Slack renders no harness approval cards yet.
-Slack `NeedsYou` is connect, fenced, or failed — never
-`approval_requested`.
+`permission_mode_unsupported`. You answer approvals where you are. A
+machine session parks on the same cards the desktop shows; the external
+stream carries their facts and you settle them from Slack. A sandbox
+session stays Allow and never asks, so it still carries none of these
+events. Slack `NeedsYou` includes `approval_requested` on a machine
+session; connect, fenced, or failed stay as they were.
 
 Incarnations follow a durable intent protocol: write the incarnation
 intent row, provision, activate. Stop and reincarnate serialize through
@@ -808,9 +810,10 @@ cost, recorded so the gate is honest:
 - Streaming tool activity or reasoning into Slack. The assistant record
   streams; the engine's interior does not.
 - Reusing `tidebreak-sandbox-protocol`.
-- Approving engine actions from a Slack button. The repository
-  confirmation and the reap button are session-lifecycle consent, and
-  that line is the boundary.
+- Approving engine actions from a Slack button on a sandbox session. The
+  repository confirmation and the reap button stay session-lifecycle
+  consent. A machine session's approval, question, and plan cards are in
+  scope (decision 90).
 - Transcript-level resume for scratch sessions.
 
 ## Open questions

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2192,8 +2192,9 @@ diffstat: Diffstat, } | { "type": "approval_requested",
  */
 approval_id: ApprovalId,
 /**
- * What the card asks, for the chat surface's replay. Internal
- * engine; absent on every row an external adapter writes.
+ * What the card asks: tool name, class, consent kind, grant ladder,
+ * and a size-capped preview. Written for machine sessions; absent
+ * on sandbox sessions, which never park on these cards.
  */
 request?: InternalApprovalRequest, } | { "type": "approval_resolved",
 /**
@@ -3054,7 +3055,12 @@ grant_scopes?: Array<GrantScope>,
 /**
  * Closed projection of what the call will do, when its tool has one.
  */
-preview?: ToolActionPreview, } | { "kind": "questions",
+preview?: ToolActionPreview,
+/**
+ * True when the preview was cut to the action-field bound so a
+ * channel adapter can fall back to a web link for the rest.
+ */
+preview_truncated?: boolean, } | { "kind": "questions",
 /**
  * Turn that resumes after the answer commits.
  */


### PR DESCRIPTION
## What changed

You can now answer a parked approval, question, or plan from the grant-authenticated external surface, the same way you do from the desktop.

A machine session streams `ApprovalRequested` with the card facts (tool name, class, consent kind, grant ladder, a size-capped preview, and a truncation flag), plus `Questions`, `Plan`, and `ApprovalResolved` with the actor. A sandbox session still carries none of these events.

You settle through `POST /external/code/sessions/{id}/approvals/{call}/decision`, with `/questions/{call}/decision` and `/plans/{call}/decision` as aliases. The actor is the grant's external identity, or the optional body `actor` a workspace grant will send. A card already settled elsewhere answers 409 `already_settled` with who decided. Approve-and-remember is offered only for the internal engine.

Decision 90 records that approvals are answerable where the person is. `docs/slack-sessions.md` no longer bans approving engine actions from Slack on a machine session.

## Why

A machine session keeps its permission mode, so Default and Plan park on cards. Slack is where the person is. The desktop already had one settlement path; the channel needed the same path instead of a second writer.

## Validation

- `cargo fmt --all`
- `cargo clippy -p tidebreak-core -p tidebreak-server-core -p tidebreak-server --all-targets -- -D warnings -A clippy::too_many_arguments`
- `cargo test -p tidebreak-core --lib -- code::event` and `chat_journal`
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --lib -- wire` (bindings and code-frame fixtures)
- Focused HTTP tests in this environment cannot connect to `127.0.0.1` (connect timed out); CI should run `a_machine_session_parks_on_an_approval_a_contributor_can_settle` and the existing machine external-session tests
- `pnpm` is not available here, so you could not run `pnpm --dir crates/tidebreak-desktop/ui` parser tests or `pnpm --dir mobile sync-wire`; desktop and mobile `wire.ts` were copied byte-equal after regenerating wire types

## Risk

A truncated preview can hide the rest of a command; the flag is how the adapter falls back to a web link. A second decision from another surface is a 409, not a silent no-op. Sandbox sessions stay off this path.

Closes #3186