### PR TITLE
feat(code): keep local base branches current by default

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client/settings.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/settings.ts
@@ -173,6 +173,7 @@ export function withSettingsApi<TBase extends Constructor<HttpCore>>(
       harness_update_channel?: HarnessUpdateChannel;
       git_source_control?: {
         auto_rename_branches?: boolean;
+        keep_local_main_up_to_date?: boolean;
         branch_prefix_mode?: "account" | "custom" | "none";
         custom_branch_prefix?: string | null;
       };

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -35,12 +35,14 @@ import type { CodeTurnSubmission, ParsedHarnessModel } from "./parsers";
 
 const toastError = vi.hoisted(() => vi.fn());
 const toastSuccess = vi.hoisted(() => vi.fn());
+const toastWarning = vi.hoisted(() => vi.fn());
 const hasLocalHostAuthority = vi.hoisted(() => vi.fn(() => true));
 const publishCodeImage = vi.hoisted(() => vi.fn());
 vi.mock("sonner", () => ({
   toast: {
     error: toastError,
     success: toastSuccess,
+    warning: toastWarning,
   },
 }));
 vi.mock("../host", async (importOriginal) => ({
@@ -84,6 +86,7 @@ afterEach(() => {
     workspaceStartups: {},
   });
   toastError.mockReset();
+  toastWarning.mockReset();
   toastSuccess.mockReset();
 });
 
@@ -427,56 +430,65 @@ describe("NewWorkspaceDialog", () => {
     ]);
   });
 
