### PR TITLE
feat(self-host): a standalone machine lends its forge credential through the same seam

### DIFF
--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -473,6 +473,92 @@ async fn a_sessions_git_borrows_the_persons_credential_from_the_loopback_route()
     assert_eq!(wrong.status(), reqwest::StatusCode::UNAUTHORIZED);
 }
 
+/// A standalone machine's static lender answers the deployment token for
+/// `https` against github.com, nothing for another host, and refuses a
+/// Person request because the machine acts as one account.
+#[tokio::test]
+async fn a_sessions_git_borrows_the_standalone_deployment_token_from_the_loopback_route() {
+    let lender = Arc::new(crate::obo_gateway::StaticGitCredentialLender::new(
+        "deployment-token".to_owned(),
+        Some("ship-bot".to_owned()),
+    ));
+    let relay = Arc::new(crate::code::harness_llm::HarnessLlmRelay::keys_only());
+    let (router, _fake, runtime, repo_id, _token, _dir) = external_app_built({
+        let lender = lender.clone();
+        let relay = relay.clone();
+        move |runtime| runtime.with_git_credentials(lender).with_harness_llm(relay)
+    })
+    .await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C8/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let session_id = bound_session_id(&runtime, &owner, "T1/C8/1.1").await;
+    let person = runtime.get_session(&owner, session_id).await.unwrap();
+    let mut bot_session = person.clone();
+    bot_session.id = tidebreak_core::SessionId::new();
+    bot_session.acts_as = Some(tidebreak_core::ActsAs::Bot);
+    tidebreak_core::db::code::insert_session(&runtime.db, &bot_session)
+        .await
+        .unwrap();
+    let bot_key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
+        owner: owner.clone(),
+        session: bot_session.id,
+    });
+    let person_key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
+        owner: owner.clone(),
+        session: session_id,
+    });
+    let route = format!(
+        "http://{addr}{}",
+        crate::code::harness_llm::GIT_CREDENTIAL_PATH
+    );
+    let ask =
+        |body: &'static str, key: &str| client.post(&route).bearer_auth(key).body(body).send();
+
+    let lent = ask(
+        "protocol=https\nhost=github.com\npath=acme/tools.git\n",
+        &bot_key,
+    )
+    .await
+    .unwrap();
+    assert_eq!(lent.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        lent.text().await.unwrap(),
+        "username=x-access-token\npassword=deployment-token\n"
+    );
+
+    let other = ask("protocol=https\nhost=evil.example\n", &bot_key)
+        .await
+        .unwrap();
+    assert_eq!(other.status(), reqwest::StatusCode::OK);
+    assert_eq!(other.text().await.unwrap(), "");
+
+    let person = ask(
+        "protocol=https\nhost=github.com\npath=acme/tools.git\n",
+        &person_key,
+    )
+    .await
+    .unwrap();
+    assert_eq!(person.status(), reqwest::StatusCode::BAD_GATEWAY);
+    let reason = person.text().await.unwrap();
+    assert!(
+        reason.contains("standalone machine acts as one"),
+        "the helper names why person is refused: {reason}"
+    );
+}
+
 /// A Slack sandbox stays remote when a browser follows the link, queues a
 /// turn, and the hosted process recovers its session rows.
 #[tokio::test]

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -807,6 +807,13 @@ pub fn hosted_attribution_sentence(identity: &GitForgeIdentity) -> String {
         ),
         GitForgeAttribution::Bot {
             bot_login: Some(bot_login),
+        } if identity.app_name
+            == crate::obo_gateway::static_lender::STANDALONE_FORGE_APP_NAME =>
+        {
+            format!("Clones and pushes use this machine's GitHub account: work lands as {bot_login}.")
+        }
+        GitForgeAttribution::Bot {
+            bot_login: Some(bot_login),
         } => format!(
             "Clones and pushes use this deployment's GitHub App: work lands as {bot_login}, not as your GitHub account."
         ),
