### PR TITLE
feat(code): attach multiple conversations to one session

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/binding.rs
+++ b/crates/tidebreak-core/src/db/ops/code/binding.rs
@@ -5,7 +5,9 @@
 //! for one conversation cannot both commit their session, so first contact
 //! converges on one session no matter how many times the channel retries.
 
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
 
 use crate::code::{
     CodeBindingId, CodeExternalBinding, CodeGrantId, CodeWorkspace, ExternalSessionResolution,
@@ -67,6 +69,8 @@ pub async fn list_external_bindings_for_sessions(
             entities::code_external_binding::Column::SessionId
                 .is_in(session_ids.iter().map(|id| id.0)),
         )
+        .order_by_asc(entities::code_external_binding::Column::CreatedAt)
+        .order_by_asc(entities::code_external_binding::Column::Id)
         .all(&store.conn)
         .await
         .map_err(store_err)?
@@ -323,10 +327,100 @@ pub async fn list_bindings_for_session(
     entities::code_external_binding::Entity::find()
         .filter(entities::code_external_binding::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_external_binding::Column::SessionId.eq(session_id.0))
+        .order_by_asc(entities::code_external_binding::Column::CreatedAt)
+        .order_by_asc(entities::code_external_binding::Column::Id)
         .all(&store.conn)
         .await
         .map_err(store_err)?
         .into_iter()
         .map(binding_from_model)
         .collect()
+}
+
+/// Attach another conversation to a session already held by this grant.
+///
+/// The session lock serializes attachment with lifecycle writes. A conversation
+/// held by another grant or session is refused without disclosing its target.
+pub async fn attach_external_binding(
+    store: &DbStore,
+    owner: &OwnerId,
+    grant_id: CodeGrantId,
+    channel_kind: &str,
+    external_key: &str,
+    session_id: SessionId,
+) -> Result<ExternalSessionResolution> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !super::acquire_code_session_write_lock(&transaction, session_id).await? {
+        return Ok(ExternalSessionResolution::GrantMismatch);
+    }
+    let held = entities::code_external_binding::Entity::find()
+        .filter(entities::code_external_binding::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_binding::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_external_binding::Column::GrantId.eq(grant_id.0))
+        .filter(entities::code_external_binding::Column::ChannelKind.eq(channel_kind))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    let Some(held) = held else {
+        return Ok(ExternalSessionResolution::GrantMismatch);
+    };
+    if matches!(
+        classify_hit(&transaction, held, grant_id).await?,
+        ExternalSessionResolution::Ended { .. }
+    ) {
+        return Ok(ExternalSessionResolution::Ended { session_id });
+    }
+    let now = database_now(&transaction).await?;
+    let binding = CodeExternalBinding {
+        id: CodeBindingId::new(),
+        owner: owner.clone(),
+        channel_kind: channel_kind.to_owned(),
+        external_key: external_key.to_owned(),
+        grant_id,
+        session_id,
+        created_at: now,
+    };
+    let inserted = entities::code_external_binding::Entity::insert(
+        entities::code_external_binding::ActiveModel {
+            id: Set(binding.id.0),
+            owner: Set(owner.as_str().to_owned()),
+            channel_kind: Set(channel_kind.to_owned()),
+            external_key: Set(external_key.to_owned()),
+            grant_id: Set(grant_id.0),
+            session_id: Set(session_id.0),
+            created_at: Set(now),
+        },
+    )
+    .on_conflict(
+        sea_orm::sea_query::OnConflict::columns([
+            entities::code_external_binding::Column::Owner,
+            entities::code_external_binding::Column::ChannelKind,
+            entities::code_external_binding::Column::ExternalKey,
+        ])
+        .do_nothing()
+        .to_owned(),
+    )
+    .try_insert()
+    .exec(&transaction)
+    .await
+    .map_err(store_err)?;
+    if matches!(inserted, sea_orm::TryInsertResult::Inserted(_)) {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ExternalSessionResolution::Created(Box::new(binding)));
+    }
+    let hit = entities::code_external_binding::Entity::find()
+        .filter(entities::code_external_binding::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_binding::Column::ChannelKind.eq(channel_kind))
+        .filter(entities::code_external_binding::Column::ExternalKey.eq(external_key))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    let resolution = match hit {
+        Some(hit) if hit.grant_id == grant_id.0 && hit.session_id == session_id.0 => {
+            ExternalSessionResolution::Existing(Box::new(binding_from_model(hit)?))
+        }
+        _ => ExternalSessionResolution::GrantMismatch,
+    };
+    transaction.commit().await.map_err(store_err)?;
+    Ok(resolution)
 }

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.dom.test.tsx
@@ -53,4 +53,22 @@ describe("SessionOriginBanner", () => {
       "Started from Slack; runs on this machine as the bot.",
     );
   });
