### PR TITLE
improve: share the updater HTTP client stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,7 +2804,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -4218,7 +4217,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.10.2",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5058,48 +5057,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http 0.6.11",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -5117,6 +5074,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5125,6 +5083,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -5135,7 +5094,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -6736,7 +6695,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6971,7 +6930,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -7189,7 +7148,7 @@ dependencies = [
  "futures",
  "image",
  "jsonschema",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -7234,7 +7193,7 @@ dependencies = [
  "futures",
  "image",
  "libc",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -7257,7 +7216,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -7318,7 +7277,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-web-kit",
  "opus-decoder",
- "reqwest 0.12.28",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -7361,7 +7320,7 @@ dependencies = [
  "axum",
  "base64 0.23.1",
  "futures",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -7381,7 +7340,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.1",
  "libc",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -7431,7 +7390,7 @@ dependencies = [
  "chrono",
  "futures",
  "image",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tidebreak-core",
@@ -7448,7 +7407,7 @@ dependencies = [
  "base64 0.23.1",
  "chrono",
  "futures",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "tidebreak-core",
  "tokio",
@@ -7522,7 +7481,7 @@ dependencies = [
  "futures",
  "image",
  "libc",
- "reqwest 0.12.28",
+ "reqwest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -7571,7 +7530,7 @@ dependencies = [
  "oauth2",
  "plist",
  "portable-pty",
- "reqwest 0.12.28",
+ "reqwest",
  "schemars 1.2.2",
  "sea-orm",
  "serde",
@@ -7623,7 +7582,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "axum",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -8494,19 +8453,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,10 +107,11 @@ tokio = { version = "=1.53.1", features = [
     "time",
 ] }
 tokio-util = { version = "=0.7.19", features = ["io-util"] }
-# rustls-tls-webpki-roots (never native-tls) matches the reqwest stack; the
-# loopback chat socket itself is plain ws://.
+# Use rustls for WebSockets; the loopback chat socket itself is plain ws://.
 tokio-tungstenite = { version = "=0.30.0", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
-reqwest = { version = "=0.12.28", default-features = false, features = ["json", "multipart", "stream", "rustls-tls"] }
+# Share reqwest with tauri-plugin-updater. Rustls uses the platform trust store;
+# query and form encoding require explicit features in reqwest 0.13.
+reqwest = { version = "=0.13.4", default-features = false, features = ["json", "multipart", "stream", "query", "form", "rustls"] }
 oauth2 = { version = "=5.0.0", default-features = false }
 jsonwebtoken = { version = "=11.0.0", default-features = false, features = ["aws_lc_rs"] }
 sha2 = "=0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,8 +109,9 @@ tokio = { version = "=1.53.1", features = [
 tokio-util = { version = "=0.7.19", features = ["io-util"] }
 # Use rustls for WebSockets; the loopback chat socket itself is plain ws://.
 tokio-tungstenite = { version = "=0.30.0", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
-# Share reqwest with tauri-plugin-updater. Rustls uses the platform trust store;
-# query and form encoding require explicit features in reqwest 0.13.
+# Share reqwest with tauri-plugin-updater. In reqwest 0.13, `rustls` enables
+# rustls-platform-verifier; ClientBuilder installs it when no custom roots are set.
+# Query and form encoding require explicit features in reqwest 0.13.
 reqwest = { version = "=0.13.4", default-features = false, features = ["json", "multipart", "stream", "query", "form", "rustls"] }
 oauth2 = { version = "=5.0.0", default-features = false }
 jsonwebtoken = { version = "=11.0.0", default-features = false, features = ["aws_lc_rs"] }

--- a/legal/THIRD-PARTY-NOTICES.md
+++ b/legal/THIRD-PARTY-NOTICES.md
@@ -27,9 +27,9 @@ a stale one.
 
 ## Summary
 
-- Rust crates: 853
+- Rust crates: 851
 - Desktop UI production packages: 535
-- Distinct license texts: 591
+- Distinct license texts: 590
 - Packages with no declared license: 0
 - Packages with a curated license: 28
 
@@ -3018,12 +3018,6 @@ License identifiers named across all declared expressions:
 - Repository: https://github.com/djkoloski/rend
 - License text: `LICENSE` ([L-a427dbea98ff](#l-a427dbea98ff))
 
-### reqwest 0.12.28
-
-- License: `MIT OR Apache-2.0`
-- Repository: https://github.com/seanmonstar/reqwest
-- License text: `LICENSE-APACHE` ([L-2db114247fb5](#l-2db114247fb5)), `LICENSE-MIT` ([L-54987d63f266](#l-54987d63f266))
-
 ### reqwest 0.13.4
 
 - License: `MIT OR Apache-2.0`
@@ -4444,12 +4438,6 @@ License identifiers named across all declared expressions:
 - License: `MIT OR Apache-2.0`
 - Repository: https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared
 - License text: `LICENSE-APACHE` ([L-769f80b5bcb4](#l-769f80b5bcb4)), `LICENSE-MIT` ([L-84e1bbfebd74](#l-84e1bbfebd74))
-
-### wasm-streams 0.4.2
-
-- License: `MIT OR Apache-2.0`
-- Repository: https://github.com/MattiasBuelens/wasm-streams/
-- License text: `LICENSE-APACHE` ([L-95bd3988beee](#l-95bd3988beee)), `LICENSE-MIT` ([L-30fefc3a7d6a](#l-30fefc3a7d6a))
 
 ### wasm-streams 0.5.0
 
@@ -16818,30 +16806,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-```
-
-### L-54987d63f266
-
-```
-Copyright (c) 2016-2025 Sean McArthur
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 ```
 
 ### L-5551a1f1ad85

--- a/scripts/http-client-stack.test.mjs
+++ b/scripts/http-client-stack.test.mjs
@@ -9,6 +9,7 @@ const packages = lockfile
   .map((entry) => ({
     name: entry.match(/^name = "([^"]+)"$/m)?.[1],
     version: entry.match(/^version = "([^"]+)"$/m)?.[1],
+    dependencies: entry.match(/^dependencies = \[([\s\S]*?)^\]/m)?.[1] ?? "",
   }));
 
 // The updater and workspace clients must share one HTTP stack. A second
@@ -23,3 +24,11 @@ for (const name of ["reqwest", "hyper", "hyper-rustls"]) {
     );
   });
 }
+
+// reqwest 0.13's rustls feature supplies the platform certificate verifier.
+// Keep that verifier in the resolved client graph when changing HTTP features.
+test("reqwest retains platform certificate verification", () => {
+  const reqwest = packages.find((entry) => entry.name === "reqwest");
+  assert.ok(reqwest);
+  assert.match(reqwest.dependencies, /^ "rustls-platform-verifier",$/m);
+});

--- a/scripts/http-client-stack.test.mjs
+++ b/scripts/http-client-stack.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const lockfile = readFileSync(new URL("../Cargo.lock", import.meta.url), "utf8");
+const packages = lockfile
+  .split(/^\[\[package\]\]$/m)
+  .slice(1)
+  .map((entry) => ({
+    name: entry.match(/^name = "([^"]+)"$/m)?.[1],
+    version: entry.match(/^version = "([^"]+)"$/m)?.[1],
+  }));
+
+// The updater and workspace clients must share one HTTP stack. A second
+// reqwest version adds compilation work to every desktop build.
+for (const name of ["reqwest", "hyper", "hyper-rustls"]) {
+  test(`the lockfile resolves one ${name} version`, () => {
+    const versions = packages.filter((entry) => entry.name === name);
+    assert.equal(
+      versions.length,
+      1,
+      `expected one ${name} version, found: ${versions.map((entry) => entry.version).join(", ")}`,
+    );
+  });
+}


### PR DESCRIPTION
The desktop builds reqwest 0.12.28 for workspace clients and 0.13.4 for the Tauri updater. Pin the workspace to the already locked 0.13.4 version so the desktop resolves one reqwest/hyper client stack.

Enable query and form encoding explicitly, retain JSON, multipart, and streaming support, and keep the Tauri updater’s verification and installation code. HTTPS certificate verification now uses the platform trust store through rustls. Request call sites need no changes.

Add a lockfile regression test for duplicate reqwest, hyper, and hyper-rustls versions, and regenerate the third-party notices. The regression test fails against the original lockfile.

Validation:
- Full macOS desktop build: passed.
- Desktop and CLI `cargo check --all-targets`: passed.
- Provider replay contracts: 5 passed.
- Gateway token exchange, refresh, and refusal tests: 28 passed.
- HTTP dependency tests: 3 passed.
- Formatting, diff, and generated notices checks: passed.

Closes #3138.