-  it("opens the workspace as soon as it exists, before the session starts", async () => {
-    const repos = [repo("repo-new", "tidebreak")];
-    useCodeCatalogStore.setState({
-      repos,
-      doctor: {
-        harnesses: [harness("claude_code")],
-        notices: [],
-      } as never,
-    });
-    const created = workspace(
-      "ws-early",
-      "repo-new",
-      "2026-08-24T12:00:00.000Z",
-    );
-    const sessionStart = deferred<CodeSessionSnapshot>();
-    const { router } = await renderWithRouter(
-      <AppContextProvider
-        value={app({
-          createCodeWorkspace: vi.fn(async () => created),
-          createCodeSession: vi.fn(() => sessionStart.promise),
-          listCodeHarnessModels: claudeModels(),
-        })}
-      >
-        <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
-      </AppContextProvider>,
-      { initialUrl: "/code/w/ws-old" },
-    );
+  it.each([false, true])(
+    "opens the workspace and starts its session with a refresh warning: %s",
+    async (warn) => {
+      const repos = [repo("repo-new", "tidebreak")];
+      useCodeCatalogStore.setState({
+        repos,
+        doctor: {
+          harnesses: [harness("claude_code")],
+          notices: [],
+        } as never,
+      });
+      const created = workspace(
+        "ws-early",
+        "repo-new",
+        "2026-08-24T12:00:00.000Z",
+      );
+      const warning =
+        "Couldn't update main to the latest version. Your workspace uses the available local history.";
+      if (warn) created.base_refresh_warning = warning;
+      const sessionStart = deferred<CodeSessionSnapshot>();
+      const { router } = await renderWithRouter(
+        <AppContextProvider
+          value={app({
+            createCodeWorkspace: vi.fn(async () => created),
+            createCodeSession: vi.fn(() => sessionStart.promise),
+            listCodeHarnessModels: claudeModels(),
+          })}
+        >
+          <NewWorkspaceDialog open onOpenChange={vi.fn()} repos={repos} />
+        </AppContextProvider>,
+        { initialUrl: "/code/w/ws-old" },
+      );
 
-    fireEvent.keyDown(screen.getByRole("dialog"), {
-      key: "Enter",
-      metaKey: true,
-    });
+      fireEvent.keyDown(screen.getByRole("dialog"), {
+        key: "Enter",
+        metaKey: true,
+      });
 
-    await waitFor(() =>
-      expect(router.state.location.pathname).toBe("/code/w/ws-early"),
-    );
-    expect(useCodeUiStore.getState().workspaceStartups["ws-early"]).toEqual({
-      harness: "claude_code",
-      hasFirstMessage: false,
-      phase: "starting_session",
-    });
-    sessionStart.resolve(
-      session("ws-early", "claude_code", "2026-08-24T12:00:00.000Z"),
-    );
-    await waitFor(() =>
-      expect(
-        useCodeUiStore.getState().workspaceStartups["ws-early"],
-      ).toBeUndefined(),
-    );
-  });
+      await waitFor(() =>
+        expect(router.state.location.pathname).toBe("/code/w/ws-early"),
+      );
+      if (warn) expect(toastWarning).toHaveBeenCalledWith(warning);
+      else expect(toastWarning).not.toHaveBeenCalled();
+      expect(toastError).not.toHaveBeenCalled();
+      expect(useCodeUiStore.getState().workspaceStartups["ws-early"]).toEqual({
+        harness: "claude_code",
+        hasFirstMessage: false,
+        phase: "starting_session",
+      });
+      sessionStart.resolve(
+        session("ws-early", "claude_code", "2026-08-24T12:00:00.000Z"),
+      );
+      await waitFor(() =>
+        expect(
+          useCodeUiStore.getState().workspaceStartups["ws-early"],
+        ).toBeUndefined(),
+      );
+    },
+  );
 
   it("removes a failed create and retries the captured request", async () => {
     const repos = [repo("repo-new", "tidebreak")];

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -791,6 +791,8 @@ export function NewWorkspaceDialog({
       );
       return;
     }
+    if (workspace.base_refresh_warning)
+      toast.warning(workspace.base_refresh_warning);
     replaceWorkspace(pending.id, workspace);
     await startFirstSession({
       client,

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -2009,6 +2009,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 describe("code frames against real server output", () => {
+  it("preserves creation warnings and rejects malformed warning values", () => {
+    const workspace = CODE_FRAMES.find(
+      ({ name }) => name === "workspace",
+    )?.value;
+    expect(isRecord(workspace)).toBe(true);
+    if (!isRecord(workspace)) throw new Error("Missing workspace fixture");
+    const warning =
+      "Couldn't update main to the latest version. Your workspace uses the available local history.";
+    expect(
+      parseCodeWorkspace({ ...workspace, base_refresh_warning: warning })
+        ?.base_refresh_warning,
+    ).toBe(warning);
+    expect(
+      parseCodeWorkspace({ ...workspace, base_refresh_warning: 42 }),
+    ).toBeNull();
+    expect(
+      parseCodeWorkspace({ ...workspace, base_refresh_warning: "" }),
+    ).toBeNull();
+  });
+
   it("carries every kind this file knows a parser for", () => {
     expect(CODE_FRAMES.length).toBeGreaterThan(40);
     const kinds = new Set(CODE_FRAMES.map(({ kind }) => kind));

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2125,6 +2125,7 @@ export function parseCodeWorkspace(
   if (
     !isRecord(value) ||
     !onlyKeys<WireCodeWorkspaceSnapshot>(value, [
+      "base_refresh_warning",
       "id",
       "repo_id",
       "title",
@@ -2139,6 +2140,8 @@ export function parseCodeWorkspace(
       "released_tip",
       "bundle_bytes",
     ]) ||
+    (value.base_refresh_warning !== undefined &&
+      !nonEmptyLine(value.base_refresh_warning)) ||
     !wireId(value.id) ||
     !wireId(value.repo_id) ||
     !nonEmptyLine(value.title) ||
@@ -2155,6 +2158,9 @@ export function parseCodeWorkspace(
     return null;
   }
   const parsed: CodeWorkspaceSnapshot = {
+    ...(value.base_refresh_warning !== undefined
+      ? { base_refresh_warning: value.base_refresh_warning }
+      : {}),
     id: value.id,
     repo_id: value.repo_id,
     title: value.title,

--- a/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceActions.tsx
@@ -708,7 +708,10 @@ export function useWorkspaceCardCommands(): {
             status: "creating",
             created_at: new Date().toISOString(),
           });
-          return client.createCodeWorkspace(body);
+          const workspace = await client.createCodeWorkspace(body);
+          if (workspace.base_refresh_warning)
+            toast.warning(workspace.base_refresh_warning);
+          return workspace;
         },
         onProgress: (progress) =>
           showPreparation(uneffPreparationSteps(progress)),

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -1683,7 +1683,11 @@ export type CodeWorkspaceSearchMatch = { path: string, line_number: number, line
 /**
  * One isolated workspace (worktree + branch) on a repo.
  */
-export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string,
+export type CodeWorkspaceSnapshot = {
+/**
+ * Present only on creation when the base refresh could not complete.
+ */
+base_refresh_warning?: string, id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string,
 /**
  * Commit the released branch pointed at, so a client can name the work
  * without the branch existing.
@@ -2611,7 +2615,7 @@ export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hin
  */
 member_catalog?: string, sign_in: SignInProgress, };
 
-export type GitSourceControlSettings = { auto_rename_branches: boolean, branch_prefix_mode: BranchPrefixMode, custom_branch_prefix?: string, account_prefix?: string, effective_branch_prefix: string, };
+export type GitSourceControlSettings = { auto_rename_branches: boolean, keep_local_main_up_to_date: boolean, branch_prefix_mode: BranchPrefixMode, custom_branch_prefix?: string, account_prefix?: string, effective_branch_prefix: string, };
 
 /**
  * How far a standing grant reaches.

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -47,6 +47,7 @@ describe("AgentsPanel", () => {
       harness_update_channel: "pinned",
       git_source_control: {
         auto_rename_branches: true,
+        keep_local_main_up_to_date: true,
         branch_prefix_mode: "account",
         effective_branch_prefix: "tidebreak/",
       },
@@ -115,6 +116,7 @@ describe("AgentsPanel", () => {
       harness_update_channel: "pinned",
       git_source_control: {
         auto_rename_branches: true,
+        keep_local_main_up_to_date: true,
         branch_prefix_mode: "account",
         effective_branch_prefix: "tidebreak/",
       },

--- a/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.dom.test.tsx
@@ -39,6 +39,7 @@ const initial: RuntimeSettings = {
   harness_update_channel: "pinned",
   git_source_control: {
     auto_rename_branches: true,
+    keep_local_main_up_to_date: true,
     branch_prefix_mode: "account",
     account_prefix: "alex/",
     effective_branch_prefix: "alex/",
@@ -49,6 +50,51 @@ const initial: RuntimeSettings = {
 afterEach(cleanup);
 
 describe("GitSourceControlPanel", () => {
+  it("defaults main updates on and saves an opt-out", async () => {
+    const putSettings = vi.fn(async () => ({
+      ...initial,
+      git_source_control: {
+        ...initial.git_source_control,
+        keep_local_main_up_to_date: false,
+      },
+    }));
+    render(
+      <GitSourceControlPanel
+        client={{ getSettings: async () => initial, putSettings } as never}
+      />,
+    );
+    const toggle = await screen.findByRole("switch", {
+      name: "Keep local main up to date",
+    });
+    expect(toggle).toBeChecked();
+    await userEvent.click(toggle);
+    await waitFor(() => expect(toggle).not.toBeChecked());
+    expect(putSettings).toHaveBeenCalledWith({
+      git_source_control: { keep_local_main_up_to_date: false },
+    });
+  });
+
+  it("restores main updates after a failed save", async () => {
+    render(
+      <GitSourceControlPanel
+        client={
+          {
+            getSettings: async () => initial,
+            putSettings: async () => {
+              throw new Error("Save failed");
+            },
+          } as never
+        }
+      />,
+    );
+    const toggle = await screen.findByRole("switch", {
+      name: "Keep local main up to date",
+    });
+    await userEvent.click(toggle);
+    await waitFor(() => expect(screen.getByText("Save failed")).toBeVisible());
+    expect(toggle).toBeChecked();
+  });
+
   it("saves branch renaming and custom prefix choices", async () => {
     const putSettings = vi.fn(async (body) => ({
       ...initial,

--- a/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/GitSourceControlPanel.tsx
@@ -139,7 +139,7 @@ export function GitSourceControlPanel({
   return (
     <SettingsPanel
       title="Git & source control"
-      description="Choose how Tidebreak names branches and worktree folders for new code workspaces."
+      description="Choose how Tidebreak updates local branches and names new code workspaces."
       busy={loading || saving}
     >
       {error && <SettingsError>{error}</SettingsError>}
@@ -147,82 +147,109 @@ export function GitSourceControlPanel({
         <p className="text-sm text-muted-foreground">Loading Git settings…</p>
       ) : (
         settings && (
-          <SettingsSection
-            title="Branch names"
-            description="These defaults apply when you add a repository. Existing repositories keep their own branch prefix."
-          >
-            <SettingsField
-              label="Name generated branches and folders automatically"
-              hint="When a new workspace starts with a message, Tidebreak names its local branch and worktree folder before creating them. Existing paths never move."
-            >
-              <Switch
-                checked={settings.auto_rename_branches}
-                disabled={saving}
-                onCheckedChange={(enabled) => {
-                  const rollback = { settings, customPrefix };
-                  setSettings({ ...settings, auto_rename_branches: enabled });
-                  void save({ auto_rename_branches: enabled }, rollback);
-                }}
-                aria-label="Name generated branches and folders automatically"
-              />
-            </SettingsField>
-            <SettingsField
-              label="Branch prefix"
-              hint={
-                settings.branch_prefix_mode === "account" &&
-                !settings.account_prefix
-                  ? "No Git account is available, so Tidebreak uses tidebreak/."
-                  : "The prefix is copied into each repository you add."
-              }
-            >
-              <Select
-                value={settings.branch_prefix_mode}
-                disabled={saving}
-                onValueChange={(value) => selectMode(value as BranchPrefixMode)}
-              >
-                <SelectTrigger aria-label="Branch prefix">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="account">
-                    Git account
-                    {settings.account_prefix
-                      ? ` (${prefixStem(settings.account_prefix)})`
-                      : ""}
-                  </SelectItem>
-                  <SelectItem value="custom">Custom</SelectItem>
-                  <SelectItem value="none">No prefix</SelectItem>
-                </SelectContent>
-              </Select>
-            </SettingsField>
-            {settings.branch_prefix_mode === "custom" && (
+          <>
+            <SettingsSection title="Local branches">
               <SettingsField
-                label="Custom prefix"
-                hint="Use a valid Git branch prefix. Tidebreak adds the trailing slash."
+                label="Keep local main up to date"
+                hint="When you create a workspace, Tidebreak fetches its base branch and fast-forwards the matching local branch. It skips branches with uncommitted changes or local-only commits. Enabled by default."
               >
-                <Input
-                  className="font-mono"
-                  aria-label="Custom prefix"
-                  value={customPrefix}
+                <Switch
+                  checked={settings.keep_local_main_up_to_date}
                   disabled={saving}
-                  spellCheck={false}
-                  placeholder="team/alex"
-                  onChange={(event) => setCustomPrefix(event.target.value)}
-                  onBlur={() => {
-                    if (customPrefix.trim()) {
-                      void save({ custom_branch_prefix: customPrefix });
-                    }
+                  onCheckedChange={(enabled) => {
+                    const rollback = { settings, customPrefix };
+                    setSettings({
+                      ...settings,
+                      keep_local_main_up_to_date: enabled,
+                    });
+                    void save(
+                      { keep_local_main_up_to_date: enabled },
+                      rollback,
+                    );
                   }}
+                  aria-label="Keep local main up to date"
                 />
               </SettingsField>
-            )}
-            <div className="rounded-lg border border-border-subtle bg-muted px-3 py-2.5">
-              <p className="text-xs text-muted-foreground">Example branch</p>
-              <p className="mt-1 truncate font-mono text-sm text-foreground">
-                {previewPrefix}fix-flaky-auth-retry
-              </p>
-            </div>
-          </SettingsSection>
+            </SettingsSection>
+            <SettingsSection
+              title="Branch names"
+              description="These defaults apply when you add a repository. Existing repositories keep their own branch prefix."
+            >
+              <SettingsField
+                label="Name generated branches and folders automatically"
+                hint="When a new workspace starts with a message, Tidebreak names its local branch and worktree folder before creating them. Existing paths never move."
+              >
+                <Switch
+                  checked={settings.auto_rename_branches}
+                  disabled={saving}
+                  onCheckedChange={(enabled) => {
+                    const rollback = { settings, customPrefix };
+                    setSettings({ ...settings, auto_rename_branches: enabled });
+                    void save({ auto_rename_branches: enabled }, rollback);
+                  }}
+                  aria-label="Name generated branches and folders automatically"
+                />
+              </SettingsField>
+              <SettingsField
+                label="Branch prefix"
+                hint={
+                  settings.branch_prefix_mode === "account" &&
+                  !settings.account_prefix
+                    ? "No Git account is available, so Tidebreak uses tidebreak/."
+                    : "The prefix is copied into each repository you add."
+                }
+              >
+                <Select
+                  value={settings.branch_prefix_mode}
+                  disabled={saving}
+                  onValueChange={(value) =>
+                    selectMode(value as BranchPrefixMode)
+                  }
+                >
+                  <SelectTrigger aria-label="Branch prefix">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="account">
+                      Git account
+                      {settings.account_prefix
+                        ? ` (${prefixStem(settings.account_prefix)})`
+                        : ""}
+                    </SelectItem>
+                    <SelectItem value="custom">Custom</SelectItem>
+                    <SelectItem value="none">No prefix</SelectItem>
+                  </SelectContent>
+                </Select>
+              </SettingsField>
+              {settings.branch_prefix_mode === "custom" && (
+                <SettingsField
+                  label="Custom prefix"
+                  hint="Use a valid Git branch prefix. Tidebreak adds the trailing slash."
+                >
+                  <Input
+                    className="font-mono"
+                    aria-label="Custom prefix"
+                    value={customPrefix}
+                    disabled={saving}
+                    spellCheck={false}
+                    placeholder="team/alex"
+                    onChange={(event) => setCustomPrefix(event.target.value)}
+                    onBlur={() => {
+                      if (customPrefix.trim()) {
+                        void save({ custom_branch_prefix: customPrefix });
+                      }
+                    }}
+                  />
+                </SettingsField>
+              )}
+              <div className="rounded-lg border border-border-subtle bg-muted px-3 py-2.5">
+                <p className="text-xs text-muted-foreground">Example branch</p>
+                <p className="mt-1 truncate font-mono text-sm text-foreground">
+                  {previewPrefix}fix-flaky-auth-retry
+                </p>
+              </div>
+            </SettingsSection>
+          </>
         )
       )}
       <PortableConfigSection client={client} />

--- a/crates/tidebreak-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -130,6 +130,7 @@ const runtimeSettings: RuntimeSettings = {
   harness_update_channel: "pinned",
   git_source_control: {
     auto_rename_branches: true,
+    keep_local_main_up_to_date: true,
     branch_prefix_mode: "account",
     account_prefix: "alex/",
     effective_branch_prefix: "alex/",

--- a/crates/tidebreak-desktop/ui/src/stories/GitSourceControlPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/GitSourceControlPanel.stories.tsx
@@ -137,3 +137,9 @@ export const Narrow: Story = {
     ),
   ],
 };
+
+export const MainUpdatesDisabled: Story = {
+  args: {
+    client: client(settings({ keep_local_main_up_to_date: false })) as never,
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fireEvent, fn, waitFor, within } from "storybook/test";
+import { Toaster } from "@/components/ui/sonner";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -23,6 +24,8 @@ import { useCodeUpdatesStore } from "@/code/CodeUpdatesStore";
 import { NewWorkspaceDialog } from "@/code/NewWorkspaceDialog";
 import { ManagedPolicyContext } from "@/managedPolicy";
 import {
+  codeWorkspace,
+  codeSession,
   harnessDoctor,
   harnessDoctorCold,
   harnessDoctorDegraded,
@@ -446,5 +449,38 @@ export const FirstRepoWhileEngineDownloads: Story = {
         done: false,
       },
     },
+  },
+};
+
+/** A base refresh failure warns without stopping workspace or session creation. */
+export const BaseRefreshWarning: Story = {
+  args: {
+    client: {
+      createCodeWorkspace: async () => ({
+        ...codeWorkspace,
+        base_refresh_warning:
+          "Couldn't update main to the latest version. Your workspace uses the available local history.",
+      }),
+      createCodeSession: fn(async () => codeSession),
+    },
+  },
+  decorators: [
+    (Story) => (
+      <>
+        <Story />
+        <Toaster richColors duration={Number.POSITIVE_INFINITY} />
+      </>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    const dialog = await body.findByRole("dialog");
+    await waitFor(() =>
+      expect(body.getByRole("button", { name: /^Create$/ })).toBeEnabled(),
+    );
+    fireEvent.keyDown(dialog, { key: "Enter", metaKey: true });
+    await body.findByText(
+      "Couldn't update main to the latest version. Your workspace uses the available local history.",
+    );
   },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsStoryHarness.tsx
@@ -95,6 +95,7 @@ export const storySettings: RuntimeSettings = {
   harness_update_channel: "pinned",
   git_source_control: {
     auto_rename_branches: true,
+    keep_local_main_up_to_date: true,
     branch_prefix_mode: "account",
     account_prefix: "alex/",
     effective_branch_prefix: "alex/",

--- a/crates/tidebreak-server-api/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server-api/src/routes/code/workspaces.rs
@@ -45,18 +45,17 @@ pub async fn create_workspace(
     code: ScopedCode,
     Json(body): Json<CreateWorkspaceBody>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let workspace = code
-        .create_workspace(
+    let (workspace, base_refresh_warning) = code
+        .create_workspace_with_warning(
             body.repo_id,
             body.title,
             body.suggested_title,
             body.base_ref,
         )
         .await?;
-    Ok((
-        StatusCode::CREATED,
-        Json(CodeWorkspaceSnapshot::from(workspace)),
-    ))
+    let mut snapshot = CodeWorkspaceSnapshot::from(workspace);
+    snapshot.base_refresh_warning = base_refresh_warning;
+    Ok((StatusCode::CREATED, Json(snapshot)))
 }
 
 /// `POST /code/workspace-title` — name a workspace before its checkout exists.

--- a/crates/tidebreak-server-api/src/routes/settings.rs
+++ b/crates/tidebreak-server-api/src/routes/settings.rs
@@ -208,6 +208,8 @@ pub struct GitSourceControlSettingsUpdate {
     #[serde(default)]
     pub auto_rename_branches: Option<bool>,
     #[serde(default)]
+    pub keep_local_main_up_to_date: Option<bool>,
+    #[serde(default)]
     pub branch_prefix_mode: Option<BranchPrefixMode>,
     #[serde(default, deserialize_with = "double_option")]
     pub custom_branch_prefix: Option<Option<String>>,
@@ -430,6 +432,10 @@ pub async fn put_settings(
             return Err(ServerError::bad_request(
                 "custom_branch_prefix is required in custom mode",
             ));
+        }
+        if let Some(enabled) = update.keep_local_main_up_to_date {
+            naming_settings::write_keep_local_main_up_to_date(&*state.store, &owner, enabled)
+                .await?;
         }
         if let Some(enabled) = update.auto_rename_branches {
             naming_settings::write_auto_rename_branches(&*state.store, &owner, enabled).await?;

--- a/crates/tidebreak-server-api/src/tests/code_workspace.rs
+++ b/crates/tidebreak-server-api/src/tests/code_workspace.rs
@@ -655,3 +655,115 @@ async fn reclaim_refuses_a_checkout_tidebreak_did_not_clone() {
         .unwrap();
     assert!(listed.is_empty(), "a removed registration leaves the list");
 }
+
+#[tokio::test]
+async fn workspace_creation_refreshes_main_by_default_and_honors_opt_out() {
+    for enabled in [true, false] {
+        let (router, token, runtime, dir) = code_app(plain_text_script()).await;
+        if !enabled {
+            crate::code::naming_settings::write_keep_local_main_up_to_date(
+                &*runtime.db,
+                &tidebreak_core::OwnerId::local(),
+                false,
+            )
+            .await
+            .unwrap();
+        }
+        let origin = init_git_repo(dir.path());
+        let local = dir.path().join("local");
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .status()
+                .unwrap()
+                .success());
+        };
+        git(
+            dir.path(),
+            &["clone", origin.to_str().unwrap(), local.to_str().unwrap()],
+        );
+        std::fs::write(origin.join("README.md"), "remote update\n").unwrap();
+        git(&origin, &["commit", "-am", "remote update"]);
+        let addr = serve(router).await;
+        let client = reqwest::Client::new();
+        let (_, workspace) = register_and_workspace(&client, addr, &token, &local).await;
+        let expected = if enabled {
+            "remote update\n"
+        } else {
+            "hello\n"
+        };
+        assert_eq!(
+            std::fs::read_to_string(local.join("README.md")).unwrap(),
+            expected
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                std::path::Path::new(workspace["worktree_path"].as_str().unwrap())
+                    .join("README.md")
+            )
+            .unwrap(),
+            expected
+        );
+    }
+}
+
+#[tokio::test]
+async fn workspace_creation_warns_and_continues_when_base_refresh_fails() {
+    for reason in ["fetch", "dirty", "diverged"] {
+        let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+        let origin = init_git_repo(dir.path());
+        let local = dir.path().join("local");
+        let git = |cwd: &std::path::Path, args: &[&str]| {
+            assert!(std::process::Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .status()
+                .unwrap()
+                .success());
+        };
+        git(
+            dir.path(),
+            &["clone", origin.to_str().unwrap(), local.to_str().unwrap()],
+        );
+        if reason == "fetch" {
+            git(
+                &local,
+                &[
+                    "remote",
+                    "set-url",
+                    "origin",
+                    dir.path().join("missing.git").to_str().unwrap(),
+                ],
+            );
+        } else {
+            std::fs::write(origin.join("README.md"), "remote update\n").unwrap();
+            git(&origin, &["commit", "-am", "remote update"]);
+            std::fs::write(local.join("README.md"), "local work\n").unwrap();
+            if reason == "diverged" {
+                git(&local, &["config", "user.email", "dev@example.com"]);
+                git(&local, &["config", "user.name", "Dev"]);
+                git(
+                    &local,
+                    &["-c", "commit.gpgsign=false", "commit", "-am", "local work"],
+                );
+            }
+        }
+        let addr = serve(router).await;
+        let client = reqwest::Client::new();
+        let (_, workspace) = register_and_workspace(&client, addr, &token, &local).await;
+        assert_eq!(workspace["status"], "active", "{reason}");
+        assert_eq!(workspace["base_refresh_warning"], "Couldn't update main to the latest version. Your workspace uses the available local history.");
+        let expected = if reason == "fetch" {
+            "hello\n"
+        } else {
+            "local work\n"
+        };
+        assert_eq!(
+            std::fs::read_to_string(local.join("README.md")).unwrap(),
+            expected
+        );
+    }
+}

--- a/crates/tidebreak-server-api/src/tests/configuration.rs
+++ b/crates/tidebreak-server-api/src/tests/configuration.rs
@@ -96,6 +96,10 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(settings["code_turn_recaps_enabled"], true);
     assert_eq!(settings["git_source_control"]["auto_rename_branches"], true);
     assert_eq!(
+        settings["git_source_control"]["keep_local_main_up_to_date"],
+        true
+    );
+    assert_eq!(
         settings["git_source_control"]["branch_prefix_mode"],
         "account"
     );
@@ -135,6 +139,7 @@ async fn settings_default_then_update_roundtrips() {
                         },
                         "git_source_control": {
                             "auto_rename_branches": false,
+                            "keep_local_main_up_to_date": false,
                             "branch_prefix_mode": "custom",
                             "custom_branch_prefix": "team/alex"
                         }
@@ -147,6 +152,10 @@ async fn settings_default_then_update_roundtrips() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let settings: serde_json::Value = json_body(response).await;
+    assert_eq!(
+        settings["git_source_control"]["keep_local_main_up_to_date"],
+        false
+    );
     assert_eq!(settings["model"], "claude-x");
     assert_eq!(settings["max_active_background_agents"], 7);
     assert_eq!(

--- a/crates/tidebreak-server-api/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server-api/src/wire_code_fixtures.rs
@@ -337,6 +337,7 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
             "workspace",
             "workspace",
             &CodeWorkspaceSnapshot {
+                base_refresh_warning: None,
                 id: workspace_id(),
                 repo_id: repo_id(),
                 title: "Bound the code parser".to_owned(),
@@ -356,6 +357,7 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
             "released workspace",
             "workspace",
             &CodeWorkspaceSnapshot {
+                base_refresh_warning: None,
                 id: WorkspaceId(id(0x12)),
                 repo_id: repo_id(),
                 title: "Old work".to_owned(),

--- a/crates/tidebreak-server/src/code/naming_settings.rs
+++ b/crates/tidebreak-server/src/code/naming_settings.rs
@@ -5,6 +5,7 @@ use tidebreak_core::{OwnerId, Store};
 
 use super::worktree::slugify;
 
+pub const KEEP_LOCAL_MAIN_UP_TO_DATE_KEY: &str = "code.git.keep_local_main_up_to_date";
 pub const AUTO_RENAME_BRANCHES_KEY: &str = "code.git.auto_rename_branches";
 pub const BRANCH_PREFIX_MODE_KEY: &str = "code.git.branch_prefix_mode";
 pub const CUSTOM_BRANCH_PREFIX_KEY: &str = "code.git.custom_branch_prefix";
@@ -21,6 +22,7 @@ pub enum BranchPrefixMode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 pub struct GitSourceControlSettings {
     pub auto_rename_branches: bool,
+    pub keep_local_main_up_to_date: bool,
     pub branch_prefix_mode: BranchPrefixMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -48,6 +50,28 @@ async fn read_value<T: serde::de::DeserializeOwned>(
         .get_setting(&user_setting_key(owner, key))
         .await?
         .and_then(|value| serde_json::from_value(value).ok()))
+}
+
+pub async fn keep_local_main_up_to_date(
+    store: &dyn Store,
+    owner: &OwnerId,
+) -> tidebreak_core::Result<bool> {
+    Ok(read_value(store, owner, KEEP_LOCAL_MAIN_UP_TO_DATE_KEY)
+        .await?
+        .unwrap_or(true))
+}
+
+pub async fn write_keep_local_main_up_to_date(
+    store: &dyn Store,
+    owner: &OwnerId,
+    enabled: bool,
+) -> tidebreak_core::Result<()> {
+    store
+        .set_setting(
+            &user_setting_key(owner, KEEP_LOCAL_MAIN_UP_TO_DATE_KEY),
+            &serde_json::json!(enabled),
+        )
+        .await
 }
 
 pub async fn auto_rename_branches(
@@ -83,6 +107,7 @@ pub async fn read(
     };
     Ok(GitSourceControlSettings {
         auto_rename_branches: auto_rename_branches(store, owner).await?,
+        keep_local_main_up_to_date: keep_local_main_up_to_date(store, owner).await?,
         branch_prefix_mode,
         custom_branch_prefix,
         account_prefix,

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -355,7 +355,7 @@ impl CodeRuntime {
                     acts_as: Some(identity.acts_as),
                     ..settings
                 };
-                let workspace = self
+                let (workspace, _base_refresh_warning) = self
                     .create_workspace_with_git_credentials(
                         owner,
                         repo_id,

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -27,6 +27,19 @@ impl CodeRuntime {
         suggested_title: Option<String>,
         base_ref: Option<String>,
     ) -> Result<CodeWorkspace, ServerError> {
+        self.create_workspace_with_warning(owner, repo_id, title, suggested_title, base_ref)
+            .await
+            .map(|(workspace, _)| workspace)
+    }
+
+    pub async fn create_workspace_with_warning(
+        &self,
+        owner: &OwnerId,
+        repo_id: RepoId,
+        title: Option<String>,
+        suggested_title: Option<String>,
+        base_ref: Option<String>,
+    ) -> Result<(CodeWorkspace, Option<String>), ServerError> {
         self.create_workspace_with_git_credentials(
             owner,
             repo_id,
@@ -49,7 +62,7 @@ impl CodeRuntime {
         base_ref: Option<String>,
         lender: Option<&dyn crate::obo_gateway::GitCredentialLender>,
         acts_as: tidebreak_core::ActsAs,
-    ) -> Result<CodeWorkspace, ServerError> {
+    ) -> Result<(CodeWorkspace, Option<String>), ServerError> {
         let repo = self.get_repo(owner, repo_id).await?;
         Self::refuse_removed_repo(&repo)?;
         let explicit_title = title
@@ -100,6 +113,8 @@ impl CodeRuntime {
         let requested_repo_default = explicit_base
             .as_deref()
             .is_none_or(|value| value == repo.default_base_ref);
+        let creation = self.workspace_creation_lock(repo_id);
+        let creation_guard = creation.lock().await;
         let base = if requested_repo_default {
             worktree::resolve_default_base_ref(repo_root, Some(&requested))
                 .await
@@ -109,14 +124,21 @@ impl CodeRuntime {
                 .await
                 .map_err(map_worktree)?
         };
+        let refreshed = match naming_settings::keep_local_main_up_to_date(&*self.db, owner).await {
+            Ok(false) => Ok(()),
+            Ok(true) => worktree::refresh_local_base(repo_root, &base).await,
+            Err(error) => Err(error.to_string()),
+        };
+        let base_refresh_warning = refreshed.err().map(|error| {
+            tracing::debug!(repo = %repo.id, %error, "local base refresh skipped");
+            format!("Couldn't update {base} to the latest version. Your workspace uses the available local history.")
+        });
         if requested_repo_default && repo.default_base_ref != base {
             let mut repo = repo.clone();
             repo.default_base_ref = base.clone();
             self.save_repo(&repo).await?;
         }
         let repo_root = std::path::Path::new(&repo.root_path);
-        let creation = self.workspace_creation_lock(repo_id);
-        let creation_guard = creation.lock().await;
         let mut existing = list_workspaces(&self.db, owner, Some(repo_id))
             .await?
             .into_iter()
@@ -204,7 +226,7 @@ impl CodeRuntime {
                     }
                 }
                 gh::run_auto_create_actions(&path, &repo.quick_actions).await;
-                Ok(workspace)
+                Ok((workspace, base_refresh_warning))
             }
             Err(err) => {
                 workspace.status = CodeWorkspaceStatus::SetupFailed;

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -347,6 +347,18 @@ impl ScopedCode {
             .await
     }
 
+    pub async fn create_workspace_with_warning(
+        &self,
+        repo_id: RepoId,
+        title: Option<String>,
+        suggested_title: Option<String>,
+        base_ref: Option<String>,
+    ) -> Result<(CodeWorkspace, Option<String>), ServerError> {
+        self.runtime
+            .create_workspace_with_warning(&self.owner, repo_id, title, suggested_title, base_ref)
+            .await
+    }
+
     pub async fn create_remote_workspace(
         &self,
         repo_id: RepoId,

--- a/crates/tidebreak-server/src/code/types.rs
+++ b/crates/tidebreak-server/src/code/types.rs
@@ -195,6 +195,10 @@ impl From<CodeRepo> for CodeRepoSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(deny_unknown_fields)]
 pub struct CodeWorkspaceSnapshot {
+    /// Present only on creation when the base refresh could not complete.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub base_refresh_warning: Option<String>,
     pub id: WorkspaceId,
     pub repo_id: RepoId,
     pub title: String,
@@ -226,6 +230,7 @@ pub struct CodeWorkspaceSnapshot {
 impl From<CodeWorkspace> for CodeWorkspaceSnapshot {
     fn from(workspace: CodeWorkspace) -> Self {
         Self {
+            base_refresh_warning: None,
             id: workspace.id,
             repo_id: workspace.repo_id,
             title: workspace.title,

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -591,6 +591,175 @@ pub async fn resolve_named_base_ref(
     Err(WorktreeError::missing_base_ref(reference, &tried))
 }
 
+/// Refresh a branch before workspace creation. Tags and commit IDs stay pinned.
+/// A failed fetch or unsafe local update leaves workspace creation available.
+pub async fn refresh_local_base(repo_root: &Path, base: &str) -> Result<(), String> {
+    let resolved = git_stdout(
+        Some(repo_root),
+        &["rev-parse", "--symbolic-full-name", "--verify", base],
+        GIT_TIMEOUT,
+    )
+    .await?;
+    let (branch, remote, remote_branch) = if let Some(branch) = resolved.strip_prefix("refs/heads/")
+    {
+        let remote = git_stdout(
+            Some(repo_root),
+            &["config", "--get", &format!("branch.{branch}.remote")],
+            GIT_TIMEOUT,
+        )
+        .await
+        .unwrap_or_else(|_| "origin".into());
+        let upstream = git_stdout(
+            Some(repo_root),
+            &["config", "--get", &format!("branch.{branch}.merge")],
+            GIT_TIMEOUT,
+        )
+        .await
+        .unwrap_or_else(|_| format!("refs/heads/{branch}"));
+        let Some(remote_branch) = upstream.strip_prefix("refs/heads/") else {
+            return Ok(());
+        };
+        (branch.to_owned(), remote, remote_branch.to_owned())
+    } else if let Some(tracking) = resolved.strip_prefix("refs/remotes/") {
+        let Some((remote, branch)) = tracking.split_once('/') else {
+            return Ok(());
+        };
+        (branch.to_owned(), remote.to_owned(), branch.to_owned())
+    } else {
+        return Ok(());
+    };
+    // Local upstreams do not need a network refresh.
+    if remote == "." || remote.starts_with('-') {
+        return Ok(());
+    }
+    let tracking = format!("refs/remotes/{remote}/{remote_branch}");
+    let refspec = format!("refs/heads/{remote_branch}:{tracking}");
+    git(
+        Some(repo_root),
+        &[
+            "fetch",
+            "--no-tags",
+            "--no-write-fetch-head",
+            "--",
+            &remote,
+            &refspec,
+        ],
+        GIT_TIMEOUT,
+    )
+    .await?;
+    let local = format!("refs/heads/{branch}");
+    let Ok(old) = git_stdout(
+        Some(repo_root),
+        &["rev-parse", "--verify", &local],
+        GIT_TIMEOUT,
+    )
+    .await
+    else {
+        return Ok(());
+    };
+    let new = git_stdout(
+        Some(repo_root),
+        &["rev-parse", "--verify", &tracking],
+        GIT_TIMEOUT,
+    )
+    .await?;
+    if old == new {
+        return Ok(());
+    }
+    git(
+        Some(repo_root),
+        &["merge-base", "--is-ancestor", &old, &new],
+        GIT_TIMEOUT,
+    )
+    .await?;
+    let entries = git_nul_stdout(
+        Some(repo_root),
+        &["worktree", "list", "--porcelain", "-z"],
+        GIT_TIMEOUT,
+    )
+    .await?;
+    let mut checkout = None;
+    let mut path = None;
+    for entry in entries {
+        if let Some(value) = entry.strip_prefix("worktree ") {
+            path = Some(PathBuf::from(value));
+        }
+        if entry.strip_prefix("branch ") == Some(local.as_str()) {
+            checkout = path.clone();
+        }
+    }
+    if let Some(checkout) = checkout {
+        let status = git_stdout(
+            Some(&checkout),
+            &["status", "--porcelain", "--untracked-files=all"],
+            GIT_TIMEOUT,
+        )
+        .await?;
+        if !status.is_empty() {
+            return Err("the base checkout has uncommitted files".into());
+        }
+        for operation in [
+            "MERGE_HEAD",
+            "CHERRY_PICK_HEAD",
+            "REVERT_HEAD",
+            "rebase-merge",
+            "rebase-apply",
+            "sequencer",
+            "BISECT_LOG",
+        ] {
+            let path = git_stdout(
+                Some(&checkout),
+                &["rev-parse", "--git-path", operation],
+                GIT_TIMEOUT,
+            )
+            .await?;
+            if checkout.join(path).exists() {
+                return Err("the base checkout has a Git operation in progress".into());
+            }
+        }
+        let head = git_stdout(
+            Some(&checkout),
+            &["symbolic-ref", "--quiet", "HEAD"],
+            GIT_TIMEOUT,
+        )
+        .await?;
+        if head != local {
+            return Err("the base checkout changed branches during refresh".into());
+        }
+        // Git protects edits made after the status check and refuses divergence.
+        git(
+            Some(&checkout),
+            &[
+                "-c",
+                "core.hooksPath=/dev/null",
+                "merge",
+                "--ff-only",
+                "--no-autostash",
+                "--no-overwrite-ignore",
+                &new,
+            ],
+            GIT_TIMEOUT,
+        )
+        .await?;
+    } else {
+        // Compare the old tip so a concurrent commit cannot be overwritten.
+        git(
+            Some(repo_root),
+            &[
+                "update-ref",
+                "-m",
+                "Tidebreak: refresh local base",
+                &local,
+                &new,
+                &old,
+            ],
+            GIT_TIMEOUT,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
 /// Create a worktree and branch under the Tidebreak data directory.
 pub async fn create_worktree(
     repo_root: &Path,
@@ -2284,6 +2453,124 @@ mod tests {
             .unwrap()
             .complete()
             .await;
+    }
+
+    #[tokio::test]
+    async fn refresh_local_base_fast_forwards_clean_and_unchecked_branches() {
+        for sibling in [false, true] {
+            let (dir, origin) = init_repo();
+            let local = dir.path().join("local");
+            run(
+                dir.path(),
+                &[
+                    "git",
+                    "clone",
+                    origin.to_str().unwrap(),
+                    local.to_str().unwrap(),
+                ],
+            );
+            let old = branch_tip(&local, "main").await.unwrap();
+            if sibling {
+                run(&local, &["git", "switch", "-c", "feature"]);
+            }
+            std::fs::write(origin.join("README.md"), "updated\n").unwrap();
+            run(&origin, &["git", "commit", "-am", "update"]);
+            refresh_local_base(&local, "main").await.unwrap();
+            assert_eq!(
+                branch_tip(&local, "main").await.unwrap(),
+                branch_tip(&origin, "main").await.unwrap()
+            );
+            if sibling {
+                assert_eq!(branch_tip(&local, "feature").await.unwrap(), old);
+                assert_eq!(
+                    std::fs::read_to_string(local.join("README.md")).unwrap(),
+                    "hello\n"
+                );
+            } else {
+                assert_eq!(
+                    std::fs::read_to_string(local.join("README.md")).unwrap(),
+                    "updated\n"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_local_base_preserves_dirty_diverged_and_untracked_work() {
+        for state in ["dirty", "diverged", "untracked", "merge"] {
+            let (dir, origin) = init_repo();
+            let local = dir.path().join("local");
+            run(
+                dir.path(),
+                &[
+                    "git",
+                    "clone",
+                    origin.to_str().unwrap(),
+                    local.to_str().unwrap(),
+                ],
+            );
+            run(&local, &["git", "config", "user.email", "dev@example.com"]);
+            run(&local, &["git", "config", "user.name", "Dev"]);
+            match state {
+                "dirty" | "diverged" => {
+                    std::fs::write(local.join("README.md"), "my work\n").unwrap();
+                    if state == "diverged" {
+                        run(&local, &["git", "commit", "-am", "local work"]);
+                    }
+                }
+                "untracked" => std::fs::write(local.join("new.txt"), "my work\n").unwrap(),
+                _ => std::fs::write(
+                    local.join(".git/MERGE_HEAD"),
+                    branch_tip(&local, "main").await.unwrap(),
+                )
+                .unwrap(),
+            }
+            let old = branch_tip(&local, "main").await.unwrap();
+            std::fs::write(origin.join("README.md"), "updated\n").unwrap();
+            run(&origin, &["git", "commit", "-am", "update"]);
+            let _ = refresh_local_base(&local, "main").await;
+            assert_eq!(branch_tip(&local, "main").await.unwrap(), old, "{state}");
+            if state == "dirty" || state == "diverged" {
+                assert_eq!(
+                    std::fs::read_to_string(local.join("README.md")).unwrap(),
+                    "my work\n"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_local_base_updates_the_sibling_checkout_and_preserves_pinned_refs() {
+        let (dir, origin) = init_repo();
+        let local = dir.path().join("local");
+        run(
+            dir.path(),
+            &[
+                "git",
+                "clone",
+                origin.to_str().unwrap(),
+                local.to_str().unwrap(),
+            ],
+        );
+        let old = branch_tip(&local, "main").await.unwrap();
+        run(&local, &["git", "-c", "tag.gpgSign=false", "tag", "v1"]);
+        run(&local, &["git", "switch", "-c", "feature"]);
+        let sibling = dir.path().join("sibling with spaces");
+        run(
+            &local,
+            &["git", "worktree", "add", sibling.to_str().unwrap(), "main"],
+        );
+        std::fs::write(origin.join("README.md"), "updated\n").unwrap();
+        run(&origin, &["git", "commit", "-am", "update"]);
+        refresh_local_base(&local, "v1").await.unwrap();
+        refresh_local_base(&local, &old).await.unwrap();
+        assert_eq!(branch_tip(&local, "main").await.unwrap(), old);
+        refresh_local_base(&local, "origin/main").await.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(sibling.join("README.md")).unwrap(),
+            "updated\n"
+        );
+        assert_eq!(branch_tip(&local, "feature").await.unwrap(), old);
     }
 
     #[tokio::test]

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -1683,7 +1683,11 @@ export type CodeWorkspaceSearchMatch = { path: string, line_number: number, line
 /**
  * One isolated workspace (worktree + branch) on a repo.
  */
-export type CodeWorkspaceSnapshot = { id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string,
+export type CodeWorkspaceSnapshot = {
+/**
+ * Present only on creation when the base refresh could not complete.
+ */
+base_refresh_warning?: string, id: WorkspaceId, repo_id: RepoId, title: string, worktree_path: string, branch_name: string, base_ref: string, status: CodeWorkspaceStatus, pr?: PullRequestDigest, created_at: string, archived_at?: string, released_at?: string,
 /**
  * Commit the released branch pointed at, so a client can name the work
  * without the branch existing.
@@ -2611,7 +2615,7 @@ export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hin
  */
 member_catalog?: string, sign_in: SignInProgress, };
 
-export type GitSourceControlSettings = { auto_rename_branches: boolean, branch_prefix_mode: BranchPrefixMode, custom_branch_prefix?: string, account_prefix?: string, effective_branch_prefix: string, };
+export type GitSourceControlSettings = { auto_rename_branches: boolean, keep_local_main_up_to_date: boolean, branch_prefix_mode: BranchPrefixMode, custom_branch_prefix?: string, account_prefix?: string, effective_branch_prefix: string, };
 
 /**
  * How far a standing grant reaches.


### PR DESCRIPTION
## Summary

Creating a code workspace now fetches its base branch and fast-forwards the matching local branch when it is safe. This keeps new workspaces and comparisons against main from using stale history.

Add “Keep local main up to date” to Settings → Git & source control. The setting defaults on for existing and new users and preserves an explicit opt-out.

If the refresh fails or the local checkout has uncommitted work, local-only commits, or an active Git operation, creation continues using available history. The desktop shows a warning toast and continues starting the session.

## Implementation and safety

- Fetch only the selected branch, using its configured upstream or origin. Tags and commit IDs remain pinned.
- Use fast-forward-only merges without autostash or ignored-file replacement for checked-out branches. Update unchecked branches with an expected-old-tip check.
- Serialize refresh with workspace creation, bound Git calls, and use the existing non-interactive Git runner.
- Return an optional creation warning in the workspace response. Existing callers retain their workspace return type; the preference needs no database migration.

## Validation

- Real Git tests cover clean and unchecked branches, sibling worktrees, dirty and untracked files, divergence, active merges, and pinned refs.
- API tests cover default-on behavior, opt-out, and successful creation after fetch or safety failures.
- UI tests cover settings persistence, rollback, warning parsing, toast display, and continued session startup.
- Rust check, generated wire types, TypeScript, formatting, and diff checks pass.
- Storybook production build passes. Reviewed settings and warning stories in four themes at desktop and narrow widths.

Network or authentication failures can leave the base stale; they produce a warning rather than blocking creation. Refresh runs when a workspace is created, not on a background timer.
