### PR TITLE
improve(browser): preserve native layout across staging and window resize

### DIFF
--- a/crates/tidebreak-desktop/tauri.staging.conf.json
+++ b/crates/tidebreak-desktop/tauri.staging.conf.json
@@ -2,14 +2,6 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tidebreak [staging]",
   "identifier": "io.brightwave.tidebreak.staging",
-  "app": {
-    "windows": [
-      {
-        "label": "main",
-        "title": "Tidebreak [staging]"
-      }
-    ]
-  },
   "plugins": {
     "deep-link": {
       "desktop": {

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.dom.test.tsx
@@ -690,6 +690,76 @@ describe("CodeBrowserTab", () => {
     expect(input).toHaveValue("example.com/second");
   });
 
+  it("resizes the native page when animation frames pause after full screen", async () => {
+    vi.useFakeTimers();
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const runtime = browserHost({ existing: true });
+    let view!: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(
+        <CodeBrowserTab
+          workspaceId="workspace-1"
+          browserId="browser-1"
+          initialUrl="https://example.com"
+          host={runtime.host}
+        />,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    runtime.calls.length = 0;
+    vi.mocked(HTMLElement.prototype.getBoundingClientRect).mockReturnValue({
+      x: 120,
+      y: 180,
+      width: 600,
+      height: 400,
+      top: 180,
+      right: 720,
+      bottom: 580,
+      left: 120,
+      toJSON: () => ({}),
+    });
+    await act(async () => {
+      fireEvent(window, new Event("resize"));
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    const boundsCalls = () =>
+      runtime.calls.filter(({ action }) => action.type === "set_bounds");
+    expect(boundsCalls().map(({ action }) => action)).toEqual([
+      {
+        type: "set_bounds",
+        bounds: { x: 120, y: 180, width: 600, height: 400 },
+      },
+    ]);
+    expect(
+      screen.getByRole("button", { name: /Viewport: Fit, rendered at 600px/ }),
+    ).toBeInTheDocument();
+    await act(async () => {
+      for (const callback of frames) callback(200);
+    });
+    expect(boundsCalls()).toHaveLength(1);
+    vi.mocked(HTMLElement.prototype.getBoundingClientRect).mockReturnValue({
+      x: 120,
+      y: 180,
+      width: 320,
+      height: 400,
+      top: 180,
+      right: 440,
+      bottom: 580,
+      left: 120,
+      toJSON: () => ({}),
+    });
+    await act(async () => {
+      fireEvent(window, new Event("resize"));
+      view.unmount();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(boundsCalls()).toHaveLength(1);
+  });
+
   it.each([
     { label: "newly created", existing: false },
     { label: "restored", existing: true },

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -928,12 +928,12 @@ function CodeBrowserTabSession({
   useEffect(() => {
     const surface = viewportSurfaceRef.current;
     if (!surface || !host.available()) return;
-    let frame: number | null = null;
+    let cancelMeasurement: (() => void) | null = null;
 
     const sync = () => {
-      if (frame !== null) window.cancelAnimationFrame(frame);
-      frame = window.requestAnimationFrame(() => {
-        frame = null;
+      if (cancelMeasurement !== null) return;
+      cancelMeasurement = scheduleBrowserMeasurement(() => {
+        cancelMeasurement = null;
         const bounds = readBrowserBounds(surface);
         if (!bounds) return;
         if (!nativeReady.current) {
@@ -988,7 +988,7 @@ function CodeBrowserTabSession({
     return () => {
       observer.disconnect();
       window.removeEventListener("resize", sync);
-      if (frame !== null) window.cancelAnimationFrame(frame);
+      cancelMeasurement?.();
     };
   }, [
     browserId,
@@ -1464,21 +1464,23 @@ function ViewportSurface({
   useEffect(() => {
     const el = surfaceRef.current;
     if (!el) return;
-    let frame: number | null = null;
+    let cancelMeasurement: (() => void) | null = null;
     const sync = () => {
-      if (frame !== null) return;
-      frame = window.requestAnimationFrame(() => {
-        frame = null;
+      if (cancelMeasurement !== null) return;
+      cancelMeasurement = scheduleBrowserMeasurement(() => {
+        cancelMeasurement = null;
         const rect = surfaceRef.current?.getBoundingClientRect();
         onViewportBoundsChange(rect && rect.width > 0 ? rect.width : null);
       });
     };
     const observer = new ResizeObserver(sync);
     observer.observe(el);
+    window.addEventListener("resize", sync);
     sync();
     return () => {
       observer.disconnect();
-      if (frame !== null) window.cancelAnimationFrame(frame);
+      window.removeEventListener("resize", sync);
+      cancelMeasurement?.();
     };
   }, [surfaceRef, onViewportBoundsChange]);
 
@@ -1533,4 +1535,22 @@ function sameBrowserBounds(
       left.width === right.width &&
       left.height === right.height,
   );
+}
+
+/** Native child views can pause the renderer's animation frames during resize. */
+function scheduleBrowserMeasurement(measure: () => void): () => void {
+  let pending = true;
+  const cancel = () => {
+    pending = false;
+    window.cancelAnimationFrame(frame);
+    window.clearTimeout(timer);
+  };
+  const run = () => {
+    if (!pending) return;
+    cancel();
+    measure();
+  };
+  const frame = window.requestAnimationFrame(run);
+  const timer = window.setTimeout(run, NATIVE_REVEAL_FALLBACK_MS);
+  return cancel;
 }

--- a/scripts/desktop-channel.test.mjs
+++ b/scripts/desktop-channel.test.mjs
@@ -73,3 +73,17 @@ test("the packaged staging overlay matches the channel contract", () => {
     overlay.bundle.icon.every((icon) => icon.startsWith("icons/staging/")),
   );
 });
+
+test("staging preserves the platform window configuration", () => {
+  const desktop = join(root, "crates", "tidebreak-desktop");
+  const load = (name) => JSON.parse(readFileSync(join(desktop, name), "utf8"));
+  const staging = load("tauri.staging.conf.json");
+  // Tauri replaces arrays when applying overlays. A title-only window entry
+  // discards the macOS overlay titlebar and the shared window dimensions.
+  assert.equal(staging.app?.windows, undefined);
+  const mac = load("tauri.macos.conf.json").app.windows[0];
+  assert.equal(mac.titleBarStyle, "Overlay");
+  assert.equal(mac.hiddenTitle, true);
+  assert.equal(mac.width, 1280);
+  assert.equal(mac.height, 800);
+});


### PR DESCRIPTION
## What changed

Native qualification for #2345 found two layout failures. The staging overlay replaced the platform window array with a title-only entry, losing the macOS overlay titlebar and window dimensions. Remove that override; channel startup already sets the staging window title.

After leaving full screen, WebKit can pause renderer animation frames and leave the native page at its previous width. Add a 100 ms timer fallback to native bounds and toolbar-width measurements. Coalesce resize events, run each measurement once, and cancel pending callbacks on unmount.

## Validation

- 53 channel and workflow security tests and 59 browser component tests pass. The regression covers paused frames, updated bounds and toolbar width, duplicate callback suppression, and unmount cancellation.
- TypeScript, focused Biome checks, and git diff checks pass.
- Desktop cargo builds pass with the base configuration and corrected staging overlay.
- Storybook build passes. Visual qualification includes 176 earlier browser captures, a rebuilt split-pane capture, and native normal/full-screen/return transitions after the fix.
- Native development build with the staging overlay keeps the toolbar visible and updates Fit from 1761 px to 985 px after full screen. This is development evidence, not a new signed staging package qualification.

## Compatibility and risk

No persisted state, protocol, dependency, or browser-authority changes. Staging keeps its identity, updater feed, icons, and runtime title while inheriting platform window settings. The timer only measures layout; native visibility and authorization checks remain in place.

## Tracking

Completes the layout defects found during #2345 / #2335 qualification. Close those issues after checks and automatic review pass, this change merges, and the acceptance record is updated.