+  it("links every conversation that reaches the session", () => {
+    render(
+      <SessionOriginBanner
+        origin={origin}
+        executionLocation="machine"
+        origins={[
+          origin,
+          {
+            channel_kind: "slack",
+            external_key: "T0400000:C0865432:1724900010.123456",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Shared across 2 conversations/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open thread 1" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open thread 2" })).toBeTruthy();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionOriginBanner.tsx
@@ -55,14 +55,20 @@ export function externalThreadUrl(
 
 export function SessionOriginBanner({
   origin,
+  origins,
   executionLocation,
   actsAs,
 }: {
   origin: CodeSessionExternalOrigin;
+  origins?: CodeSessionExternalOrigin[];
   executionLocation: ExecutionLocation;
   actsAs?: "person" | "bot";
 }) {
-  const url = externalThreadUrl(origin);
+  const conversations = origins?.length ? origins : [origin];
+  const links = conversations.flatMap((conversation, index) => {
+    const url = externalThreadUrl(conversation);
+    return url ? [{ url, index }] : [];
+  });
   const where =
     executionLocation === "machine" ? "on this machine" : "in a sandbox";
   const who =
@@ -76,19 +82,30 @@ export function SessionOriginBanner({
         className="text-muted-foreground mt-px size-3.5 shrink-0"
         aria-hidden
       />
-      <p className="text-muted-foreground min-w-0 flex-1 text-xs">
-        Started from {channelLabel(origin.channel_kind)}; runs {where}
-        {who}.
-      </p>
-      {url && (
-        <button
-          type="button"
-          className="text-foreground shrink-0 cursor-pointer text-xs underline underline-offset-2 hover:no-underline"
-          onClick={() => void openExternal(url).catch(() => undefined)}
-        >
-          Open the thread
-        </button>
-      )}
+      <div className="flex min-w-0 flex-1 flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        <p className="text-muted-foreground text-xs">
+          Started from {channelLabel(origin.channel_kind)}; runs {where}
+          {who}.
+          {conversations.length > 1 &&
+            ` Shared across ${conversations.length} conversations.`}
+        </p>
+        {links.length > 0 && (
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {links.map(({ url, index }) => (
+              <button
+                key={url}
+                type="button"
+                className="text-foreground cursor-pointer text-xs underline underline-offset-2 hover:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                onClick={() => void openExternal(url).catch(() => undefined)}
+              >
+                {conversations.length === 1
+                  ? "Open the thread"
+                  : `Open thread ${index + 1}`}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -450,6 +450,31 @@ describe("parseCodeSession external origin", () => {
   });
 });
 
+describe("parseCodeSession conversation bindings", () => {
+  const first = { channel_kind: "slack", external_key: "T1/C1/1.1" };
+  const second = { channel_kind: "slack", external_key: "T1/C2/2.2" };
+
+  it("preserves every origin and accepts older snapshots", () => {
+    expect(
+      parseCodeSession({ ...SESSION, external_origins: [first, second] })
+        ?.external_origins,
+    ).toEqual([first, second]);
+    expect(parseCodeSession(SESSION)).not.toBeNull();
+  });
+
+  it("refuses malformed and duplicate origins", () => {
+    for (const external_origins of [
+      null,
+      {},
+      [first, first],
+      [{ ...first, external_key: "" }],
+      [{ ...first, extra: true }],
+    ]) {
+      expect(parseCodeSession({ ...SESSION, external_origins })).toBeNull();
+    }
+  });
+});
+
 describe("parseCodeSessionList", () => {
   it("accepts GET /code/workspaces/{id}/sessions", () => {
     const ended = {

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -2689,6 +2689,7 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
       "visibility",
       "created_at",
       "external_origin",
+      "external_origins",
       "execution_location",
       "owner_kind",
       "acts_as",
@@ -2754,6 +2755,31 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
             (value.external_origin as Record<string, unknown>).external_key,
           ),
         };
+  let external_origins: CodeSessionExternalOrigin[] | undefined;
+  if (value.external_origins !== undefined) {
+    if (!Array.isArray(value.external_origins)) return null;
+    external_origins = [];
+    const seen = new Set<string>();
+    for (const origin of value.external_origins) {
+      if (
+        !isRecord(origin) ||
+        !onlyKeys<CodeSessionExternalOrigin>(origin, [
+          "channel_kind",
+          "external_key",
+        ]) ||
+        !nonEmptyLine(origin.channel_kind) ||
+        !wireId(origin.external_key)
+      )
+        return null;
+      const key = JSON.stringify([origin.channel_kind, origin.external_key]);
+      if (seen.has(key)) return null;
+      seen.add(key);
+      external_origins.push({
+        channel_kind: origin.channel_kind,
+        external_key: origin.external_key,
+      });
+    }
+  }
   return {
     id: value.id,
     workspace_id: value.workspace_id,
@@ -2782,6 +2808,7 @@ export function parseCodeSession(value: unknown): CodeSessionSnapshot | null {
       : {}),
     ...(fence_reason ? { fence_reason } : {}),
     ...(external_origin !== undefined ? { external_origin } : {}),
+    ...(external_origins !== undefined ? { external_origins } : {}),
     ...(value.owner_kind !== undefined ? { owner_kind: value.owner_kind } : {}),
     ...(value.acts_as !== undefined
       ? { acts_as: value.acts_as as "person" | "bot" }

--- a/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
@@ -547,6 +547,7 @@ export function CodeSessionPane({
       {!subagentCallId && session.external_origin && (
         <SessionOriginBanner
           origin={session.external_origin}
+          origins={session.external_origins}
           executionLocation={session.execution_location}
           actsAs={session.acts_as}
         />

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -4905,6 +4905,10 @@ fast_mode: boolean, lifecycle: SessionLifecycle, fence_reason?: FenceReason, att
  */
 external_origin?: SessionExternalOrigin,
 /**
+ * Every conversation that reaches this session, in creation order.
+ */
+external_origins?: Array<SessionExternalOrigin>,
+/**
  * Where the engine runs, fixed at creation (decision 0088).
  */
 execution_location: ExecutionLocation,

--- a/crates/tidebreak-desktop/ui/src/stories/SessionOriginBanner.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SessionOriginBanner.stories.tsx
@@ -62,3 +62,31 @@ export const ActsAsYou: Story = {
 export const ActsAsTheBot: Story = {
   args: { ...SlackThread.args, actsAs: "bot" },
 };
+
+export const SeveralThreads: Story = {
+  args: {
+    ...ActsAsTheBot.args,
+    origins: [
+      SlackThread.args.origin,
+      {
+        channel_kind: "slack",
+        external_key: "T0400000:C0865432:1724900010.123456",
+      },
+      {
+        channel_kind: "slack",
+        external_key: "T0400000:C0898765:1724900020.123456",
+      },
+    ],
+  },
+};
+
+export const SeveralThreadsNarrow: Story = {
+  ...SeveralThreads,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/crates/tidebreak-server-api/fixtures/code-frames.json
+++ b/crates/tidebreak-server-api/fixtures/code-frames.json
@@ -91,6 +91,16 @@
         "channel_kind": "slack",
         "external_key": "T0/C1/1756700000.000100"
       },
+      "external_origins": [
+        {
+          "channel_kind": "slack",
+          "external_key": "T0/C1/1756700000.000100"
+        },
+        {
+          "channel_kind": "slack",
+          "external_key": "T0/C2/1756700001.000100"
+        }
+      ],
       "fast_mode": false,
       "harness_kind": "claude_code",
       "harness_resume_ref": "9f2c1d4e-resume",
@@ -124,6 +134,16 @@
       },
       "created_at": "2025-09-01T04:13:20Z",
       "execution_location": "sandbox",
+      "external_origins": [
+        {
+          "channel_kind": "slack",
+          "external_key": "T0/C1/1756700000.000100"
+        },
+        {
+          "channel_kind": "slack",
+          "external_key": "T0/C2/1756700001.000100"
+        }
+      ],
       "fast_mode": false,
       "fence_reason": {
         "detail": "the engine forgot the resume ref",

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -471,6 +471,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::external_get_or_create),
         )
         .route(
+            "/external/code/sessions/{id}/bindings",
+            get(routes::code::external_bindings).post(routes::code::external_attach_binding),
+        )
+        .route(
             "/external/code/sessions/{id}/messages",
             post(routes::code::external_messages),
         )

--- a/crates/tidebreak-server-api/src/routes/code/access.rs
+++ b/crates/tidebreak-server-api/src/routes/code/access.rs
@@ -49,7 +49,8 @@ pub async fn set_session_visibility(
     Path(id): Path<SessionId>,
     Json(body): Json<SetSessionVisibilityBody>,
 ) -> Result<Json<SessionSnapshot>, ServerError> {
-    Ok(Json(SessionSnapshot::from(
-        code.set_session_visibility(id, body.visibility).await?,
-    )))
+    let session = code.set_session_visibility(id, body.visibility).await?;
+    Ok(Json(
+        super::sessions::snapshot_with_origin(&code, session).await?,
+    ))
 }

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -290,6 +290,143 @@ pub async fn external_get_or_create(
 }
 
 #[derive(serde::Deserialize)]
+pub struct ExternalBindingBody {
+    pub external_key: String,
+    #[serde(default)]
+    pub channel_id: Option<String>,
+    #[serde(default)]
+    pub set_by: Option<ExternalSetBy>,
+}
+
+/// Attach a conversation to the session this grant already holds.
+pub async fn external_attach_binding(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path(id): Path<SessionId>,
+    Json(body): Json<ExternalBindingBody>,
+) -> Result<(StatusCode, Json<tidebreak_core::CodeExternalBinding>), ServerError> {
+    let runtime = require_bound(&state, &grant, id).await?;
+    let key = body.external_key.trim();
+    if key.is_empty() || key.len() > 1024 || key.chars().any(char::is_control) {
+        return Err(ServerError::bad_request_kind(
+            "invalid_external_key",
+            "a conversation key needs 1 to 1024 bytes and no control characters",
+        ));
+    }
+    if grant.kind.is_workspace() {
+        require_binding_repository(
+            &runtime,
+            &grant,
+            id,
+            body.channel_id.as_deref(),
+            body.set_by.as_ref(),
+        )
+        .await?;
+    }
+    match tidebreak_core::db::code::attach_external_binding(
+        &runtime.db,
+        &grant.owner,
+        grant.id,
+        &grant.channel_kind,
+        key,
+        id,
+    )
+    .await?
+    {
+        ExternalSessionResolution::Created(binding) => Ok((StatusCode::CREATED, Json(*binding))),
+        ExternalSessionResolution::Existing(binding) => Ok((StatusCode::OK, Json(*binding))),
+        ExternalSessionResolution::Ended { .. } => Err(ServerError::conflict_kind(
+            "ended",
+            "the session has ended; start another session to continue",
+        )),
+        ExternalSessionResolution::GrantMismatch => {
+            Err(ServerError::not_found("code session not found"))
+        }
+    }
+}
+
+async fn require_binding_repository(
+    runtime: &crate::code::runtime::CodeRuntime,
+    grant: &CodeExternalGrant,
+    id: SessionId,
+    channel_id: Option<&str>,
+    set_by: Option<&ExternalSetBy>,
+) -> Result<(), ServerError> {
+    let channel_id = channel_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ServerError::bad_request_kind(
+                "channel_id_required",
+                "a workspace grant names the channel that will continue this session",
+            )
+        })?;
+    let session = runtime.get_session(&grant.owner, id).await?;
+    if let Some(workspace_id) = session.workspace_id {
+        let workspace = runtime.get_workspace(&grant.owner, workspace_id).await?;
+        let repo = runtime.get_repo(&grant.owner, workspace.repo_id).await?;
+        let repository = repo
+            .origin_owner
+            .zip(repo.origin_name)
+            .map(|(owner, name)| format!("{owner}/{name}"))
+            .ok_or_else(|| {
+                ServerError::conflict_kind(
+                    "repo_origin_unknown",
+                    "the repository records no origin to confirm",
+                )
+            })?;
+        if !tidebreak_core::db::code::channel_repository_is_confirmed(
+            &runtime.db,
+            &grant.owner,
+            grant.id,
+            channel_id,
+            &repository,
+        )
+        .await?
+        {
+            let set_by = set_by.ok_or_else(|| {
+                ServerError::bad_request_kind(
+                    "set_by_required",
+                    "name who set this channel's repository",
+                )
+            })?;
+            tidebreak_core::db::code::ensure_pending_channel_repository(
+                &runtime.db,
+                &grant.owner,
+                grant.id,
+                channel_id,
+                &repository,
+                &set_by.identity,
+                &set_by.display,
+            )
+            .await?;
+            return Err(ServerError::conflict_kind(
+                "repository_unconfirmed",
+                "an administrator must confirm this repository for the destination channel",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// List every conversation attached under the authenticated grant.
+pub async fn external_bindings(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path(id): Path<SessionId>,
+) -> Result<Json<Vec<tidebreak_core::CodeExternalBinding>>, ServerError> {
+    let runtime = require_bound(&state, &grant, id).await?;
+    let bindings =
+        tidebreak_core::db::code::list_bindings_for_session(&runtime.db, &grant.owner, id).await?;
+    Ok(Json(
+        bindings
+            .into_iter()
+            .filter(|binding| binding.grant_id == grant.id)
+            .collect(),
+    ))
+}
+
+#[derive(serde::Deserialize)]
 pub struct ExternalMessageBody {
     pub text: String,
     /// The channel's delivery id; replays of it answer from the first row.
@@ -438,6 +575,14 @@ pub async fn external_events(
 ) -> Result<Response, ServerError> {
     let runtime = require_bound(&state, &grant, id).await?;
     let session = runtime.get_session(&grant.owner, id).await?;
+    let bindings =
+        tidebreak_core::db::code::list_bindings_for_session(&runtime.db, &grant.owner, id).await?;
+    let mut session_snapshot = SessionSnapshot::from(session);
+    session_snapshot.set_external_origins(
+        bindings
+            .into_iter()
+            .filter(|binding| binding.grant_id == grant.id),
+    );
     let owner = grant.owner.clone();
     let grant_id = grant.id;
     // Subscribe before deciding to serve, then re-read the durable row while
@@ -457,7 +602,7 @@ pub async fn external_events(
         // lifecycle and the attention snapshot arrive first, as their own
         // frame shape.
         let snapshot = serde_json::json!({
-            "snapshot": SessionSnapshot::from(session),
+            "snapshot": session_snapshot,
         });
         if let Ok(json) = serde_json::to_string(&snapshot) {
             if socket
@@ -519,7 +664,15 @@ pub async fn external_reap(
 ) -> Result<Json<SessionSnapshot>, ServerError> {
     let runtime = require_bound(&state, &grant, id).await?;
     let session = runtime.reap(&grant.owner, id).await?;
-    Ok(Json(SessionSnapshot::from(session)))
+    let bindings =
+        tidebreak_core::db::code::list_bindings_for_session(&runtime.db, &grant.owner, id).await?;
+    let mut snapshot = SessionSnapshot::from(session);
+    snapshot.set_external_origins(
+        bindings
+            .into_iter()
+            .filter(|binding| binding.grant_id == grant.id),
+    );
+    Ok(Json(snapshot))
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -51,9 +51,9 @@ pub(crate) use delivery::{
     resolve_repositories as resolve_delivery_repositories, run_detail as delivery_run_detail,
 };
 pub(crate) use external::{
-    external_approval_decision, external_events, external_get_or_create, external_interrupt,
-    external_messages, external_plan_decision, external_question_decision, external_reap,
-    external_rotate, external_session_access,
+    external_approval_decision, external_attach_binding, external_bindings, external_events,
+    external_get_or_create, external_interrupt, external_messages, external_plan_decision,
+    external_question_decision, external_reap, external_rotate, external_session_access,
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,

--- a/crates/tidebreak-server-api/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server-api/src/routes/code/sessions.rs
@@ -17,8 +17,8 @@ use axum::response::{IntoResponse, Response};
 use super::types::{
     CodeForkTranscript, CreateInternalSessionBody, CreateRemoteSessionBody, CreateSessionBody,
     QueuePausedBody, QueuedTurn, QueuedTurnUpdate, QueuedTurnsSnapshot, SequencedEventFrame,
-    SessionExternalOrigin, SessionSnapshot, SetAttentionBody, SetFastModeBody,
-    SetPermissionModeBody, SetReasoningEffortBody, SteerBody, SubmitTurnBody, TurnSnapshot,
+    SessionSnapshot, SetAttentionBody, SetFastModeBody, SetPermissionModeBody,
+    SetReasoningEffortBody, SteerBody, SubmitTurnBody, TurnSnapshot,
 };
 use crate::code::runtime::{NewSessionSettings, SubmitTurnOutcome};
 use tidebreak_core::{PermissionMode, SessionId, TurnSteer, WorkspaceId};
@@ -128,21 +128,13 @@ pub async fn create_remote_session(
 /// here: the desktop writes the answer over its listed row, so a snapshot
 /// that hard-coded no origin would erase the provenance banner on the
 /// next reap, mode change, or attention edit.
-async fn snapshot_with_origin(
+pub(super) async fn snapshot_with_origin(
     code: &ScopedCode,
     session: tidebreak_core::Session,
 ) -> Result<SessionSnapshot, ServerError> {
-    let origin = code
-        .external_bindings_for_sessions(&[session.id])
-        .await?
-        .into_iter()
-        .next()
-        .map(|binding| SessionExternalOrigin {
-            channel_kind: binding.channel_kind,
-            external_key: binding.external_key,
-        });
+    let bindings = code.external_bindings_for_sessions(&[session.id]).await?;
     let mut snapshot = SessionSnapshot::from(session);
-    snapshot.external_origin = origin;
+    snapshot.set_external_origins(bindings);
     Ok(snapshot)
 }
 
@@ -151,32 +143,33 @@ pub async fn list_workspace_sessions(
     Path(workspace_id): Path<WorkspaceId>,
 ) -> Result<Json<Vec<SessionSnapshot>>, ServerError> {
     let sessions = code.list_workspace_sessions(workspace_id).await?;
+    Ok(Json(snapshots_with_origins(&code, sessions).await?))
+}
+
+async fn snapshots_with_origins(
+    code: &ScopedCode,
+    sessions: Vec<tidebreak_core::Session>,
+) -> Result<Vec<SessionSnapshot>, ServerError> {
     let ids: Vec<SessionId> = sessions.iter().map(|session| session.id).collect();
-    let origins: std::collections::HashMap<SessionId, SessionExternalOrigin> = code
-        .external_bindings_for_sessions(&ids)
-        .await?
+    let mut bindings: std::collections::HashMap<
+        SessionId,
+        Vec<tidebreak_core::CodeExternalBinding>,
+    > = std::collections::HashMap::new();
+    for binding in code.external_bindings_for_sessions(&ids).await? {
+        bindings
+            .entry(binding.session_id)
+            .or_default()
+            .push(binding);
+    }
+    Ok(sessions
         .into_iter()
-        .map(|binding| {
-            (
-                binding.session_id,
-                SessionExternalOrigin {
-                    channel_kind: binding.channel_kind,
-                    external_key: binding.external_key,
-                },
-            )
+        .map(|session| {
+            let origins = bindings.remove(&session.id).unwrap_or_default();
+            let mut snapshot = SessionSnapshot::from(session);
+            snapshot.set_external_origins(origins);
+            snapshot
         })
-        .collect();
-    Ok(Json(
-        sessions
-            .into_iter()
-            .map(|session| {
-                let origin = origins.get(&session.id).cloned();
-                let mut snapshot = SessionSnapshot::from(session);
-                snapshot.external_origin = origin;
-                snapshot
-            })
-            .collect(),
-    ))
+        .collect())
 }
 
 /// `GET /sessions` — the owner's conversations that bind no
@@ -185,9 +178,7 @@ pub async fn list_internal_sessions(
     code: ScopedCode,
 ) -> Result<Json<Vec<SessionSnapshot>>, ServerError> {
     let sessions = code.list_internal_sessions().await?;
-    Ok(Json(
-        sessions.into_iter().map(SessionSnapshot::from).collect(),
-    ))
+    Ok(Json(snapshots_with_origins(&code, sessions).await?))
 }
 
 /// `GET /sessions/{id}` — one session by id, whatever it binds.
@@ -196,18 +187,7 @@ pub async fn get_session(
     Path(id): Path<SessionId>,
 ) -> Result<Json<SessionSnapshot>, ServerError> {
     let session = code.get_session(id).await?;
-    let origin = code
-        .external_bindings_for_sessions(&[id])
-        .await?
-        .into_iter()
-        .next()
-        .map(|binding| SessionExternalOrigin {
-            channel_kind: binding.channel_kind,
-            external_key: binding.external_key,
-        });
-    let mut snapshot = SessionSnapshot::from(session);
-    snapshot.external_origin = origin;
-    Ok(Json(snapshot))
+    Ok(Json(snapshot_with_origin(&code, session).await?))
 }
 
 pub async fn submit_turn(
@@ -367,7 +347,7 @@ pub async fn get_session_debug(
 ) -> Result<Json<super::types::SessionDebug>, ServerError> {
     let (session, turns, events) = code.session_debug(id).await?;
     Ok(Json(super::types::SessionDebug {
-        session: SessionSnapshot::from(session),
+        session: snapshot_with_origin(&code, session).await?,
         turns: turns.into_iter().map(TurnSnapshot::from).collect(),
         events: events
             .into_iter()

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -2715,6 +2715,35 @@ async fn a_service_principal_starts_a_workspace_handshake_and_an_admin_approves_
     let session_id = bound_session_id(&runtime, &service, "T1/C1/1.1").await;
     let session = runtime.get_session(&service, session_id).await.unwrap();
     assert_eq!(session.acts_as(), tidebreak_core::ActsAs::Bot);
+    let bindings_url = format!("/external/code/sessions/{session_id}/bindings");
+    let destination = serde_json::json!({"external_key":"T1/C2/2.2", "channel_id":"C2", "set_by":{"identity":"U1", "display":"Casey"}});
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &bindings_url,
+        &grant_token,
+        Some(destination.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &format!("/deployment/code/grants/workspace/{grant_id}/channels/C2/repositories/confirm"),
+        ALICE_TOKEN,
+        Some(serde_json::json!({"repository":"acme/tools"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &bindings_url,
+        &grant_token,
+        Some(destination),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
 
     let (status, named) = call_json(
         &router,
@@ -3090,5 +3119,282 @@ async fn a_machine_session_parks_on_an_approval_a_contributor_can_settle() {
             )
         }),
         "a sandbox session carries none of these cards"
+    );
+}
+
+#[tokio::test]
+async fn external_bindings_attach_idempotently_and_refuse_foreign_or_ended_targets() {
+    let (router, fake, runtime, repo_id, token, _dir) = external_app_with_token().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (_, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U-bindings", "T1")
+        .await
+        .unwrap();
+    let (_, foreign) = runtime
+        .mint_adapter_grant(&owner, "slack", "U-other", "T1")
+        .await
+        .unwrap();
+    let created: serde_json::Value = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({"external_key":"T1/C1/1.1", "repo_id":repo_id}))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let id: tidebreak_core::SessionId =
+        serde_json::from_value(created["session_id"].clone()).unwrap();
+    let url = format!("http://{addr}/external/code/sessions/{id}/bindings");
+    let body = serde_json::json!({"external_key":"T1/C2/2.2"});
+    let request = || {
+        client
+            .post(&url)
+            .bearer_auth(&pair.token)
+            .json(&body)
+            .send()
+    };
+    let (left, right) = tokio::join!(request(), request());
+    let mut statuses = vec![
+        left.unwrap().status().as_u16(),
+        right.unwrap().status().as_u16(),
+    ];
+    statuses.sort();
+    assert_eq!(statuses, vec![200, 201]);
+    let bindings: serde_json::Value = client
+        .get(&url)
+        .bearer_auth(&pair.token)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(bindings.as_array().unwrap().len(), 2);
+    assert_eq!(bindings[0]["external_key"], "T1/C1/1.1");
+    assert_eq!(bindings[1]["session_id"], created["session_id"]);
+    let snapshot: serde_json::Value = client
+        .get(format!("http://{addr}/code/sessions/{id}"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(snapshot["external_origins"].as_array().unwrap().len(), 2);
+    assert_eq!(snapshot["external_origin"], snapshot["external_origins"][0]);
+    for request in [client.get(&url), client.post(&url).json(&body)] {
+        assert_eq!(
+            request
+                .bearer_auth(&foreign.token)
+                .send()
+                .await
+                .unwrap()
+                .status(),
+            reqwest::StatusCode::NOT_FOUND
+        );
+    }
+    // A different grant can hold another session, but cannot capture its key.
+    client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&foreign.token)
+        .json(&serde_json::json!({"external_key":"T1/C3/3.3", "repo_id":repo_id}))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    assert_eq!(
+        client
+            .post(&url)
+            .bearer_auth(&pair.token)
+            .json(&serde_json::json!({"external_key":"T1/C3/3.3"}))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    // The same grant cannot move a key away from another session.
+    client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({"external_key":"T1/C5/5.5", "repo_id":repo_id}))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    assert_eq!(
+        client
+            .post(&url)
+            .bearer_auth(&pair.token)
+            .json(&serde_json::json!({"external_key":"T1/C5/5.5"}))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    let (_, other_owner) = runtime
+        .mint_adapter_grant(
+            &OwnerId::new("other-owner").unwrap(),
+            "slack",
+            "U-foreign-owner",
+            "T1",
+        )
+        .await
+        .unwrap();
+    for request in [client.get(&url), client.post(&url).json(&body)] {
+        assert_eq!(
+            request
+                .bearer_auth(&other_owner.token)
+                .send()
+                .await
+                .unwrap()
+                .status(),
+            reqwest::StatusCode::NOT_FOUND
+        );
+    }
+    for key in [
+        String::new(),
+        "   ".to_owned(),
+        "bad\nkey".to_owned(),
+        "x".repeat(1025),
+    ] {
+        let response = client
+            .post(&url)
+            .bearer_auth(&pair.token)
+            .json(&serde_json::json!({"external_key":key}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.json::<serde_json::Value>().await.unwrap()["kind"],
+            "invalid_external_key"
+        );
+    }
+    for path in [
+        format!(
+            "/code/workspaces/{}/sessions",
+            snapshot["workspace_id"].as_str().unwrap()
+        ),
+        format!("/code/sessions/{id}/debug"),
+    ] {
+        let response: serde_json::Value = client
+            .get(format!("http://{addr}{path}"))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let row = if response.is_array() {
+            response
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|row| row["id"] == snapshot["id"])
+                .unwrap()
+        } else {
+            &response["session"]
+        };
+        assert_eq!(row["external_origins"], snapshot["external_origins"]);
+    }
+    // Two readers see the same session and both origins before the same journal.
+    let mut sockets = Vec::new();
+    for _ in 0..2 {
+        let mut request = format!("ws://{addr}/external/code/sessions/{id}/events")
+            .into_client_request()
+            .unwrap();
+        request.headers_mut().insert(
+            "Authorization",
+            format!("Bearer {}", pair.token).parse().unwrap(),
+        );
+        let (mut socket, _) = connect_async(request).await.unwrap();
+        let frame = tokio::time::timeout(Duration::from_secs(5), socket.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(frame.to_text().unwrap()).unwrap();
+        assert_eq!(
+            value["snapshot"]["external_origins"],
+            snapshot["external_origins"]
+        );
+        sockets.push(socket);
+    }
+    client
+        .post(format!(
+            "http://{addr}/external/code/sessions/{id}/messages"
+        ))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({"text":"hello", "event_id":"Ev-bindings", "channel_ts":"3.3"}))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+        sandbox_id: "sb-ext".to_owned(),
+        state: SandboxState::Running,
+        latest_event_seq: 1,
+        events: vec![SandboxEvent {
+            seq: 1,
+            kind: "turn_started".to_owned(),
+            payload: serde_json::json!({"turn":1}),
+            created_at: String::new(),
+        }],
+    });
+    let mut live = runtime.get_session(&owner, id).await.unwrap();
+    runtime
+        .remote_sessions()
+        .unwrap()
+        .driver(&runtime.db, runtime.bus.as_ref())
+        .pump(&mut live, 0)
+        .await
+        .unwrap();
+    let mut frames = Vec::new();
+    for socket in &mut sockets {
+        let frame = tokio::time::timeout(Duration::from_secs(5), socket.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        frames.push(serde_json::from_str::<serde_json::Value>(frame.to_text().unwrap()).unwrap());
+    }
+    assert_eq!(frames[0], frames[1]);
+    let mut session = runtime.get_session(&owner, id).await.unwrap();
+    session.lifecycle = tidebreak_core::SessionLifecycle::Ended;
+    assert!(
+        tidebreak_core::db::code::save_session(&runtime.db, &session)
+            .await
+            .unwrap()
+    );
+    let ended = client
+        .post(&url)
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({"external_key":"T1/C4/4.4"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ended.status(), reqwest::StatusCode::CONFLICT);
+    assert_eq!(
+        ended.json::<serde_json::Value>().await.unwrap()["kind"],
+        "ended"
     );
 }

--- a/crates/tidebreak-server-api/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server-api/src/wire_code_fixtures.rs
@@ -178,6 +178,16 @@ fn session() -> SessionSnapshot {
         created_at: at(1_756_700_000),
         execution_location: tidebreak_core::ExecutionLocation::Sandbox,
         acts_as: Some(tidebreak_core::ActsAs::Bot),
+        external_origins: Some(vec![
+            SessionExternalOrigin {
+                channel_kind: "slack".to_owned(),
+                external_key: "T0/C1/1756700000.000100".to_owned(),
+            },
+            SessionExternalOrigin {
+                channel_kind: "slack".to_owned(),
+                external_key: "T0/C2/1756700001.000100".to_owned(),
+            },
+        ]),
         external_origin: Some(SessionExternalOrigin {
             channel_kind: "slack".to_owned(),
             external_key: "T0/C1/1756700000.000100".to_owned(),

--- a/crates/tidebreak-server/src/code/types.rs
+++ b/crates/tidebreak-server/src/code/types.rs
@@ -304,6 +304,10 @@ pub struct SessionSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub external_origin: Option<SessionExternalOrigin>,
+    /// Every conversation that reaches this session, in creation order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub external_origins: Option<Vec<SessionExternalOrigin>>,
     /// Where the engine runs, fixed at creation (decision 0088).
     pub execution_location: ExecutionLocation,
     /// Whose forge identity this session borrows as (decision 0090).
@@ -312,6 +316,24 @@ pub struct SessionSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub acts_as: Option<tidebreak_core::ActsAs>,
+}
+
+impl SessionSnapshot {
+    /// Keep the original provenance field while exposing every binding.
+    pub fn set_external_origins(
+        &mut self,
+        bindings: impl IntoIterator<Item = tidebreak_core::CodeExternalBinding>,
+    ) {
+        let origins: Vec<_> = bindings
+            .into_iter()
+            .map(|binding| SessionExternalOrigin {
+                channel_kind: binding.channel_kind,
+                external_key: binding.external_key,
+            })
+            .collect();
+        self.external_origin = origins.first().cloned();
+        self.external_origins = (!origins.is_empty()).then_some(origins);
+    }
 }
 
 impl From<Session> for SessionSnapshot {
@@ -338,6 +360,7 @@ impl From<Session> for SessionSnapshot {
             // Provenance is a separate lookup; the handlers that serve the
             // desktop attach it.
             external_origin: None,
+            external_origins: None,
             execution_location: session.execution_location,
             acts_as: Some(acts_as),
         }

--- a/docs/decisions/0093-a-session-can-have-several-conversation-bindings.md
+++ b/docs/decisions/0093-a-session-can-have-several-conversation-bindings.md
@@ -1,0 +1,31 @@
+# 93. A session can have several conversation bindings
+
+- Status: Accepted
+- Date: 2026-09-08
+- Owners: thet
+- Related: [0092](0092-workspace-grants.md); `docs/slack-sessions.md`; #3198
+- Supersedes: none
+
+## Context
+
+A session outlives the thread that starts it. The binding table already permits several conversations to reach one session, but the adapter API only creates a session with its first binding. Moving a conversation must preserve its execution identity, access, and journal.
+
+## Decision
+
+An adapter attaches a conversation through `POST /external/code/sessions/{id}/bindings`. The grant must already hold that session. The destination key stays within the grant's channel family. Attaching the same key to the same session is idempotent. A key held by another session or grant returns the same not-found response as an inaccessible session. An ended session refuses attachment.
+
+The session row lock serializes attachment with lifecycle updates. The existing unique conversation key resolves concurrent attachments. Attaching a workspace-grant session also requires an administrator's repository confirmation for the destination channel. The adapter remains responsible for Slack workspace and membership checks; an opaque key does not confer access.
+
+`GET` on the bindings route lists the grant's bindings. Session snapshots expose all origins in creation order and keep `external_origin` as the first origin for existing clients. Each thread reads the same session journal with its own cursor. Attaching a binding neither copies the journal nor changes ownership or contributors.
+
+## Alternatives considered
+
+Copying the session would split its history and delivery state. Moving its sole binding would make the old thread stop receiving results. Crossing grants would silently change the authority behind a conversation. Each conflicts with the requirement that several threads continue the same session.
+
+## Consequences
+
+An adapter stores rendering state per binding. Access changes across private and public channels remain explicit; attaching a binding does not grant a web viewer access. Revisit this boundary if a session must move across Slack workspaces or execution identities.
+
+## Validation
+
+HTTP tests cover idempotent attachment, concurrent attachment, foreign grants, destination conflicts, ended sessions, destination repository confirmation, and binding reads. Two event readers receive the same session journal, and both snapshots list the attached conversations.

--- a/docs/decisions/manifest.txt
+++ b/docs/decisions/manifest.txt
@@ -101,3 +101,4 @@
 0090  0090-a-session-acts-as-one-forge-identity.md
 0091  0091-approvals-are-answerable-where-the-person-is.md
 0092  0092-workspace-grants.md
+0093  0093-a-session-can-have-several-conversation-bindings.md

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -854,3 +854,21 @@ proceeds on the stated answers.
   — the agent side of remote execution.
 - [`deferred.md`](deferred.md) — remote session execution, unparked by
   stage 1.
+
+
+### Several threads for one session
+
+The adapter attaches a thread through
+`POST /external/code/sessions/{id}/bindings` with `external_key`. The grant
+must already hold the session. Repeating an attachment returns the existing
+binding; a destination held by another session or grant returns not found.
+Ended sessions return `409 ended`. `GET` on the same route lists the bindings.
+
+A workspace grant also sends `channel_id` and names the person requesting a
+new repository confirmation in `set_by: {identity, display}`. An unconfirmed
+destination creates a pending approval and returns `409 repository_unconfirmed`.
+After an administrator confirms the repository, the adapter retries attachment. The adapter
+checks workspace membership before calling; attachment does not change the
+session's access rows. Each bound thread reads the same event stream with its
+own cursor. Snapshots expose `external_origins` and preserve `external_origin`
+as the first thread for older clients. Decision 93 records the boundary.

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -4905,6 +4905,10 @@ fast_mode: boolean, lifecycle: SessionLifecycle, fence_reason?: FenceReason, att
  */
 external_origin?: SessionExternalOrigin,
 /**
+ * Every conversation that reaches this session, in creation order.
+ */
+external_origins?: Array<SessionExternalOrigin>,
+/**
  * Where the engine runs, fixed at creation (decision 0088).
  */
 execution_location: ExecutionLocation,


### PR DESCRIPTION
A Slack conversation can now attach to an existing session under the same owner and grant. Retried and concurrent attachment requests converge on one binding; a destination held by another session or grant returns not found, and an ended session refuses attachment. Workspace grants create the destination repository approval before retrying.

Session snapshots retain every thread origin across list, detail, visibility, recovery, and external stream responses. The web and desktop banner links to each thread and wraps at narrow widths. Existing clients keep the first `external_origin`; the new `external_origins` field is additive, and the database schema is unchanged. Both conversations consume the same journal without copying it or changing access.

Validation: 26 external HTTP/stream tests passed; 3 owner-scope tests passed; 24 wire contract tests passed; 106 focused parser, banner, and style tests passed. TypeScript, Storybook build, ADR manifest, formatting, and diff checks passed. Captured and inspected all eight banner stories at 900px and 390px across four theme settings (64 images). The existing macOS linker unwind-table warning remains.

Closes #3198.