@@ -856,8 +863,9 @@ pub fn git_forge_refusal_message(refusal: &GitForgeError) -> String {
                                                   add it to the installation on GitHub."
             .to_owned(),
         GitForgeError::PersonNotOffered => {
-            "This session asked to act as you, and the deployment's git forge does not offer \
-             that identity. Ask as the App's bot, or connect a forge that can act as you."
+            "This session asked to act as you, and the deployment does not offer that identity. \
+             A standalone machine acts as one GitHub account. Ask as the deployment's account, \
+             or connect a forge that can act as you."
                 .to_owned()
         }
     }
@@ -1281,6 +1289,20 @@ mod tests {
             Some(("compressing objects".into(), 100))
         );
         assert_eq!(parse_clone_progress_line("Cloning into 'foo'..."), None);
+    }
+
+    #[test]
+    fn standalone_attribution_names_the_deployment_account() {
+        let identity = GitForgeIdentity {
+            app_name: crate::obo_gateway::static_lender::STANDALONE_FORGE_APP_NAME.to_owned(),
+            attribution: GitForgeAttribution::Bot {
+                bot_login: Some("ship-bot".into()),
+            },
+        };
+        assert_eq!(
+            hosted_attribution_sentence(&identity),
+            "Clones and pushes use this machine's GitHub account: work lands as ship-bot."
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -96,6 +96,9 @@ pub struct HarnessLlmRelay {
     client: reqwest::Client,
     state: Mutex<RelayState>,
     external: Option<Arc<crate::obo_gateway::external::ExternalDelegations>>,
+    /// When false, the registry still mints session keys for git's loopback
+    /// route, but workers do not point engine inference at this relay.
+    forwards_inference: bool,
 }
 
 #[derive(Default)]
@@ -119,7 +122,29 @@ impl HarnessLlmRelay {
             client,
             state: Mutex::new(RelayState::default()),
             external: None,
+            forwards_inference: true,
         }
+    }
+
+    /// Session keys for git's loopback route on a machine that lends forge
+    /// credentials but does not relay engine inference (standalone self-host).
+    pub fn keys_only() -> Self {
+        let obo = Arc::new(
+            OboGateway::new(
+                "http://127.0.0.1",
+                "tidebreak:standalone-git-relay-keys".to_owned(),
+            )
+            .expect("loopback dummy gateway URL is valid"),
+        );
+        let mut relay = Self::new(obo);
+        relay.forwards_inference = false;
+        relay
+    }
+
+    /// Whether workers should point engine children at this relay for inference.
+    #[must_use]
+    pub fn forwards_inference(&self) -> bool {
+        self.forwards_inference
     }
 
     /// Attach durable external consent before any worker can use this relay.
@@ -486,6 +511,27 @@ pub fn spawn_wiring(
 
 /// The loopback route a machine session's git asks for a credential.
 pub const GIT_CREDENTIAL_PATH: &str = "/code/git/credential";
+
+/// Whether `name` is a GitHub forge token the engine child must not inherit
+/// once this machine lends credentials itself.
+#[must_use]
+pub fn is_forge_token_env(name: &str) -> bool {
+    name.eq_ignore_ascii_case("GH_TOKEN") || name.eq_ignore_ascii_case("GITHUB_TOKEN")
+}
+
+/// Drop `GH_TOKEN` and `GITHUB_TOKEN` from a string environment overlay.
+pub fn scrub_forge_token_env(env: &mut Vec<(String, String)>) {
+    env.retain(|(name, _)| !is_forge_token_env(name));
+}
+
+/// Drop `GH_TOKEN` and `GITHUB_TOKEN` from a captured process environment.
+pub fn scrub_forge_token_os_env(env: &mut Vec<(std::ffi::OsString, std::ffi::OsString)>) {
+    env.retain(|(name, _)| {
+        name.to_str()
+            .map(|name| !is_forge_token_env(name))
+            .unwrap_or(true)
+    });
+}
 
 /// What the git helper and the `gh` wrapper print to stderr, before the
 /// status and the machine's reason, when the loopback route refuses.
@@ -1065,6 +1111,54 @@ mod tests {
         assert!(
             odd.contains("exec '/opt/it'\\''s/gh'"),
             "a quote in the path survives: {odd}"
+        );
+    }
+
+    #[test]
+    fn a_lending_child_env_carries_the_relay_key_and_no_forge_token() {
+        let mut extra = vec![
+            (RELAY_KEY_ENV.to_owned(), "session-relay-key".to_owned()),
+            ("GH_TOKEN".to_owned(), "must-not-reach-the-child".to_owned()),
+            (
+                "GITHUB_TOKEN".to_owned(),
+                "must-not-reach-the-child-either".to_owned(),
+            ),
+        ];
+        extra.extend(git_credential_wiring("http://127.0.0.1:9"));
+        extra.push(("PATH".to_owned(), "/session/bin:/usr/bin".to_owned()));
+        scrub_forge_token_env(&mut extra);
+        let mut probe = vec![
+            (
+                std::ffi::OsString::from("GH_TOKEN"),
+                std::ffi::OsString::from("from-the-process"),
+            ),
+            (
+                std::ffi::OsString::from("PATH"),
+                std::ffi::OsString::from("/usr/bin"),
+            ),
+        ];
+        scrub_forge_token_os_env(&mut probe);
+        assert!(
+            extra
+                .iter()
+                .any(|(name, value)| name == RELAY_KEY_ENV && value == "session-relay-key"),
+            "the session relay key stays: {extra:?}"
+        );
+        assert!(
+            extra
+                .iter()
+                .any(|(name, value)| name == "PATH" && value.starts_with("/session/bin:")),
+            "the gh wrapper precedes the real binary: {extra:?}"
+        );
+        assert!(
+            extra.iter().all(|(name, _)| !is_forge_token_env(name)),
+            "overlay holds no forge token: {extra:?}"
+        );
+        assert!(
+            probe
+                .iter()
+                .all(|(name, _)| name.to_str() != Some("GH_TOKEN")),
+            "the captured snapshot holds no forge token: {probe:?}"
         );
     }
 }

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -287,7 +287,10 @@ impl CodeRuntime {
         // On a gateway-authenticated machine, point the engine's own
         // inference at this server's relay (decision 71): a per-session key
         // stands in for provider credentials the hosted image does not have.
-        let (extra_argv, extra_env, relay_key_env) = match self.harness_llm.as_ref() {
+        // A standalone machine that lends a forge token still mints the key
+        // so git can borrow through the loopback route, without redirecting
+        // inference.
+        let (extra_argv, extra_env, relay_key_env, child_env) = match self.harness_llm.as_ref() {
             // An in-process engine resolves inference through the server
             // itself; there is no child to point at the relay.
             Some(relay) if !session.harness_kind.is_in_process() => {
@@ -303,19 +306,32 @@ impl CodeRuntime {
                     owner: session.owner.clone(),
                     session: session.id,
                 });
-                let (argv, mut env) =
-                    crate::code::harness_llm::spawn_wiring(session.harness_kind, &base, &key);
-                // A repository session's own git borrows the person's forge
-                // credential through the loopback route under the same key,
-                // so the harness's shell can push what it made. A machine
-                // that lends none leaves git as it found it.
+                let (argv, mut env) = if relay.forwards_inference() {
+                    crate::code::harness_llm::spawn_wiring(session.harness_kind, &base, &key)
+                } else {
+                    (Vec::new(), Vec::new())
+                };
+                if !env
+                    .iter()
+                    .any(|(name, _)| name == crate::code::harness_llm::RELAY_KEY_ENV)
+                {
+                    env.push((
+                        crate::code::harness_llm::RELAY_KEY_ENV.to_owned(),
+                        key.clone(),
+                    ));
+                }
+                let mut child_env = probe.env.clone();
+                // A repository session's own git borrows through the loopback
+                // route under the same key. Claude Code, Codex, Opencode, and
+                // Grok all take this overlay; the wrapper's directory is
+                // prepended to PATH so it precedes the real `gh`.
                 if workspace.is_some() && self.git_credentials.is_some() {
                     env.extend(crate::code::harness_llm::git_credential_wiring(&base));
                     if let Some(path) = self
                         .gh_shim_path(
                             &private_root,
                             workspace.as_ref(),
-                            &probe.env,
+                            &child_env,
                             &base,
                             &session.owner,
                         )
@@ -323,14 +339,17 @@ impl CodeRuntime {
                     {
                         env.push(("PATH".to_owned(), path));
                     }
+                    crate::code::harness_llm::scrub_forge_token_env(&mut env);
+                    crate::code::harness_llm::scrub_forge_token_os_env(&mut child_env);
                 }
                 (
                     argv,
                     env,
                     Some(crate::code::harness_llm::RELAY_KEY_ENV.to_owned()),
+                    child_env,
                 )
             }
-            _ => (Vec::new(), Vec::new(), None),
+            _ => (Vec::new(), Vec::new(), None, probe.env.clone()),
         };
 
         let spec = SessionSpec {
@@ -351,7 +370,7 @@ impl CodeRuntime {
             extra_argv,
             extra_env,
             relay_key_env,
-            env: probe.env.clone(),
+            env: child_env,
             approval,
             binary: binary.clone(),
             sink: sink.clone() as Arc<dyn HarnessEventSink>,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1273,6 +1273,30 @@ async fn bind_inner(
         state.mcp.set_host_folders(host.clone());
     }
     state.host_folders = host_folders;
+    // Gateway-authenticated machines borrow per-caller forge credentials
+    // (decision 63). A standalone self-host machine with GH_TOKEN lends that
+    // one account through the same seam so the engine child never holds it.
+    // Desktop profiles never build a lender.
+    let git_credentials: Option<Arc<dyn obo_gateway::GitCredentialLender>> =
+        if let Some(gateway) = state.on_behalf_of_gateway.clone() {
+            Some(gateway)
+        } else if state.config.profile == Profile::SelfHost {
+            obo_gateway::StaticGitCredentialLender::from_env()
+                .map(|lender| Arc::new(lender) as Arc<dyn obo_gateway::GitCredentialLender>)
+        } else {
+            None
+        };
+    let harness_llm = if let Some(gateway) = state.on_behalf_of_gateway.clone() {
+        Some(Arc::new(
+            code::harness_llm::HarnessLlmRelay::new(gateway).with_external_delegations(db.clone()),
+        ))
+    } else if git_credentials.is_some() {
+        // Keys only: the loopback git route authenticates with a session
+        // relay key, but engines keep their own provider credentials.
+        Some(Arc::new(code::harness_llm::HarnessLlmRelay::keys_only()))
+    } else {
+        None
+    };
     let runtime = code::CodeRuntime::new(
         db.clone(),
         state.config.data_dir.clone(),
@@ -1280,22 +1304,8 @@ async fn bind_inner(
         code_host_tool_broker,
         browser_runtime,
         browser_bridge_command,
-        // On a gateway-authenticated hosted machine, git operations borrow
-        // per-caller forge credentials from the same on-behalf-of handle the
-        // router exchanges through (decision 63).
-        state
-            .on_behalf_of_gateway
-            .clone()
-            .map(|gateway| gateway as Arc<dyn obo_gateway::GitCredentialLender>),
-        // And engine inference rides the caller's gateway grant through the
-        // relay, since the hosted image has no provider credentials of its
-        // own (decision 71).
-        state.on_behalf_of_gateway.clone().map(|gateway| {
-            Arc::new(
-                code::harness_llm::HarnessLlmRelay::new(gateway)
-                    .with_external_delegations(db.clone()),
-            )
-        }),
+        git_credentials,
+        harness_llm,
     )
     .with_gateway_runtime(state.gateway.clone())
     // A channel-bound session on this machine's engine starts in the

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -34,6 +34,9 @@
 //!   [`crate::providers::collect_routes`].
 
 pub mod external;
+pub mod static_lender;
+
+pub use static_lender::StaticGitCredentialLender;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/tidebreak-server/src/obo_gateway/static_lender.rs
+++ b/crates/tidebreak-server/src/obo_gateway/static_lender.rs
@@ -1,0 +1,194 @@
+//! Deployment-token git lending on a standalone self-host machine.
+//!
+//! A gateway-authenticated machine borrows per operation through
+//! [`super::OboGateway`]. A standalone machine has no gateway, and used to
+//! hand the process `GH_TOKEN` to every engine child. This lender holds that
+//! token in the server and answers the same [`super::GitCredentialLender`]
+//! seam, so clone, delivery, and the session loopback route borrow it and
+//! the child never sees it.
+
+use async_trait::async_trait;
+use tidebreak_core::OwnerId;
+
+use super::{
+    GitCredential, GitCredentialLender, GitForgeAttribution, GitForgeAttributionRequest,
+    GitForgeError, GitForgeIdentity, GitHubRepository,
+};
+
+/// Display name the add-repository sentence and the git card read when this
+/// lender answers. Distinct from a gateway App name so the UI does not call
+/// the token an App.
+pub const STANDALONE_FORGE_APP_NAME: &str = "this machine";
+
+/// What the UI names when the operator did not set `TIDEBREAK_GIT_BOT_LOGIN`.
+pub const STANDALONE_BOT_LOGIN_FALLBACK: &str = "the deployment's GitHub account";
+
+/// One standing GitHub token, lent per operation as `x-access-token`.
+pub struct StaticGitCredentialLender {
+    token: String,
+    bot_login: Option<String>,
+}
+
+impl std::fmt::Debug for StaticGitCredentialLender {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("StaticGitCredentialLender")
+            .field("bot_login", &self.bot_login)
+            .field("token", &"<redacted>")
+            .finish()
+    }
+}
+
+impl StaticGitCredentialLender {
+    /// Hold `token` and, when set, the login the token belongs to.
+    #[must_use]
+    pub fn new(token: String, bot_login: Option<String>) -> Self {
+        Self { token, bot_login }
+    }
+
+    /// Build from `GH_TOKEN` or `GITHUB_TOKEN`, plus optional
+    /// `TIDEBREAK_GIT_BOT_LOGIN`. `None` when no token is set, so a
+    /// standalone machine without one keeps today's uncredentialed git.
+    #[must_use]
+    pub fn from_env() -> Option<Self> {
+        let token = std::env::var("GH_TOKEN")
+            .or_else(|_| std::env::var("GITHUB_TOKEN"))
+            .ok()
+            .filter(|value| !value.is_empty())?;
+        let bot_login = std::env::var("TIDEBREAK_GIT_BOT_LOGIN")
+            .ok()
+            .filter(|value| !value.is_empty());
+        Some(Self::new(token, bot_login))
+    }
+
+    fn bot_login(&self) -> String {
+        self.bot_login
+            .clone()
+            .unwrap_or_else(|| STANDALONE_BOT_LOGIN_FALLBACK.to_owned())
+    }
+
+    fn refuse_person(attribution: GitForgeAttributionRequest) -> Result<(), GitForgeError> {
+        match attribution {
+            GitForgeAttributionRequest::Person => Err(GitForgeError::PersonNotOffered),
+            GitForgeAttributionRequest::Installation => Ok(()),
+        }
+    }
+}
+
+#[async_trait]
+impl GitCredentialLender for StaticGitCredentialLender {
+    async fn git_forge_identity(
+        &self,
+        _owner: &OwnerId,
+        attribution: GitForgeAttributionRequest,
+    ) -> Result<GitForgeIdentity, GitForgeError> {
+        Self::refuse_person(attribution)?;
+        Ok(GitForgeIdentity {
+            app_name: STANDALONE_FORGE_APP_NAME.to_owned(),
+            attribution: GitForgeAttribution::Bot {
+                bot_login: Some(self.bot_login()),
+            },
+        })
+    }
+
+    async fn git_credential(
+        &self,
+        _owner: &OwnerId,
+        _repository: &str,
+        attribution: GitForgeAttributionRequest,
+    ) -> Result<GitCredential, GitForgeError> {
+        Self::refuse_person(attribution)?;
+        Ok(GitCredential {
+            username: "x-access-token".to_owned(),
+            secret: self.token.clone(),
+        })
+    }
+
+    async fn list_repositories(
+        &self,
+        _owner: &OwnerId,
+        _attribution: GitForgeAttributionRequest,
+    ) -> Result<Vec<GitHubRepository>, GitForgeError> {
+        Err(GitForgeError::NoGitForge)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owner() -> OwnerId {
+        OwnerId::new("user:alice").unwrap()
+    }
+
+    #[tokio::test]
+    async fn identity_names_the_configured_login() {
+        let lender = StaticGitCredentialLender::new("tok".into(), Some("ship-bot".into()));
+        let identity = lender
+            .git_forge_identity(&owner(), GitForgeAttributionRequest::Installation)
+            .await
+            .unwrap();
+        assert_eq!(identity.app_name, STANDALONE_FORGE_APP_NAME);
+        assert_eq!(
+            identity.attribution,
+            GitForgeAttribution::Bot {
+                bot_login: Some("ship-bot".into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_falls_back_when_no_login_is_set() {
+        let lender = StaticGitCredentialLender::new("tok".into(), None);
+        let identity = lender
+            .git_forge_identity(&owner(), GitForgeAttributionRequest::Installation)
+            .await
+            .unwrap();
+        assert_eq!(
+            identity.attribution,
+            GitForgeAttribution::Bot {
+                bot_login: Some(STANDALONE_BOT_LOGIN_FALLBACK.into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn a_person_request_is_not_offered() {
+        let lender = StaticGitCredentialLender::new("tok".into(), Some("ship-bot".into()));
+        let identity = lender
+            .git_forge_identity(&owner(), GitForgeAttributionRequest::Person)
+            .await
+            .unwrap_err();
+        assert_eq!(identity, GitForgeError::PersonNotOffered);
+        let credential = lender
+            .git_credential(&owner(), "acme/demo", GitForgeAttributionRequest::Person)
+            .await
+            .unwrap_err();
+        assert_eq!(credential, GitForgeError::PersonNotOffered);
+    }
+
+    #[tokio::test]
+    async fn an_installation_borrow_returns_the_token_username_pair() {
+        let lender = StaticGitCredentialLender::new("tok".into(), None);
+        let credential = lender
+            .git_credential(
+                &owner(),
+                "acme/demo",
+                GitForgeAttributionRequest::Installation,
+            )
+            .await
+            .unwrap();
+        assert_eq!(credential.username, "x-access-token");
+        assert_eq!(credential.secret, "tok");
+    }
+
+    #[tokio::test]
+    async fn the_repository_list_keeps_the_local_path() {
+        let lender = StaticGitCredentialLender::new("tok".into(), None);
+        let listed = lender
+            .list_repositories(&owner(), GitForgeAttributionRequest::Installation)
+            .await
+            .unwrap_err();
+        assert_eq!(listed, GitForgeError::NoGitForge);
+    }
+}

--- a/docs/decisions/0063-hosted-machines-borrow-forge-credentials.md
+++ b/docs/decisions/0063-hosted-machines-borrow-forge-credentials.md
@@ -75,10 +75,20 @@ is `installation_only` cannot attribute it to the person.
    forge repository — a local path, a bare test origin, any host but the
    forge's — borrows nothing and pushes exactly as it does today.
 
-5. **Nothing else changes.** Static-token self-host machines and desktops
-   never build the lender, so every existing git and `gh` path is untouched.
-   Pull-request creation and the delivery reads still ride `gh` and remain
-   unavailable on hosted machines; they are the next slice, not this one.
+5. **Nothing else changes.** Desktops never build the lender, so every
+   existing git and `gh` path on a local machine is untouched. Pull-request
+   creation and the delivery reads still ride `gh` and remain unavailable
+   on hosted machines; they are the next slice, not this one.
+
+## Amendment 2026-09-08: a standalone machine lends its own token
+
+A standalone self-host machine has no gateway to mint from. When you set
+`GH_TOKEN` (or `GITHUB_TOKEN`) on that profile, the server now builds a
+static lender on the same seam: clone, delivery, and a session's loopback
+git helper borrow the token per operation, and the engine child does not
+inherit it. The machine acts as one account. A session that asks to act as
+the person is refused by name. Set `TIDEBREAK_GIT_BOT_LOGIN` so the UI can
+name that account. Desktop profiles still build no lender.
 
 ## Rejected
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -272,6 +272,8 @@ aspirational.
 | `TIDEBREAK_AUTH_OIDC_CLIENT_SECRET` | with OIDC | — | OIDC client secret, used only for the server-to-server code exchange. It stays in process memory. |
 | `TIDEBREAK_AUTH_OIDC_CLAIM` | no | `sub` | ID-token claim whose string value becomes the Tidebreak user id. Requires OIDC. |
 | `TIDEBREAK_ADAPTER_BOOTSTRAP_TOKENS` | no | unset | Comma-separated service bearers allowed to start an external channel connect handshake. Each value must be 32–512 header-safe characters. Leave unset to disable connect start. To rotate without downtime, add the new value, move the adapter, then remove the old value. |
+| `GH_TOKEN` or `GITHUB_TOKEN` | no | unset | Standalone forge token the server holds and lends per git operation. The agent child never inherits it. |
+| `TIDEBREAK_GIT_BOT_LOGIN` | no | unset | GitHub login the token belongs to, so the UI can say whose account work lands as. |
 | `TIDEBREAK_VAULT_ADDR` | required with Vault custody | — | Vault base URL. HTTPS is required except for literal loopback development. Setting any Vault option enables Vault configuration and requires this variable plus `TIDEBREAK_VAULT_TOKEN_FILE`. |
 | `TIDEBREAK_VAULT_TOKEN_FILE` | required with Vault custody | — | Mounted file containing the Vault token. Tidebreak reads it for every request so rotation does not require a restart. |
 | `TIDEBREAK_VAULT_MOUNT` | no | `secret` | KV v2 mount path. |
@@ -511,12 +513,13 @@ per engine.
 
 Two things the image deliberately does not decide for you:
 
-- **A GitHub identity.** Tidebreak observes `gh`'s authentication and never
-  reads or stores a token ([decision record
-  34](decisions/0034-harness-discovery-credentials.md)), and a container has
-  no terminal to run `gh auth login` in. Set `GH_TOKEN` in the server's
-  environment and `gh` picks it up. Everyone on the deployment then acts as
-  that one account; per-user GitHub identity is not built yet.
+- **A GitHub identity.** Set `GH_TOKEN` (or `GITHUB_TOKEN`) in the server's
+  environment. The server holds it and lends it per git operation through
+  the same seam a hosted machine uses; the agent child never sees the
+  token. Everyone on the deployment acts as that one account. Set
+  `TIDEBREAK_GIT_BOT_LOGIN` to the GitHub login the token belongs to so the
+  UI can say whose account work lands as. Per-user GitHub identity is a
+  hosted-machine path, not this one.
 - **A commit identity.** `git commit` needs a name and an email, and the image
   invents neither. Set `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`,
   `GIT_COMMITTER_NAME`, and `GIT_COMMITTER_EMAIL` in the server's environment,


### PR DESCRIPTION
## What

On a standalone self-host machine, the server now holds `GH_TOKEN` (or `GITHUB_TOKEN`) and lends it through the same `GitCredentialLender` seam hosted machines already use. Clone, workspace delivery, and a machine session's loopback `POST /code/git/credential` borrow per operation. The engine child does not inherit the token.

This is track D of epic #3178 (the standalone half of "agents never hold a token"). The branch merges `thet/session-acts-as` so it builds on `GitForgeAttributionRequest` and `GitForgeError::PersonNotOffered` rather than defining them again.

## Why

A standalone machine used to leave `GH_TOKEN` in the process environment. The server's git and the engine child both saw it, so the agent held the deployment token. Decision 63 already named the borrow seam; this slice puts the standalone token behind that seam.

A session that asks to act as the person is refused: this machine acts as one account. Set `TIDEBREAK_GIT_BOT_LOGIN` so the add-repository sentence and the workspace git card can name that account.

Desktop profiles still build no lender.

## How you verify

- `cargo fmt --all`
- `cargo clippy -p tidebreak-core -p tidebreak-server-core -p tidebreak-server --all-targets -- -D warnings -A clippy::too_many_arguments`
- Unit tests: `static_lender`, `a_lending_child_env_carries_the_relay_key_and_no_forge_token`, `standalone_attribution_names_the_deployment_account`

## Risk

A person-owned session on standalone now gets `PersonNotOffered` on a forge borrow (the machine only answers an installation/bot request). Bot-owned sessions and server-side clone/delivery that ask for the installation identity keep working. The add-repository GitHub picker stays a local path because `list_repositories` answers `NoGitForge`.

## What this environment could not run

Loopback HTTP tests in `code_external` (`a_sessions_git_borrows_the_standalone_deployment_token_from_the_loopback_route` and the existing person-borrow test) timed out connecting to the local listener here. CI should run them. No browser UI to check. Full workspace test suite was not run.