### PR TITLE
feat(slack): a channel session names who it acts as, and the thread learns the answer

### DIFF
--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -116,6 +116,10 @@ pub struct ExternalSessionBody {
     /// workspace grant creates a pending confirmation.
     #[serde(default)]
     pub set_by: Option<ExternalSetBy>,
+    /// Whose forge identity this conversation should act as. A service-owned
+    /// session or a workspace grant ignores this and always acts as the bot.
+    #[serde(default)]
+    pub acts_as: Option<tidebreak_core::ActsAs>,
 }
 
 #[derive(serde::Deserialize)]
@@ -129,6 +133,16 @@ pub struct ExternalSessionResponse {
     /// `created`, `existing`, or `ended`.
     pub status: &'static str,
     pub session_id: SessionId,
+    pub acts_as: tidebreak_core::ActsAs,
+    /// The person's login or the App's bot login, when the forge named one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acting_login: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_name: Option<String>,
+    /// Present only when the person could connect and did not, so the session
+    /// is running as the bot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connect_url: Option<String>,
 }
 
 /// `POST /external/code/sessions` — idempotent get-or-create for one
@@ -220,9 +234,13 @@ pub async fn external_get_or_create(
             ));
         }
     }
-    let resolution = runtime
+    let owner_kind = state
+        .principal_authenticator
+        .session_owner_kind_for(&grant.owner);
+    let (resolution, identity) = runtime
         .external_get_or_create(
             &grant.owner,
+            owner_kind,
             grant.id,
             &grant.channel_kind,
             &body.external_key,
@@ -238,30 +256,29 @@ pub async fn external_get_or_create(
                 acts_as: None,
             },
             body.permission_mode,
+            body.acts_as,
         )
         .await?;
+    let response_from = |status: &'static str, session_id: SessionId| ExternalSessionResponse {
+        status,
+        session_id,
+        acts_as: identity.acts_as,
+        acting_login: identity.acting_login.clone(),
+        app_name: identity.app_name.clone(),
+        connect_url: identity.connect_url.clone(),
+    };
     let (status, response) = match resolution {
         ExternalSessionResolution::Created(binding) => (
             StatusCode::CREATED,
-            ExternalSessionResponse {
-                status: "created",
-                session_id: binding.session_id,
-            },
+            response_from("created", binding.session_id),
         ),
         ExternalSessionResolution::Existing(binding) => (
             StatusCode::OK,
-            ExternalSessionResponse {
-                status: "existing",
-                session_id: binding.session_id,
-            },
+            response_from("existing", binding.session_id),
         ),
-        ExternalSessionResolution::Ended { session_id } => (
-            StatusCode::OK,
-            ExternalSessionResponse {
-                status: "ended",
-                session_id,
-            },
-        ),
+        ExternalSessionResolution::Ended { session_id } => {
+            (StatusCode::OK, response_from("ended", session_id))
+        }
         ExternalSessionResolution::GrantMismatch => {
             return Err(ServerError::not_found("code session not found"));
         }

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -314,7 +314,23 @@ impl crate::obo_gateway::GitCredentialLender for LendingFake {
         attribution: crate::obo_gateway::GitForgeAttributionRequest,
     ) -> Result<crate::obo_gateway::GitForgeIdentity, crate::obo_gateway::GitForgeError> {
         self.asked.lock().unwrap().push(attribution);
-        Err(crate::obo_gateway::GitForgeError::NoGitForge)
+        Ok(crate::obo_gateway::GitForgeIdentity {
+            app_name: "Acme Forge".to_owned(),
+            attribution: match attribution {
+                crate::obo_gateway::GitForgeAttributionRequest::Person => {
+                    crate::obo_gateway::GitForgeAttribution::Person {
+                        login: "mira".to_owned(),
+                        display_name: None,
+                        commit_email: None,
+                    }
+                }
+                crate::obo_gateway::GitForgeAttributionRequest::Installation => {
+                    crate::obo_gateway::GitForgeAttribution::Bot {
+                        bot_login: Some("acme-bot".to_owned()),
+                    }
+                }
+            },
+        })
     }
 
     async fn git_credential(
@@ -413,8 +429,11 @@ async fn a_sessions_git_borrows_the_persons_credential_from_the_loopback_route()
     );
     assert_eq!(
         lender.asked.lock().unwrap().as_slice(),
-        [crate::obo_gateway::GitForgeAttributionRequest::Person],
-        "a person session asks to act as the person"
+        [
+            crate::obo_gateway::GitForgeAttributionRequest::Person,
+            crate::obo_gateway::GitForgeAttributionRequest::Person,
+        ],
+        "get-or-create probes the person, then the session's git borrow uses that identity"
     );
 
     let person = runtime.get_session(&owner, session_id).await.unwrap();
@@ -438,6 +457,7 @@ async fn a_sessions_git_borrows_the_persons_credential_from_the_loopback_route()
     assert_eq!(
         lender.asked.lock().unwrap().as_slice(),
         [
+            crate::obo_gateway::GitForgeAttributionRequest::Person,
             crate::obo_gateway::GitForgeAttributionRequest::Person,
             crate::obo_gateway::GitForgeAttributionRequest::Installation,
         ],
@@ -505,20 +525,21 @@ async fn a_sessions_git_borrows_the_standalone_deployment_token_from_the_loopbac
         .unwrap();
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let session_id = bound_session_id(&runtime, &owner, "T1/C8/1.1").await;
-    let person = runtime.get_session(&owner, session_id).await.unwrap();
-    let mut bot_session = person.clone();
-    bot_session.id = tidebreak_core::SessionId::new();
-    bot_session.acts_as = Some(tidebreak_core::ActsAs::Bot);
-    tidebreak_core::db::code::insert_session(&runtime.db, &bot_session)
+    let bot = runtime.get_session(&owner, session_id).await.unwrap();
+    assert_eq!(bot.acts_as(), tidebreak_core::ActsAs::Bot);
+    let mut person_session = bot.clone();
+    person_session.id = tidebreak_core::SessionId::new();
+    person_session.acts_as = Some(tidebreak_core::ActsAs::Person);
+    tidebreak_core::db::code::insert_session(&runtime.db, &person_session)
         .await
         .unwrap();
     let bot_key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
         owner: owner.clone(),
-        session: bot_session.id,
+        session: session_id,
     });
     let person_key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
         owner: owner.clone(),
-        session: session_id,
+        session: person_session.id,
     });
     let route = format!(
         "http://{addr}{}",
@@ -1909,6 +1930,351 @@ async fn a_machine_session_above_the_ceiling_is_refused_by_name() {
             .unwrap()
             .is_none(),
         "a refused start binds nothing"
+    );
+}
+
+struct ProbeFake {
+    person:
+        StdMutex<Result<crate::obo_gateway::GitForgeIdentity, crate::obo_gateway::GitForgeError>>,
+    installation:
+        StdMutex<Result<crate::obo_gateway::GitForgeIdentity, crate::obo_gateway::GitForgeError>>,
+    minted: StdMutex<Vec<crate::obo_gateway::GitForgeAttributionRequest>>,
+    asked: StdMutex<Vec<crate::obo_gateway::GitForgeAttributionRequest>>,
+}
+
+impl ProbeFake {
+    fn person_connected(login: &str) -> Arc<Self> {
+        Arc::new(Self {
+            person: StdMutex::new(Ok(crate::obo_gateway::GitForgeIdentity {
+                app_name: "Acme Forge".to_owned(),
+                attribution: crate::obo_gateway::GitForgeAttribution::Person {
+                    login: login.to_owned(),
+                    display_name: Some("Mira".to_owned()),
+                    commit_email: None,
+                },
+            })),
+            installation: StdMutex::new(Ok(crate::obo_gateway::GitForgeIdentity {
+                app_name: "Acme Forge".to_owned(),
+                attribution: crate::obo_gateway::GitForgeAttribution::Bot {
+                    bot_login: Some("acme-bot".to_owned()),
+                },
+            })),
+            minted: StdMutex::new(Vec::new()),
+            asked: StdMutex::new(Vec::new()),
+        })
+    }
+
+    fn not_connected(connect_url: &str) -> Arc<Self> {
+        let fake = Self::person_connected("mira");
+        *fake.person.lock().unwrap() = Err(crate::obo_gateway::GitForgeError::NotConnected {
+            connect_url: Some(connect_url.to_owned()),
+        });
+        fake
+    }
+
+    fn unavailable() -> Arc<Self> {
+        let fake = Self::person_connected("mira");
+        *fake.person.lock().unwrap() = Err(crate::obo_gateway::GitForgeError::Unavailable(
+            "forge down".into(),
+        ));
+        fake
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::obo_gateway::GitCredentialLender for ProbeFake {
+    async fn git_forge_identity(
+        &self,
+        _owner: &OwnerId,
+        attribution: crate::obo_gateway::GitForgeAttributionRequest,
+    ) -> Result<crate::obo_gateway::GitForgeIdentity, crate::obo_gateway::GitForgeError> {
+        self.asked.lock().unwrap().push(attribution);
+        match attribution {
+            crate::obo_gateway::GitForgeAttributionRequest::Person => {
+                self.person.lock().unwrap().clone()
+            }
+            crate::obo_gateway::GitForgeAttributionRequest::Installation => {
+                self.installation.lock().unwrap().clone()
+            }
+        }
+    }
+
+    async fn git_credential(
+        &self,
+        _owner: &OwnerId,
+        _repository: &str,
+        attribution: crate::obo_gateway::GitForgeAttributionRequest,
+    ) -> Result<crate::obo_gateway::GitCredential, crate::obo_gateway::GitForgeError> {
+        self.minted.lock().unwrap().push(attribution);
+        Ok(crate::obo_gateway::GitCredential {
+            username: "x-access-token".to_owned(),
+            secret: "lent-secret".to_owned(),
+        })
+    }
+
+    async fn list_repositories(
+        &self,
+        _owner: &OwnerId,
+        _attribution: crate::obo_gateway::GitForgeAttributionRequest,
+    ) -> Result<Vec<crate::obo_gateway::GitHubRepository>, crate::obo_gateway::GitForgeError> {
+        Ok(Vec::new())
+    }
+}
+
+async fn machine_with_lender(
+    lender: Arc<ProbeFake>,
+) -> (Router, Arc<CodeRuntime>, RepoId, tempfile::TempDir) {
+    let cloned = lender.clone();
+    machine_app_built(move |runtime| runtime.with_git_credentials(cloned)).await
+}
+
+/// A DM with no `acts_as` acts as the person when the gateway offers them.
+#[tokio::test]
+async fn an_external_machine_session_acts_as_the_connected_person() {
+    let lender = ProbeFake::person_connected("mira");
+    let (router, runtime, repo_id, _dir) = machine_with_lender(lender.clone()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C-id/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let body: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(body["acts_as"], "person");
+    assert_eq!(body["acting_login"], "mira");
+    assert_eq!(body["app_name"], "Acme Forge");
+    assert!(body.get("connect_url").is_none());
+    let session_id = bound_session_id(&runtime, &owner, "T1/C-id/1.1").await;
+    let session = runtime.get_session(&owner, session_id).await.unwrap();
+    assert_eq!(session.acts_as(), tidebreak_core::ActsAs::Person);
+    assert!(
+        lender
+            .asked
+            .lock()
+            .unwrap()
+            .contains(&crate::obo_gateway::GitForgeAttributionRequest::Person),
+        "the clone path probes the person before checkout"
+    );
+}
+
+/// When the person is not connected, the session runs as the bot and names
+/// the connect URL.
+#[tokio::test]
+async fn an_external_machine_session_falls_back_to_the_bot_when_not_connected() {
+    let lender = ProbeFake::not_connected("https://gateway.example/connect");
+    let (router, runtime, repo_id, _dir) = machine_with_lender(lender.clone()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C-id/2.2", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let body: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(body["acts_as"], "bot");
+    assert_eq!(body["connect_url"], "https://gateway.example/connect");
+    assert_eq!(body["acting_login"], "acme-bot");
+    let session_id = bound_session_id(&runtime, &owner, "T1/C-id/2.2").await;
+    let session = runtime.get_session(&owner, session_id).await.unwrap();
+    assert_eq!(session.acts_as(), tidebreak_core::ActsAs::Bot);
+    assert!(
+        lender
+            .asked
+            .lock()
+            .unwrap()
+            .contains(&crate::obo_gateway::GitForgeAttributionRequest::Installation),
+        "the clone borrows the installation after the person probe fails"
+    );
+}
+
+/// A person may ask for the bot even when their identity is offered.
+#[tokio::test]
+async fn an_explicit_bot_request_acts_as_the_bot_while_connected() {
+    let lender = ProbeFake::person_connected("mira");
+    let (router, runtime, repo_id, _dir) = machine_with_lender(lender.clone()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "external_key": "T1/C-id/3.3",
+            "repo_id": repo_id,
+            "acts_as": "bot",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+    let body: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(body["acts_as"], "bot");
+    assert_eq!(body["acting_login"], "acme-bot");
+    assert!(
+        !lender
+            .asked
+            .lock()
+            .unwrap()
+            .contains(&crate::obo_gateway::GitForgeAttributionRequest::Person),
+        "an explicit bot request does not probe the person"
+    );
+}
+
+/// A transient forge failure starts nothing so the adapter can retry.
+#[tokio::test]
+async fn an_unavailable_forge_refuses_get_or_create_with_no_binding() {
+    let lender = ProbeFake::unavailable();
+    let (router, runtime, repo_id, _dir) = machine_with_lender(lender).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let refused = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C-id/4.4", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::BAD_GATEWAY);
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["kind"], "forge_unavailable");
+    assert!(
+        tidebreak_core::db::code::get_external_binding(&runtime.db, &owner, "slack", "T1/C-id/4.4")
+            .await
+            .unwrap()
+            .is_none(),
+        "an unavailable forge starts nothing"
+    );
+}
+
+/// A service-owned grant always acts as the bot, whatever the body says.
+#[tokio::test]
+async fn a_service_owned_grant_acts_as_the_bot_regardless_of_the_body() {
+    let lender = ProbeFake::person_connected("mira");
+    let tokens = crate::auth::TokenMap::parse(
+        "admin aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa admin\n\
+         bot-svc bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb service\n",
+    )
+    .unwrap();
+    let service = crate::principal::Principal::User {
+        id: crate::principal::UserId::new("bot-svc").unwrap(),
+        kind: crate::principal::PrincipalKind::Service,
+        role: crate::principal::Role::Member,
+    };
+    let owner = service.owner_id();
+    let (dir, store) = temp_db_store("code.db").await;
+    let db = Arc::new(store);
+    let store_trait: Arc<dyn Store> = db.clone();
+    let mut registry = tidebreak_harness::AdapterRegistry::new();
+    registry.register(Arc::new(
+        crate::scripted_harness::ScriptedAdapter::new(crate::scripted_harness::plain_text_script())
+            .with_approvals(tidebreak_core::CapLevel::Supported)
+            .with_plan_mode(tidebreak_core::CapLevel::Supported)
+            .with_auto_mode(tidebreak_core::CapLevel::Supported)
+            .with_allow_mode(tidebreak_core::CapLevel::Supported),
+    ));
+    let runtime = Arc::new(
+        CodeRuntime::with_registry_and_browser_runtime(
+            db,
+            dir.path().to_path_buf(),
+            registry,
+            None,
+            None,
+        )
+        .with_git_credentials(lender.clone()),
+    );
+    let root = super::code::init_git_repo(dir.path());
+    let repo = CodeRepo {
+        id: RepoId::new(),
+        owner: owner.clone(),
+        root_path: root.display().to_string(),
+        display_name: "tools".into(),
+        default_base_ref: "main".into(),
+        branch_prefix: "tidebreak/".into(),
+        setup_script: None,
+        archive_script: None,
+        quick_actions: Vec::new(),
+        created_at: chrono::Utc::now(),
+        removed_at: None,
+        cloned_from: None,
+        origin_host: None,
+        origin_owner: None,
+        origin_name: None,
+    };
+    insert_repo(&runtime.db, &repo).await.unwrap();
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store_trait,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.code = Some(runtime.clone());
+    state.principal_authenticator = Arc::new(crate::auth::PrincipalAuthenticator::Static(tokens));
+    state.adapter_bootstrap_tokens = Some(Arc::new(crate::auth::AdapterBootstrapTokens::for_test(
+        ADAPTER_BOOTSTRAP_TOKEN,
+    )));
+    let router = app(state);
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let (_grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U-bot", "T1")
+        .await
+        .unwrap();
+    let created = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({
+            "external_key": "T1/C-svc/1.1",
+            "repo_id": repo.id,
+            "acts_as": "person",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED,);
+    let body: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(body["acts_as"], "bot", "{body}");
+    let session_id = bound_session_id(&runtime, &owner, "T1/C-svc/1.1").await;
+    let session = runtime.get_session(&owner, session_id).await.unwrap();
+    assert_eq!(session.acts_as(), tidebreak_core::ActsAs::Bot);
+    assert_eq!(session.owner_kind.as_deref(), Some("service"));
+    assert!(
+        !lender
+            .asked
+            .lock()
+            .unwrap()
+            .contains(&crate::obo_gateway::GitForgeAttributionRequest::Person),
+        "a service owner never probes the person"
     );
 }
 

--- a/crates/tidebreak-server/src/auth.rs
+++ b/crates/tidebreak-server/src/auth.rs
@@ -618,6 +618,19 @@ impl PrincipalAuthenticator {
         }
     }
 
+    /// `"service"` when this owner is a service principal the token file names;
+    /// `None` for a person, the local owner, or an authenticator that does not
+    /// keep a roster.
+    pub fn session_owner_kind_for(&self, owner: &tidebreak_core::OwnerId) -> Option<&'static str> {
+        match self {
+            Self::Static(tokens) => tokens
+                .kind_for_owner(owner)
+                .is_some_and(|kind| kind == crate::principal::PrincipalKind::Service)
+                .then_some("service"),
+            _ => None,
+        }
+    }
+
     async fn resolve(&self, presented: &str) -> Option<Principal> {
         match self.try_resolve(presented).await {
             Ok(principal) => principal,
@@ -1565,6 +1578,16 @@ impl TokenMap {
             ));
         }
         Ok(Self { entries })
+    }
+
+    /// The principal kind recorded for this owner key, when the file names
+    /// that user. Used when an adapter grant must know whether its owner is a
+    /// service without presenting that owner's token.
+    pub fn kind_for_owner(&self, owner: &tidebreak_core::OwnerId) -> Option<PrincipalKind> {
+        let id = owner.as_str().strip_prefix("user:")?;
+        self.entries
+            .iter()
+            .find_map(|(_, user, kind, _)| (user.to_string() == id).then_some(*kind))
     }
 
     /// The user the presented credential names and the role they hold, if

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1503,9 +1503,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (runtime, _fake, owner, repo) = runtime_with_remote(dir.path()).await;
         let grant = tidebreak_core::CodeGrantId::new();
-        let resolved = runtime
+        let (resolved, _) = runtime
             .external_get_or_create(
                 &owner,
+                None,
                 grant,
                 "slack",
                 "T1/C7/42.1",
@@ -1513,6 +1514,7 @@ mod tests {
                 Some("fix the flake".into()),
                 HarnessKind::ClaudeCode,
                 session_settings(),
+                None,
                 None,
             )
             .await
@@ -1532,9 +1534,10 @@ mod tests {
         assert!(workspace.is_remote());
 
         // The channel's retry answers with the same session.
-        let again = runtime
+        let (again, _) = runtime
             .external_get_or_create(
                 &owner,
+                None,
                 grant,
                 "slack",
                 "T1/C7/42.1",
@@ -1542,6 +1545,7 @@ mod tests {
                 None,
                 HarnessKind::ClaudeCode,
                 session_settings(),
+                None,
                 None,
             )
             .await
@@ -1552,9 +1556,10 @@ mod tests {
         assert_eq!(hit.session_id, binding.session_id);
 
         // Another grant's call on the same conversation refuses.
-        let refused = runtime
+        let (refused, _) = runtime
             .external_get_or_create(
                 &owner,
+                None,
                 tidebreak_core::CodeGrantId::new(),
                 "slack",
                 "T1/C7/42.1",
@@ -1562,6 +1567,7 @@ mod tests {
                 None,
                 HarnessKind::ClaudeCode,
                 session_settings(),
+                None,
                 None,
             )
             .await
@@ -1580,9 +1586,10 @@ mod tests {
         assert!(tidebreak_core::db::code::save_session(&runtime.db, &stored)
             .await
             .unwrap());
-        let ended = runtime
+        let (ended, _) = runtime
             .external_get_or_create(
                 &owner,
+                None,
                 grant,
                 "slack",
                 "T1/C7/42.1",
@@ -1590,6 +1597,7 @@ mod tests {
                 None,
                 HarnessKind::ClaudeCode,
                 session_settings(),
+                None,
                 None,
             )
             .await
@@ -1610,9 +1618,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
         let grant = tidebreak_core::CodeGrantId::new();
-        let resolved = runtime
+        let (resolved, _) = runtime
             .external_get_or_create(
                 &owner,
+                None,
                 grant,
                 "slack",
                 "T1/C9/77.1",
@@ -1620,6 +1629,7 @@ mod tests {
                 None,
                 HarnessKind::ClaudeCode,
                 session_settings(),
+                None,
                 None,
             )
             .await
@@ -1758,9 +1768,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
         let grant = tidebreak_core::CodeGrantId::new();
-        let resolved = runtime
+        let (resolved, _) = runtime
             .external_get_or_create(
                 &owner,
+                None,
                 grant,
                 "slack",
                 "T1/C4/5.5",
@@ -1768,6 +1779,7 @@ mod tests {
                 None,
                 HarnessKind::ClaudeCode,
                 session_settings(),
+                None,
                 None,
             )
             .await

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -90,6 +90,7 @@ mod adapters;
 mod approvals;
 mod recover;
 mod remote;
+pub use remote::ExternalActsAsView;
 mod repos;
 mod sessions;
 mod settings;

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -18,6 +18,18 @@ fn external_delegation_error(error: tidebreak_core::AgentError) -> ServerError {
     }
 }
 
+/// What get-or-create decided the session acts as, for the adapter to render.
+/// `acting_login`, `app_name`, and `connect_url` are known at create when the
+/// forge answered; an existing session reports `acts_as` from the row and
+/// leaves the rest empty (they are not stored on the session).
+#[derive(Debug, Clone)]
+pub struct ExternalActsAsView {
+    pub acts_as: tidebreak_core::ActsAs,
+    pub acting_login: Option<String>,
+    pub app_name: Option<String>,
+    pub connect_url: Option<String>,
+}
+
 impl CodeRuntime {
     /// Create a workspace whose checkout lives in a sandbox, not on this
     /// machine. A per-workspace `remote:<id>` worktree marker records that
@@ -179,6 +191,7 @@ impl CodeRuntime {
     pub async fn external_get_or_create(
         &self,
         owner: &OwnerId,
+        owner_kind: Option<&str>,
         grant_id: tidebreak_core::CodeGrantId,
         channel_kind: &str,
         external_key: &str,
@@ -187,7 +200,14 @@ impl CodeRuntime {
         harness: HarnessKind,
         settings: NewSessionSettings,
         requested_mode: Option<tidebreak_core::PermissionMode>,
-    ) -> Result<tidebreak_core::ExternalSessionResolution, ServerError> {
+        requested_acts_as: Option<tidebreak_core::ActsAs>,
+    ) -> Result<
+        (
+            tidebreak_core::ExternalSessionResolution,
+            ExternalActsAsView,
+        ),
+        ServerError,
+    > {
         if channel_kind.trim().is_empty() || external_key.trim().is_empty() {
             return Err(ServerError::conflict_kind(
                 "binding_key_invalid",
@@ -221,16 +241,34 @@ impl CodeRuntime {
         .await?
         {
             if binding.grant_id != grant_id {
-                return Ok(tidebreak_core::ExternalSessionResolution::GrantMismatch);
+                return Ok((
+                    tidebreak_core::ExternalSessionResolution::GrantMismatch,
+                    ExternalActsAsView {
+                        acts_as: tidebreak_core::ActsAs::default_for_owner_kind(owner_kind),
+                        acting_login: None,
+                        app_name: None,
+                        connect_url: None,
+                    },
+                ));
             }
             let session = self.get_session(owner, binding.session_id).await?;
+            let identity = ExternalActsAsView {
+                acts_as: session.acts_as(),
+                acting_login: None,
+                app_name: None,
+                connect_url: None,
+            };
             if session.lifecycle == SessionLifecycle::Ended {
-                return Ok(tidebreak_core::ExternalSessionResolution::Ended {
-                    session_id: binding.session_id,
-                });
+                return Ok((
+                    tidebreak_core::ExternalSessionResolution::Ended {
+                        session_id: binding.session_id,
+                    },
+                    identity,
+                ));
             }
-            return Ok(tidebreak_core::ExternalSessionResolution::Existing(
-                Box::new(binding),
+            return Ok((
+                tidebreak_core::ExternalSessionResolution::Existing(Box::new(binding)),
+                identity,
             ));
         }
         let repo = self.get_repo(owner, repo_id).await?;
@@ -239,14 +277,18 @@ impl CodeRuntime {
             tidebreak_core::db::code::get_external_grant(&self.db, owner, grant_id)
                 .await?
                 .is_some_and(|grant| grant.kind.is_workspace());
-        let settings = NewSessionSettings {
-            acts_as: if workspace_grant {
-                Some(tidebreak_core::ActsAs::Bot)
-            } else {
-                settings.acts_as
-            },
-            ..settings
+        let requested_acts_as = if workspace_grant {
+            Some(tidebreak_core::ActsAs::Bot)
+        } else {
+            requested_acts_as
         };
+        let lender: Option<&dyn crate::obo_gateway::GitCredentialLender> = delegated
+            .as_ref()
+            .map(|gateway| gateway.as_ref() as &dyn crate::obo_gateway::GitCredentialLender)
+            .or_else(|| self.git_credentials().map(|lender| lender.as_ref()));
+        let identity = self
+            .decide_external_acts_as(owner, owner_kind, requested_acts_as, lender)
+            .await?;
         match self.external_execution_location() {
             ExecutionLocation::Sandbox => {
                 if let Some(mode) = requested_mode.filter(|mode| *mode != PermissionMode::Allow) {
@@ -267,11 +309,15 @@ impl CodeRuntime {
                         "the repository records no origin, so a sandbox cannot clone it",
                     ));
                 }
+                let settings = NewSessionSettings {
+                    acts_as: Some(identity.acts_as),
+                    ..settings
+                };
                 let workspace = self.build_remote_workspace(owner, &repo, title).await?;
                 let session =
-                    Self::remote_session_value(owner, None, workspace.id, harness, settings);
+                    Self::remote_session_value(owner, owner_kind, workspace.id, harness, settings);
                 self.validate_remote_execution(&session)?;
-                Ok(tidebreak_core::db::code::resolve_external_session(
+                let resolution = tidebreak_core::db::code::resolve_external_session(
                     &self.db,
                     owner,
                     grant_id,
@@ -280,7 +326,8 @@ impl CodeRuntime {
                     &workspace,
                     &session,
                 )
-                .await?)
+                .await?;
+                Ok((resolution, identity))
             }
             ExecutionLocation::Machine => {
                 // The machine's own engine: the ordinary local workspace and
@@ -305,14 +352,7 @@ impl CodeRuntime {
                 }
                 let settings = NewSessionSettings {
                     permission_mode: mode,
-                    ..settings
-                };
-                let settings = NewSessionSettings {
-                    acts_as: if workspace_grant {
-                        Some(tidebreak_core::ActsAs::Bot)
-                    } else {
-                        settings.acts_as
-                    },
+                    acts_as: Some(identity.acts_as),
                     ..settings
                 };
                 let workspace = self
@@ -322,19 +362,14 @@ impl CodeRuntime {
                         title,
                         None,
                         None,
-                        delegated
-                            .as_ref()
-                            .map(|gateway| {
-                                gateway.as_ref() as &dyn crate::obo_gateway::GitCredentialLender
-                            })
-                            .or_else(|| self.git_credentials().map(|lender| lender.as_ref())),
-                        settings.acts_as.unwrap_or(tidebreak_core::ActsAs::Person),
+                        lender,
+                        identity.acts_as,
                     )
                     .await?;
                 let session = self
                     .create_session_of_kind_unattached(
                         owner,
-                        None,
+                        owner_kind,
                         workspace.id,
                         SessionKind::Interactive,
                         harness,
@@ -357,9 +392,101 @@ impl CodeRuntime {
                 ) {
                     self.attach_and_spawn_worker(session).await?;
                 }
-                Ok(resolution)
+                Ok((resolution, identity))
             }
         }
+    }
+
+    /// Choose the session's forge identity once, before the workspace is
+    /// cloned, so the clone borrows the same identity the session will
+    /// (decision 0090 amendment).
+    async fn decide_external_acts_as(
+        &self,
+        owner: &OwnerId,
+        owner_kind: Option<&str>,
+        requested: Option<tidebreak_core::ActsAs>,
+        lender: Option<&dyn crate::obo_gateway::GitCredentialLender>,
+    ) -> Result<ExternalActsAsView, ServerError> {
+        use crate::obo_gateway::{GitForgeAttribution, GitForgeAttributionRequest, GitForgeError};
+
+        if owner_kind == Some("service") {
+            return self.external_bot_identity(owner, lender, None).await;
+        }
+        let Some(lender) = lender else {
+            // Standalone and desktop: local git identity, no probe.
+            return Ok(ExternalActsAsView {
+                acts_as: requested.unwrap_or(tidebreak_core::ActsAs::Person),
+                acting_login: None,
+                app_name: None,
+                connect_url: None,
+            });
+        };
+        if requested == Some(tidebreak_core::ActsAs::Bot) {
+            return self.external_bot_identity(owner, Some(lender), None).await;
+        }
+        match lender
+            .git_forge_identity(owner, GitForgeAttributionRequest::Person)
+            .await
+        {
+            Ok(identity) => match identity.attribution {
+                GitForgeAttribution::Person { login, .. } => Ok(ExternalActsAsView {
+                    acts_as: tidebreak_core::ActsAs::Person,
+                    acting_login: Some(login),
+                    app_name: Some(identity.app_name).filter(|name| !name.is_empty()),
+                    connect_url: None,
+                }),
+                GitForgeAttribution::Bot { bot_login } => Ok(ExternalActsAsView {
+                    acts_as: tidebreak_core::ActsAs::Bot,
+                    acting_login: bot_login,
+                    app_name: Some(identity.app_name).filter(|name| !name.is_empty()),
+                    connect_url: None,
+                }),
+            },
+            Err(GitForgeError::NotConnected { connect_url }) => {
+                self.external_bot_identity(owner, Some(lender), connect_url)
+                    .await
+            }
+            Err(GitForgeError::PersonNotOffered | GitForgeError::NoGitForge) => {
+                self.external_bot_identity(owner, Some(lender), None).await
+            }
+            Err(GitForgeError::Unavailable(detail)) => Err(ServerError::bad_gateway_kind(
+                "forge_unavailable",
+                format!("the forge is temporarily unavailable; retry ({detail})"),
+            )),
+            Err(_) => Err(ServerError::bad_gateway_kind(
+                "forge_unavailable",
+                "the forge could not answer who this session acts as; retry",
+            )),
+        }
+    }
+
+    async fn external_bot_identity(
+        &self,
+        owner: &OwnerId,
+        lender: Option<&dyn crate::obo_gateway::GitCredentialLender>,
+        connect_url: Option<String>,
+    ) -> Result<ExternalActsAsView, ServerError> {
+        use crate::obo_gateway::{GitForgeAttribution, GitForgeAttributionRequest};
+
+        let mut view = ExternalActsAsView {
+            acts_as: tidebreak_core::ActsAs::Bot,
+            acting_login: None,
+            app_name: None,
+            connect_url,
+        };
+        let Some(lender) = lender else {
+            return Ok(view);
+        };
+        if let Ok(identity) = lender
+            .git_forge_identity(owner, GitForgeAttributionRequest::Installation)
+            .await
+        {
+            view.app_name = Some(identity.app_name).filter(|name| !name.is_empty());
+            if let GitForgeAttribution::Bot { bot_login } = identity.attribution {
+                view.acting_login = bot_login;
+            }
+        }
+        Ok(view)
     }
 
     /// Where an external session runs on this deployment (decision 0088):

--- a/crates/tidebreak-server/src/error.rs
+++ b/crates/tidebreak-server/src/error.rs
@@ -168,6 +168,18 @@ impl ServerError {
         }
     }
 
+    /// A `502 Bad Gateway` with a route-specific stable kind, for a dependency
+    /// the caller should retry (the forge, a verifier).
+    pub fn bad_gateway_kind(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_GATEWAY,
+            info: AgentErrorInfo {
+                kind: kind.to_owned(),
+                message: message.into(),
+            },
+        }
+    }
+
     /// A `500 Internal Server Error` for an unexpected server-side failure that
     /// isn't an [`AgentError`] (for example, another subsystem fault). Carries a stable
     /// `kind` so a client sees the same `{ kind, message }` shape as any error.

--- a/crates/tidebreak-server/src/obo_gateway/external/tests.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external/tests.rs
@@ -234,6 +234,7 @@ async fn browser_credentials_cannot_mask_missing_or_unconfirmed_delegation() {
     let error = runtime
         .external_get_or_create(
             &owner,
+            None,
             grant.id,
             "slack",
             "T1/C1/legacy",
@@ -241,6 +242,7 @@ async fn browser_credentials_cannot_mask_missing_or_unconfirmed_delegation() {
             None,
             tidebreak_core::HarnessKind::ClaudeCode,
             crate::code::runtime::NewSessionSettings::default(),
+            None,
             None,
         )
         .await
@@ -492,9 +494,10 @@ async fn first_external_worker_after_restart_names_the_owner_before_workspace_se
         CodeRuntime::with_registry(db, dir.path().to_path_buf(), registry).with_harness_llm(relay),
     );
     restarted.start("http://127.0.0.1:1".into()).await.unwrap();
-    let result = restarted
+    let (result, _) = restarted
         .external_get_or_create(
             &owner,
+            None,
             grant.id,
             "slack",
             "T1/C1/restarted",
@@ -502,6 +505,7 @@ async fn first_external_worker_after_restart_names_the_owner_before_workspace_se
             Some("From Slack".into()),
             HarnessKind::ClaudeCode,
             crate::code::runtime::NewSessionSettings::default(),
+            None,
             None,
         )
         .await

--- a/docs/decisions/0090-a-session-acts-as-one-forge-identity.md
+++ b/docs/decisions/0090-a-session-acts-as-one-forge-identity.md
@@ -32,6 +32,17 @@ asked to act as you and the forge cannot).
 This slice does not read the channel's request. External get-or-create keeps
 today's behavior; a following slice can take the adapter's choice.
 
+## Amendment 2026-09-08: get-or-create names who the session acts as
+
+External get-or-create now takes optional `acts_as` and decides once, before
+the workspace is cloned. A service-owned session always acts as the bot. A
+request for `bot` acts as the bot. `person` or an absent value probes the
+delegated lender as the person: a person identity is kept; `not_connected`,
+`person_not_offered`, or `no_git_forge` falls back to the bot and, when the
+person could connect, returns `connect_url`; `unavailable` is `502
+forge_unavailable` and starts nothing. A machine with no lender keeps today's
+person semantics and does not probe.
+
 ## Alternatives considered
 
 **Decide from the channel at each borrow.** Rejected: a session that starts

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -225,10 +225,18 @@ as good as that confirmation gate.
 ## Identity and connect
 
 A session acts as one forge identity, chosen when it starts, the same way it
-chooses where the engine runs. A person's session acts as them; a service
-principal's acts as the App's bot. Hosted git names that choice on every
-borrow, and the gateway answers or refuses by name. This page does not yet
-let the channel pick the identity; get-or-create keeps today's default.
+chooses where the engine runs. Hosted git names that choice on every borrow,
+and the gateway answers or refuses by name.
+
+A DM session defaults to acting as the person when the gateway offers their
+identity. When it does not, the session runs as the bot, says so, and offers
+a Connect link. A person may ask for `bot` explicitly. A session owned by a
+service principal always acts as the bot; the body's `acts_as` is ignored.
+
+Get-or-create decides this once, before the workspace is cloned, so the clone
+borrows the same identity the session will. The response names `acts_as`,
+`acting_login`, `app_name`, and `connect_url` (only when the person could
+connect and did not) so the adapter can say who is acting and how to connect.
 
 A Slack user does not run until they hold a grant. Channel sessions run
 under a workspace grant instead: a service principal starts that
@@ -645,6 +653,10 @@ an owner attaches a file ("Attachments aren't read yet").
 The command surface is four words; nothing propagates by folklore:
 
 - `/tidebreak help` lists everything with examples.
+- `/tidebreak mode` names the permission mode a machine session should
+  take, within the operator's ceiling.
+- `/tidebreak identity` names who the next session acts as (`person` or
+  `bot`), within the get-or-create rule above.
 - The App Home shows grant status, active sessions with thread links,
   the channel defaults the user can see, and a revoke control.
 - The install welcome DM introduces the mention pattern and the


### PR DESCRIPTION
## What

External get-or-create now takes optional `acts_as` (`person` | `bot`) and chooses the session's forge identity once, before the workspace is cloned, so the clone borrows the same identity the session will.

- A service-owned grant always acts as the bot; the body is ignored.
- `bot` acts as the bot.
- `person` or an absent value probes the delegated lender as the person. A person identity is kept. `not_connected`, `person_not_offered`, or `no_git_forge` falls back to the bot and, when the person could connect, returns `connect_url`. `unavailable` is `502 forge_unavailable` and starts nothing.
- A machine with no lender keeps person semantics and does not probe.

The create response names `acts_as`, `acting_login`, `app_name`, and `connect_url` (only when the person could connect and did not) so the adapter can say who is acting. The event-stream snapshot already carries `acts_as`. `acting_login` and `app_name` stay on the create response: they are not stored on the session, so putting them on the snapshot would not be cheap.

`POST .../messages` accepts optional `actor { external_identity, display }`. Until workspace grants land, a person grant ignores `external_identity` so a channel cannot forge another person's turn. `display` still applies.

This branch merges `origin/thet/session-acts-as` so it builds on `ActsAs` and `GitForgeAttributionRequest` rather than defining them again.

## Why

A DM should act as the person when the gateway offers them, and should say so and offer Connect when it does not. A channel owned by a service principal has no person to act as. The thread needs the answer on create so it can render it.

## Validation

- `cargo fmt --all`
- `cargo clippy -p tidebreak-core -p tidebreak-server-core -p tidebreak-server --all-targets -- -D warnings -A clippy::too_many_arguments`
- `cargo test -p tidebreak-server-core --lib an_external_conversation_binds_once` (in-process get-or-create)
- Added HTTP tests on `machine_app_built` with a controllable lender: connected person, not connected + `connect_url`, explicit `bot`, `unavailable` → 502 and no binding, service-owned grant via `name token service` → bot regardless of the body. Extended the loopback borrow test so later `git` uses the chosen identity.

## Risk

Low. Existing conversations keep their stored `acts_as`. A new session on a hosted machine with a live person identity still acts as the person. The fallback-to-bot path is the new product behavior. `502 forge_unavailable` is the adapter's retry signal; nothing is bound.

## Checks this environment could not run

- HTTP loopback tests in `code_external` (`127.0.0.1` TCP connect times out here). CI should run them.
- `UPDATE_WIRE_TYPES` / `pnpm --dir mobile sync-wire` — no snapshot or generated wire type changed.
- Full workspace test suite and desktop UI Storybook.