### PR TITLE
chore(storybook): add code review and source control proposal

### DIFF
--- a/crates/tidebreak-desktop/ui/src/stories/review-proposal/Components.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/review-proposal/Components.stories.tsx
@@ -1,0 +1,227 @@
+import { useState, type ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  AgentDraft,
+  CheckRun,
+  CommitControls,
+  FileDiff,
+  FileRail,
+  PullRequestRow,
+  RefreshNotice,
+  ReviewHeader,
+  ReviewThread,
+  ViewedControl,
+} from "./ReviewComponents";
+import { failedLog, reviewComment, reviewFiles, reviewPr } from "./fixtures";
+import "./review-proposal.css";
+
+const meta = {
+  title: "Code/Review proposal/Components",
+  parameters: { layout: "padded" },
+} satisfies Meta;
+export default meta;
+type Story = StoryObj<typeof meta>;
+function Surface({ children }: { children: ReactNode }) {
+  return (
+    <div className="review-proposal max-w-4xl rounded-lg border border-border-subtle bg-background text-foreground">
+      {children}
+    </div>
+  );
+}
+function HeaderExample({ long = false }: { long?: boolean }) {
+  const [note, setNote] = useState("");
+  return (
+    <Surface>
+      <ReviewHeader
+        pr={
+          long
+            ? {
+                ...reviewPr,
+                title:
+                  "Preserve unsent review comments and file selection when multiple repositories finish refreshing at different times",
+                head_branch:
+                  "thet/preserve-review-context-across-concurrent-repository-refreshes",
+              }
+            : reviewPr
+        }
+        onBack={() => setNote("Return to the PR inbox.")}
+        onInspect={() => setNote("Open the failed check and its logs.")}
+        onRefresh={() => setNote("Sample data refreshed.")}
+        onMerge={() => setNote("Open merge confirmation.")}
+      />
+      {note && (
+        <p role="status" className="px-5 pb-3 text-sm text-muted-foreground">
+          {note}
+        </p>
+      )}
+    </Surface>
+  );
+}
+export const PullRequestHeader: Story = { render: () => <HeaderExample /> };
+export const LongHeader: Story = { render: () => <HeaderExample long /> };
+export const InboxRow: Story = {
+  render: () => {
+    const [opened, setOpened] = useState(false);
+    return (
+      <Surface>
+        <PullRequestRow pr={reviewPr} onOpen={() => setOpened(true)} />
+        {opened && (
+          <p role="status" className="p-4 text-sm">
+            Open the full review workspace.
+          </p>
+        )}
+      </Surface>
+    );
+  },
+};
+export const FileDiffWithRail: Story = {
+  render: () => {
+    const [file, setFile] = useState(reviewFiles[0]!.path);
+    const [viewed, setViewed] = useState<string[]>([]);
+    return (
+      <Surface>
+        <div className="review-proposal-files grid grid-cols-[220px_minmax(0,1fr)]">
+          <FileRail
+            files={reviewFiles}
+            selected={file}
+            onSelect={setFile}
+            viewed={viewed}
+          />
+          <div className="min-w-0 p-4">
+            <FileDiff
+              file={reviewFiles.find((item) => item.path === file)!}
+              actions={
+                <ViewedControl
+                  checked={viewed.includes(file)}
+                  onChange={(checked) =>
+                    setViewed(
+                      checked
+                        ? [...viewed, file]
+                        : viewed.filter((path) => path !== file),
+                    )
+                  }
+                />
+              }
+            />
+          </div>
+        </div>
+      </Surface>
+    );
+  },
+};
+export const InlineReviewThread: Story = {
+  render: () => {
+    const [context, setContext] = useState<string | null>(null);
+    return (
+      <Surface>
+        <div className="px-4 pb-4">
+          <ReviewThread
+            path={reviewFiles[0]!.path}
+            body={reviewComment.body}
+            onAgent={setContext}
+          />
+        </div>
+        {context && (
+          <AgentDraft context={context} onClose={() => setContext(null)} />
+        )}
+      </Surface>
+    );
+  },
+};
+export const CheckResults: Story = {
+  render: () => {
+    const [context, setContext] = useState<string | null>(null);
+    return (
+      <Surface>
+        <div className="px-4">
+          <CheckRun
+            check={reviewPr.checks[0]!}
+            log={failedLog}
+            defaultOpen
+            onAgent={setContext}
+          />
+          <CheckRun
+            check={{
+              name: "desktop / build",
+              bucket: "pending",
+              detail: "Running · 14 seconds",
+            }}
+            onAgent={setContext}
+          />
+          <CheckRun check={reviewPr.checks[1]!} onAgent={setContext} />
+        </div>
+        {context && (
+          <AgentDraft context={context} onClose={() => setContext(null)} />
+        )}
+      </Surface>
+    );
+  },
+};
+export const CommitAndPush: Story = {
+  render: () => {
+    const [count, setCount] = useState(2);
+    const [ahead, setAhead] = useState(2);
+    const [note, setNote] = useState("");
+    return (
+      <Surface>
+        <CommitControls
+          stagedCount={count}
+          ahead={ahead}
+          onCommit={(message) => {
+            setCount(0);
+            setAhead(ahead + 1);
+            setNote(`Sample commit: ${message}`);
+          }}
+          onPush={() => {
+            setAhead(0);
+            setNote("Sample push complete.");
+          }}
+        />
+        {note && (
+          <p role="status" className="px-4 pb-3 text-sm text-muted-foreground">
+            {note}
+          </p>
+        )}
+      </Surface>
+    );
+  },
+};
+export const AgentMessage: Story = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <Surface>
+        {open ? (
+          <AgentDraft
+            context={`${reviewComment.path}:${reviewComment.line}\n${reviewComment.body}`}
+            onClose={() => setOpen(false)}
+          />
+        ) : (
+          <p className="p-4 text-sm">
+            Agent draft closed. Reload the story to reopen it.
+          </p>
+        )}
+      </Surface>
+    );
+  },
+};
+export const RefreshStates: Story = {
+  render: () => {
+    const [failed, setFailed] = useState(true);
+    return (
+      <Surface>
+        <div className="space-y-4 p-4">
+          <RefreshNotice state="ready" onRetry={() => {}} />
+          <RefreshNotice state="refreshing" onRetry={() => {}} />
+        </div>
+        {failed ? (
+          <RefreshNotice state="failed" onRetry={() => setFailed(false)} />
+        ) : (
+          <p role="status" className="p-4 text-sm">
+            Sample refresh succeeded. Your results stay visible.
+          </p>
+        )}
+      </Surface>
+    );
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/review-proposal/Pages.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/review-proposal/Pages.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ReviewPrototype } from "./ReviewPages";
+
+const meta = {
+  title: "Code/Review proposal/Pages",
+  component: ReviewPrototype,
+  parameters: { layout: "fullscreen" },
+  args: { scenario: "files" },
+  render: (args) => <ReviewPrototype key={args.scenario} {...args} />,
+} satisfies Meta<typeof ReviewPrototype>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PullRequestInbox: Story = { args: { scenario: "inbox" } };
+export const InboxLoading: Story = { args: { scenario: "inbox-loading" } };
+export const InboxEmpty: Story = { args: { scenario: "inbox-empty" } };
+export const RefreshFailed: Story = { args: { scenario: "inbox-failed" } };
+export const ReviewFiles: Story = { args: { scenario: "files" } };
+export const FilesLoading: Story = { args: { scenario: "files-loading" } };
+export const ReviewDiscussion: Story = { args: { scenario: "discussion" } };
+export const ReviewChecks: Story = { args: { scenario: "checks" } };
+export const ReadyToMerge: Story = { args: { scenario: "ready" } };
+export const SourceControl: Story = { args: { scenario: "source" } };
+export const StagedChanges: Story = { args: { scenario: "staged" } };
+export const CleanWorkingTree: Story = { args: { scenario: "clean" } };
+export const MergeConflict: Story = { args: { scenario: "conflict" } };

--- a/crates/tidebreak-desktop/ui/src/stories/review-proposal/ReviewComponents.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/review-proposal/ReviewComponents.tsx
@@ -1,0 +1,758 @@
+import { useId, useState, type ReactNode } from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Check,
+  ChevronDown,
+  CircleAlert,
+  CircleCheck,
+  Clock3,
+  FileCode2,
+  GitBranch,
+  GitPullRequest,
+  MessageSquare,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import type {
+  CodeDeliveryCheck,
+  CodeDeliveryPullRequestFile,
+  CodeDeliveryPullRequestSummary,
+} from "@/api/types";
+import {
+  checkCounts,
+  checkSummary,
+  mergeBlockedReasons,
+  prStateChips,
+  prStatus,
+  STATUS_TONE_BADGE_VARIANT,
+} from "@/code/prState";
+import { STATUS_TEXT, type StatusTone } from "@/code/statusTone";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+export type LoadState = "ready" | "loading" | "refreshing" | "failed";
+export function RefreshNotice({
+  state,
+  onRetry,
+}: {
+  state: LoadState;
+  onRetry: () => void;
+}) {
+  if (state === "failed")
+    return (
+      <div
+        role="alert"
+        className="notice-surface notice-warning mx-5 my-3 flex flex-wrap items-center justify-between gap-2 p-3 text-sm"
+      >
+        <span>
+          Could not refresh GitHub. Your last results are still available.
+        </span>
+        <Button size="sm" variant="outline" onClick={onRetry}>
+          Retry refresh
+        </Button>
+      </div>
+    );
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 text-xs text-muted-foreground"
+    >
+      {state === "refreshing" ? (
+        <>
+          <Spinner className="size-3" aria-hidden />
+          Refreshing GitHub…
+        </>
+      ) : (
+        "Last confirmed 20 seconds ago"
+      )}
+    </div>
+  );
+}
+
+export function ReviewHeader({
+  pr,
+  onBack,
+  onInspect,
+  onRefresh,
+  onMerge,
+  refreshing = false,
+}: {
+  pr: CodeDeliveryPullRequestSummary;
+  onBack: () => void;
+  onInspect: () => void;
+  onRefresh: () => void;
+  onMerge: () => void;
+  refreshing?: boolean;
+}) {
+  const status = prStatus(pr);
+  const blockers = mergeBlockedReasons(pr);
+  return (
+    <header className="px-5 pt-4">
+      <div className="mb-3 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+        <Button size="sm" variant="ghost" className="-ml-2" onClick={onBack}>
+          <ArrowLeft />
+          Pull requests
+        </Button>
+        <span>
+          {pr.repository.name} #{pr.number}
+        </span>
+      </div>
+      <div className="review-proposal-heading flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold tracking-tight wrap-anywhere">
+            {pr.title}
+          </h1>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {prStateChips(pr)
+              .slice(0, 1)
+              .map((chip) => (
+                <Badge
+                  key={chip.key}
+                  size="sm"
+                  variant={STATUS_TONE_BADGE_VARIANT[chip.tone]}
+                >
+                  {chip.label}
+                </Badge>
+              ))}
+            <span>{pr.author}</span>
+            <span className="flex min-w-0 items-start gap-1 font-mono">
+              <GitBranch className="mt-0.5 size-3 shrink-0" />
+              <span className="min-w-0 wrap-anywhere">
+                {pr.head_branch} <ArrowRight className="inline size-3" />{" "}
+                {pr.base_branch}
+              </span>
+            </span>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            size="sm"
+            onClick={status.gate === "ready" ? onMerge : onInspect}
+          >
+            {status.gate === "ready"
+              ? "Review merge…"
+              : status.checks.failing
+                ? "Inspect failure"
+                : "Review feedback"}
+          </Button>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            aria-label="Refresh pull request"
+            onClick={onRefresh}
+            disabled={refreshing}
+          >
+            {refreshing ? <Spinner aria-hidden /> : <RefreshCw />}
+          </Button>
+        </div>
+      </div>
+      <div className="mt-4 border-t border-border-subtle py-3">
+        <div
+          className={cn(
+            "flex flex-wrap items-center gap-2 text-sm",
+            STATUS_TEXT[status.headline.tone],
+          )}
+        >
+          {status.gate === "ready" ? (
+            <CircleCheck className="size-3.5" />
+          ) : (
+            <CircleAlert className="size-3.5" />
+          )}
+          <span className="font-medium">{status.headline.label}</span>
+          {status.checks.failing > 0 && (
+            <span>· {checkSummary(status.checks).label}</span>
+          )}
+        </div>
+        {blockers.length > 0 && (
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            {blockers.join(" ")}
+          </p>
+        )}
+      </div>
+    </header>
+  );
+}
+
+export function PullRequestRow({
+  pr,
+  onOpen,
+}: {
+  pr: CodeDeliveryPullRequestSummary;
+  onOpen: () => void;
+}) {
+  const status = prStatus(pr);
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="review-proposal-pr-row grid w-full grid-cols-[minmax(0,1fr)_190px] items-center gap-5 border-b border-border-subtle px-5 py-4 text-left hover:bg-muted/30 focus-visible:outline-2 focus-visible:outline-ring"
+      aria-label={`Open PR ${pr.number}: ${pr.title}`}
+    >
+      <div className="min-w-0">
+        <div className="flex items-start gap-2">
+          <GitPullRequest
+            className={cn(
+              "mt-0.5 size-4 shrink-0",
+              STATUS_TEXT[status.headline.tone],
+            )}
+          />
+          <span className="text-md font-medium wrap-anywhere">{pr.title}</span>
+        </div>
+        <p className="mt-1 pl-6 text-xs text-muted-foreground">
+          {pr.repository.name} #{pr.number} · {pr.author}
+        </p>
+      </div>
+      <div className="text-sm">
+        <div className={STATUS_TEXT[status.headline.tone]}>
+          {status.headline.label}
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {checkSummary(checkCounts(pr)).label} · {pr.comment_count} comments
+        </p>
+      </div>
+    </button>
+  );
+}
+
+export function ReviewEmpty({
+  title = "No pull requests need your attention",
+  description = "You are caught up. Open All to see the rest of your pull requests.",
+}: {
+  title?: string;
+  description?: string;
+}) {
+  return (
+    <Empty className="min-h-64">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <GitPullRequest />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}
+export function ReviewLoading({
+  label = "Loading pull requests…",
+}: {
+  label?: string;
+}) {
+  return (
+    <div className="space-y-6 p-5" role="status" aria-label={label}>
+      <span className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner aria-hidden />
+        {label}
+      </span>
+      {[0, 1, 2].map((n) => (
+        <div key={n} className="space-y-2">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-3 w-1/3" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+type PatchLine = {
+  oldLine?: number;
+  newLine?: number;
+  text: string;
+  kind: "add" | "remove" | "context" | "hunk";
+};
+function patchLines(patch: string): PatchLine[] {
+  let oldLine = 0;
+  let newLine = 0;
+  return patch.split("\n").map((text) => {
+    const hunk = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(text);
+    if (hunk) {
+      oldLine = Number(hunk[1]);
+      newLine = Number(hunk[2]);
+      return { text, kind: "hunk" };
+    }
+    if (text.startsWith("+"))
+      return { text: text.slice(1), kind: "add", newLine: newLine++ };
+    if (text.startsWith("-"))
+      return { text: text.slice(1), kind: "remove", oldLine: oldLine++ };
+    if (text.startsWith("\\")) return { text, kind: "context" };
+    return {
+      text: text.slice(1),
+      kind: "context",
+      oldLine: oldLine++,
+      newLine: newLine++,
+    };
+  });
+}
+export function FileDiff({
+  file,
+  actions,
+  wrap = true,
+}: {
+  file: CodeDeliveryPullRequestFile;
+  actions?: ReactNode;
+  wrap?: boolean;
+}) {
+  return (
+    <section className="min-w-0" aria-label={`Diff for ${file.path}`}>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <span className="min-w-0 font-mono text-sm wrap-anywhere">
+          {file.path.split("/").at(-1)}{" "}
+          <span className={STATUS_TEXT.ready}>+{file.additions}</span>{" "}
+          <span className={STATUS_TEXT.critical}>−{file.deletions}</span>
+        </span>
+        <div className="flex flex-wrap items-center gap-2">{actions}</div>
+      </div>
+      <div className="overflow-x-auto rounded-lg border border-border-subtle font-mono text-sm">
+        {file.patch ? (
+          patchLines(file.patch).map((line, n) =>
+            line.kind === "hunk" ? (
+              <div
+                key={n}
+                className="bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground whitespace-pre-wrap wrap-anywhere"
+              >
+                {line.text}
+              </div>
+            ) : (
+              <div
+                key={n}
+                className={cn(
+                  "grid min-h-6 grid-cols-[2.5rem_2.5rem_1rem_minmax(0,1fr)]",
+                  line.kind === "add" && "bg-success/10",
+                  line.kind === "remove" && "bg-critical/10",
+                  !wrap && "w-max min-w-full",
+                )}
+              >
+                <span className="py-0.5 pr-2 text-right text-xs text-muted-foreground select-none">
+                  {line.oldLine}
+                </span>
+                <span className="py-0.5 pr-2 text-right text-xs text-muted-foreground select-none">
+                  {line.newLine}
+                </span>
+                <span
+                  aria-label={
+                    line.kind === "add"
+                      ? "Added"
+                      : line.kind === "remove"
+                        ? "Removed"
+                        : undefined
+                  }
+                  className={cn(
+                    "py-0.5",
+                    line.kind === "add" && STATUS_TEXT.ready,
+                    line.kind === "remove" && STATUS_TEXT.critical,
+                  )}
+                >
+                  {line.kind === "add"
+                    ? "+"
+                    : line.kind === "remove"
+                      ? "−"
+                      : " "}
+                </span>
+                <code
+                  className={cn(
+                    "py-0.5 pr-3",
+                    wrap
+                      ? "whitespace-pre-wrap wrap-anywhere"
+                      : "whitespace-pre",
+                  )}
+                >
+                  {line.text || " "}
+                </code>
+              </div>
+            ),
+          )
+        ) : (
+          <p className="p-4 text-sm text-muted-foreground">
+            No text diff is available for this file.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function FileRail({
+  files,
+  selected,
+  onSelect,
+  viewed = [],
+}: {
+  files: CodeDeliveryPullRequestFile[];
+  selected: string;
+  onSelect: (path: string) => void;
+  viewed?: string[];
+}) {
+  return (
+    <>
+      <aside
+        className="review-proposal-file-rail border-r border-border-subtle bg-muted/20 px-2 py-4"
+        aria-label="Changed files"
+      >
+        <h2 className="px-2 pb-3 text-xs font-medium text-muted-foreground">
+          {files.length} {files.length === 1 ? "file" : "files"} changed
+        </h2>
+        {files.map((file) => (
+          <button
+            type="button"
+            key={file.path}
+            aria-pressed={selected === file.path}
+            onClick={() => onSelect(file.path)}
+            className={cn(
+              "mb-1 flex w-full items-start gap-2 rounded-md px-2 py-2.5 text-left text-sm hover:bg-muted/50 focus-visible:outline-2 focus-visible:outline-ring",
+              selected === file.path && "bg-muted",
+            )}
+          >
+            {viewed.includes(file.path) ? (
+              <Check className="mt-0.5 size-3.5 shrink-0" />
+            ) : (
+              <FileCode2 className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+            )}
+            <span className="min-w-0 wrap-anywhere">
+              {file.path.split("/").at(-1)}
+              <span className="mt-1 block text-xs text-muted-foreground">
+                {file.path.split("/").slice(0, -1).join("/")}
+              </span>
+            </span>
+          </button>
+        ))}
+      </aside>
+      <label className="review-proposal-file-picker hidden px-4 pt-4 text-xs text-muted-foreground">
+        Changed file
+        <select
+          value={selected}
+          onChange={(event) => onSelect(event.target.value)}
+          className="mt-1 h-control w-full rounded-md border border-input bg-background px-2 font-mono text-sm text-foreground"
+        >
+          {files.map((file) => (
+            <option key={file.path} value={file.path}>
+              {file.path.split("/").at(-1)}
+            </option>
+          ))}
+        </select>
+      </label>
+    </>
+  );
+}
+
+export function ReviewThread({
+  body,
+  author = "devon",
+  path,
+  line = 345,
+  initialResolved = false,
+  onAgent,
+}: {
+  body: string;
+  author?: string;
+  path: string;
+  line?: number;
+  initialResolved?: boolean;
+  onAgent: (context: string) => void;
+}) {
+  const [resolved, setResolved] = useState(initialResolved);
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [reply, setReply] = useState("");
+  const [replies, setReplies] = useState<string[]>([]);
+  const id = useId();
+  return (
+    <section
+      className="mt-4 border-t border-border-subtle pt-4"
+      aria-label="Inline review thread"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <MessageSquare className="size-3.5 text-muted-foreground" />
+          <span className="font-medium">{author}</span>
+          <span className="text-xs text-muted-foreground">Line {line}</span>
+        </div>
+        <span
+          className={cn("text-xs", STATUS_TEXT[resolved ? "ready" : "neutral"])}
+        >
+          {resolved ? "Resolved" : "Unresolved"}
+        </span>
+      </div>
+      <p className="my-3 text-md leading-relaxed">{body}</p>
+      {replies.map((text, i) => (
+        <p key={i} className="my-2 border-l-2 border-border pl-3 text-sm">
+          <span className="font-medium">You · </span>
+          {text}
+        </p>
+      ))}
+      <div className="-ml-2 flex flex-wrap gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onAgent(`${path}:${line}\n${body}`)}
+        >
+          Add to agent message
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setReplyOpen(!replyOpen)}
+        >
+          Reply
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setResolved(!resolved)}
+        >
+          {resolved ? "Reopen thread" : "Resolve thread"}
+        </Button>
+      </div>
+      {replyOpen && (
+        <form
+          className="mt-3 space-y-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!reply.trim()) return;
+            setReplies([...replies, reply.trim()]);
+            setReply("");
+            setReplyOpen(false);
+          }}
+        >
+          <label htmlFor={id} className="text-xs">
+            Reply to {author}
+          </label>
+          <Textarea
+            id={id}
+            value={reply}
+            onChange={(event) => setReply(event.target.value)}
+            rows={2}
+          />
+          <Button size="sm" disabled={!reply.trim()} type="submit">
+            Add sample reply
+          </Button>
+        </form>
+      )}
+    </section>
+  );
+}
+
+export function CheckRun({
+  check,
+  log,
+  defaultOpen = false,
+  onAgent,
+}: {
+  check: CodeDeliveryCheck;
+  log?: string;
+  defaultOpen?: boolean;
+  onAgent: (context: string) => void;
+}) {
+  const [queued, setQueued] = useState(false);
+  const [open, setOpen] = useState(defaultOpen);
+  const bucket = queued ? "pending" : check.bucket;
+  const tone: StatusTone =
+    bucket === "fail" ? "critical" : bucket === "pass" ? "ready" : "pending";
+  const Icon =
+    bucket === "fail" ? CircleAlert : bucket === "pass" ? CircleCheck : Clock3;
+  return (
+    <section className="border-b border-border-subtle py-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <Icon className={cn("size-4 shrink-0", STATUS_TEXT[tone])} />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-medium">{check.name}</h3>
+          <p className={cn("mt-0.5 text-xs", STATUS_TEXT[tone])}>
+            {queued
+              ? "Rerun queued"
+              : (check.detail ??
+                checkSummary(checkCounts({ checks: [check] })).label)}
+          </p>
+        </div>
+        {log && (
+          <Button
+            size="sm"
+            variant="ghost"
+            aria-expanded={open}
+            onClick={() => setOpen(!open)}
+          >
+            {open ? "Hide logs" : "Show logs"}
+            <ChevronDown className={open ? "rotate-180" : ""} />
+          </Button>
+        )}
+        {check.bucket === "fail" && (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={queued}
+            onClick={() => setQueued(true)}
+          >
+            {queued ? "Queued" : "Rerun failed"}
+          </Button>
+        )}
+      </div>
+      {open && log && (
+        <>
+          <pre className="mt-3 whitespace-pre-wrap rounded-lg bg-muted/40 p-3 font-mono text-xs leading-relaxed wrap-anywhere">
+            {log}
+          </pre>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="mt-2"
+            onClick={() => onAgent(`${check.name}\n${log}`)}
+          >
+            Ask agent to fix
+          </Button>
+        </>
+      )}
+    </section>
+  );
+}
+
+export function CommitControls({
+  stagedCount,
+  ahead,
+  onCommit,
+  onPush,
+  busy = false,
+  blocked = false,
+  error,
+}: {
+  stagedCount: number;
+  ahead: number;
+  onCommit: (message: string) => void;
+  onPush: () => void;
+  busy?: boolean;
+  blocked?: boolean;
+  error?: string;
+}) {
+  const [message, setMessage] = useState("Keep review drafts during refresh");
+  const id = useId();
+  return (
+    <form
+      className="space-y-2 border-t border-border-subtle p-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (message.trim() && stagedCount > 0 && !busy && !blocked)
+          onCommit(message.trim());
+      }}
+    >
+      <label htmlFor={id} className="text-xs font-medium">
+        Commit message
+      </label>
+      <div className="review-proposal-commit-row flex gap-2">
+        <Input
+          id={id}
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          className="min-w-0 flex-1"
+        />
+        <Button
+          size="sm"
+          type="submit"
+          disabled={stagedCount === 0 || !message.trim() || busy || blocked}
+        >
+          {busy && <Spinner aria-hidden />}Commit staged ({stagedCount})
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          type="button"
+          disabled={ahead === 0 || busy || blocked}
+          onClick={onPush}
+        >
+          <ArrowUp />
+          {blocked
+            ? "Push blocked"
+            : ahead === 0
+              ? "Up to date"
+              : `Push ${ahead} ${ahead === 1 ? "commit" : "commits"}`}
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {blocked
+          ? "Resolve the conflict before committing or pushing."
+          : "Only staged changes enter this commit."}
+      </p>
+      {error && (
+        <p role="alert" className={cn("text-sm", STATUS_TEXT.critical)}>
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}
+
+export function AgentDraft({
+  context,
+  onClose,
+}: {
+  context: string;
+  onClose: () => void;
+}) {
+  const [message, setMessage] = useState(
+    `Address this review feedback. Leave the changes uncommitted.\n\n${context}`,
+  );
+  const id = useId();
+  return (
+    <section
+      className="border-t border-border-subtle bg-muted/20 p-4"
+      aria-label="Agent message draft"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-medium">Message to agent</h2>
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={onClose}
+          aria-label="Close agent draft"
+        >
+          <X />
+        </Button>
+      </div>
+      <label htmlFor={id} className="mb-2 block text-xs text-muted-foreground">
+        Review context and instruction
+      </label>
+      <Textarea
+        id={id}
+        value={message}
+        onChange={(event) => setMessage(event.target.value)}
+        rows={4}
+      />
+      <p className="mt-2 text-xs text-muted-foreground">
+        Storybook draft only. No agent starts.
+      </p>
+    </section>
+  );
+}
+
+export function ViewedControl({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  const id = useId();
+  return (
+    <label
+      htmlFor={id}
+      className="flex items-center gap-2 text-xs text-muted-foreground"
+    >
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(value) => onChange(value === true)}
+      />
+      Viewed
+    </label>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/review-proposal/ReviewPages.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/review-proposal/ReviewPages.tsx
@@ -1,0 +1,641 @@
+import { useState } from "react";
+import { ArrowRight, GitBranch, RefreshCw, Search } from "lucide-react";
+import { prStatus } from "@/code/prState";
+import { STATUS_TEXT } from "@/code/statusTone";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import {
+  AgentDraft,
+  CheckRun,
+  CommitControls,
+  FileDiff,
+  FileRail,
+  PullRequestRow,
+  RefreshNotice,
+  ReviewEmpty,
+  ReviewHeader,
+  ReviewLoading,
+  ReviewThread,
+  ViewedControl,
+  type LoadState,
+} from "./ReviewComponents";
+import {
+  failedLog,
+  inboxPrs,
+  readyPr,
+  reviewComment,
+  reviewDetail,
+  reviewFiles,
+  reviewPr,
+} from "./fixtures";
+import "./review-proposal.css";
+
+export type ReviewScenario =
+  | "inbox"
+  | "inbox-loading"
+  | "inbox-empty"
+  | "inbox-failed"
+  | "files"
+  | "files-loading"
+  | "discussion"
+  | "checks"
+  | "ready"
+  | "source"
+  | "staged"
+  | "clean"
+  | "conflict";
+type View = "inbox" | "review" | "source";
+type Scope = "unstaged" | "staged" | "branch" | "turn";
+const tabClass =
+  "rounded-none border-b-2 border-transparent px-0 py-3 data-[state=active]:border-foreground data-[state=active]:bg-transparent";
+
+// Index: inbox and file rail. Resource detail: diff, review, and commit form.
+export function ReviewPrototype({
+  scenario = "files",
+}: {
+  scenario?: ReviewScenario;
+}) {
+  const [view, setView] = useState<View>(() =>
+    scenario.startsWith("inbox")
+      ? "inbox"
+      : ["source", "staged", "clean", "conflict"].includes(scenario)
+        ? "source"
+        : "review",
+  );
+  const [selectedPr, setSelectedPr] = useState(
+    scenario === "ready" ? readyPr : reviewPr,
+  );
+  const [tab, setTab] = useState(
+    scenario === "checks"
+      ? "checks"
+      : scenario === "discussion"
+        ? "discussion"
+        : "files",
+  );
+  const [listState, setListState] = useState<LoadState>(
+    scenario === "inbox-loading"
+      ? "loading"
+      : scenario === "inbox-failed"
+        ? "failed"
+        : "ready",
+  );
+  const [filter, setFilter] = useState("attention");
+  const [search, setSearch] = useState("");
+  const [filesLoading, setFilesLoading] = useState(
+    scenario === "files-loading",
+  );
+  const [scope, setScope] = useState<Scope>(
+    scenario === "staged" ? "staged" : "unstaged",
+  );
+  const [staged, setStaged] = useState<string[]>(
+    scenario === "staged" ? [reviewFiles[0]!.path] : [],
+  );
+  const [committed, setCommitted] = useState<string[]>(
+    scenario === "clean" ? reviewFiles.map((file) => file.path) : [],
+  );
+  const [ahead, setAhead] = useState(scenario === "clean" ? 0 : 2);
+  const [selectedFile, setSelectedFile] = useState(reviewFiles[0]!.path);
+  const [viewed, setViewed] = useState<string[]>([]);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [savedComments, setSavedComments] = useState<Record<string, string[]>>(
+    {},
+  );
+  const [agentContext, setAgentContext] = useState<string | null>(null);
+  const [notice, setNotice] = useState("");
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+  const [simulateFailure, setSimulateFailure] = useState(
+    scenario === "inbox-failed",
+  );
+  const conflict = scenario === "conflict";
+  const dirtyFiles = reviewFiles.filter(
+    (file) => !staged.includes(file.path) && !committed.includes(file.path),
+  );
+  const scopedFiles =
+    view !== "source" || scope === "branch" || scope === "turn"
+      ? reviewFiles
+      : scope === "staged"
+        ? reviewFiles.filter((file) => staged.includes(file.path))
+        : dirtyFiles;
+  const file =
+    scopedFiles.find((item) => item.path === selectedFile) ?? scopedFiles[0];
+  const draft = drafts[selectedPr.id] ?? "";
+
+  function refresh() {
+    setListState("ready");
+    setFilesLoading(false);
+    setSimulateFailure(false);
+    setConfirmed(true);
+    setNotice("Sample data refreshed. Your selection and draft stay in place.");
+  }
+  function openPr(pr = reviewPr) {
+    setSelectedPr(pr);
+    setView("review");
+    setTab("files");
+  }
+  function startAgent(context: string) {
+    setAgentContext(context);
+    setNotice("Review context added to the agent draft.");
+  }
+  function fileArea(source = false) {
+    if (filesLoading && !source)
+      return <ReviewLoading label="Loading changed files…" />;
+    if (!file)
+      return (
+        <ReviewEmpty
+          title={
+            scope === "staged" ? "No staged changes" : "No uncommitted changes"
+          }
+          description={
+            scope === "staged"
+              ? "Stage a file or hunk to prepare your next commit."
+              : "Your working tree is clean. Use Branch to review the changes against main."
+          }
+        />
+      );
+    const changeStage = () => {
+      if (scope === "staged") {
+        setStaged(staged.filter((path) => path !== file.path));
+        setScope("unstaged");
+        setNotice("Sample file unstaged.");
+      } else {
+        setStaged([...new Set([...staged, file.path])]);
+        setScope("staged");
+        setNotice("Sample file staged. Other files stay unstaged.");
+      }
+    };
+    return (
+      <div className="review-proposal-files grid grid-cols-[220px_minmax(0,1fr)]">
+        <FileRail
+          files={scopedFiles}
+          selected={file.path}
+          onSelect={setSelectedFile}
+          viewed={viewed}
+        />
+        <div className="min-w-0 p-5">
+          <FileDiff
+            file={file}
+            actions={
+              source ? (
+                <>
+                  {(scope === "unstaged" || scope === "staged") &&
+                    !conflict && (
+                      <>
+                        {scope === "unstaged" && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={changeStage}
+                          >
+                            Stage hunk
+                          </Button>
+                        )}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={changeStage}
+                        >
+                          {scope === "staged" ? "Unstage file" : "Stage file"}
+                        </Button>
+                      </>
+                    )}
+                </>
+              ) : (
+                <ViewedControl
+                  checked={viewed.includes(file.path)}
+                  onChange={(checked) =>
+                    setViewed(
+                      checked
+                        ? [...new Set([...viewed, file.path])]
+                        : viewed.filter((path) => path !== file.path),
+                    )
+                  }
+                />
+              )
+            }
+          />
+          {!source && (
+            <ReviewThread
+              key={`${selectedPr.id}:${file.path}`}
+              path={file.path}
+              body={reviewComment.body}
+              onAgent={startAgent}
+            />
+          )}
+          {source && (
+            <p className="mt-3 text-xs text-muted-foreground">
+              {scope === "staged"
+                ? "This is the content your next commit includes."
+                : scope === "unstaged"
+                  ? "Each sample file has one hunk. Choose only the changes you want to commit."
+                  : scope === "branch"
+                    ? "Changes on this branch compared with main."
+                    : "Changes from the last agent turn."}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+  const listed = (scenario === "inbox-empty" ? [] : inboxPrs).filter(
+    (pr) =>
+      (filter === "all" || prStatus(pr).group === "attention") &&
+      `${pr.title} ${pr.repository.name} ${pr.number}`
+        .toLowerCase()
+        .includes(search.toLowerCase()),
+  );
+
+  return (
+    <div
+      className="review-proposal flex h-full min-h-0 flex-col bg-background text-foreground"
+      data-testid="review-prototype"
+      data-scenario={scenario}
+    >
+      <header className="flex shrink-0 flex-wrap items-center gap-4 border-b border-border-subtle bg-page-background px-4 py-2">
+        <span className="flex items-center gap-2 text-sm font-medium">
+          <GitBranch className="size-4" />
+          Tidebreak
+        </span>
+        <nav aria-label="Code navigation" className="flex gap-1">
+          <Button
+            size="sm"
+            variant={view === "source" ? "ghost" : "secondary"}
+            onClick={() => setView("inbox")}
+          >
+            Pull requests
+          </Button>
+          <Button
+            size="sm"
+            variant={view === "source" ? "secondary" : "ghost"}
+            onClick={() => setView("source")}
+          >
+            Source control
+          </Button>
+        </nav>
+        <span className="ml-auto hidden text-xs text-muted-foreground sm:block">
+          Review proposal · sample data
+        </span>
+      </header>
+      <main className="min-h-0 flex-1 overflow-auto">
+        {view === "inbox" ? (
+          <section className="pb-8">
+            <div className="flex flex-wrap items-center justify-between gap-3 px-5 pt-6">
+              <div>
+                <h1 className="text-xl font-semibold tracking-tight">
+                  Pull requests
+                </h1>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Review what needs your attention.
+                </p>
+              </div>
+              <Button size="sm" variant="outline" onClick={refresh}>
+                <RefreshCw />
+                Refresh
+              </Button>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-4">
+              <div className="flex gap-1">
+                {["attention", "all"].map((value) => (
+                  <Button
+                    key={value}
+                    size="sm"
+                    variant={filter === value ? "secondary" : "ghost"}
+                    aria-pressed={filter === value}
+                    onClick={() => setFilter(value)}
+                  >
+                    {value === "attention" ? "Needs attention" : "All"}
+                  </Button>
+                ))}
+              </div>
+              <label className="relative min-w-0 max-w-72 flex-1">
+                <Search className="pointer-events-none absolute top-2 left-2 size-3.5 text-muted-foreground" />
+                <Input
+                  aria-label="Search pull requests"
+                  placeholder="Search pull requests…"
+                  size="sm"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  className="pl-7"
+                />
+              </label>
+            </div>
+            {simulateFailure && (
+              <RefreshNotice state="failed" onRetry={refresh} />
+            )}
+            {listState === "loading" ? (
+              <ReviewLoading />
+            ) : listed.length === 0 ? (
+              <ReviewEmpty
+                title={search ? "No matching pull requests" : undefined}
+                description={
+                  search
+                    ? "Try a different title, repository, or PR number."
+                    : undefined
+                }
+              />
+            ) : (
+              listed.map((pr) => (
+                <PullRequestRow key={pr.id} pr={pr} onOpen={() => openPr(pr)} />
+              ))
+            )}
+          </section>
+        ) : view === "review" ? (
+          <>
+            <ReviewHeader
+              pr={selectedPr}
+              onBack={() => setView("inbox")}
+              onRefresh={refresh}
+              onMerge={() => setMergeOpen(true)}
+              onInspect={() =>
+                setTab(
+                  prStatus(selectedPr).checks.failing ? "checks" : "discussion",
+                )
+              }
+            />
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabsList
+                className="flex w-full justify-start gap-6 rounded-none border-b border-border-subtle px-5"
+                aria-label="Pull request sections"
+              >
+                <TabsTrigger value="files" className={tabClass}>
+                  Files <span className="text-xs text-muted-foreground">3</span>
+                </TabsTrigger>
+                <TabsTrigger value="discussion" className={tabClass}>
+                  Discussion
+                </TabsTrigger>
+                <TabsTrigger value="checks" className={tabClass}>
+                  Checks{" "}
+                  <span className="text-xs text-muted-foreground">
+                    {prStatus(selectedPr).checks.failing
+                      ? "1 failed"
+                      : "Passed"}
+                  </span>
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="files" className="mt-0">
+                {fileArea()}
+              </TabsContent>
+              <TabsContent value="discussion" className="m-0 max-w-4xl p-5">
+                <h2 className="text-base font-medium">
+                  Keep your review in place
+                </h2>
+                <p className="mt-2 text-md leading-relaxed text-muted-foreground">
+                  {reviewDetail.body}
+                </p>
+                <ReviewThread
+                  path={reviewComment.path!}
+                  body={reviewComment.body}
+                  onAgent={startAgent}
+                />
+                <form
+                  className="mt-6 space-y-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    if (!draft.trim()) return;
+                    setSavedComments({
+                      ...savedComments,
+                      [selectedPr.id]: [
+                        ...(savedComments[selectedPr.id] ?? []),
+                        draft.trim(),
+                      ],
+                    });
+                    setDrafts({ ...drafts, [selectedPr.id]: "" });
+                    setNotice(
+                      "Sample comment added. Nothing was sent to GitHub.",
+                    );
+                  }}
+                >
+                  <label
+                    htmlFor="review-comment-draft"
+                    className="text-sm font-medium"
+                  >
+                    Comment
+                  </label>
+                  <Textarea
+                    id="review-comment-draft"
+                    rows={3}
+                    placeholder="Add a comment to the review…"
+                    value={draft}
+                    onChange={(event) =>
+                      setDrafts({
+                        ...drafts,
+                        [selectedPr.id]: event.target.value,
+                      })
+                    }
+                  />
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-xs text-muted-foreground">
+                      Your draft stays with this PR when you switch views.
+                    </p>
+                    <Button size="sm" type="submit" disabled={!draft.trim()}>
+                      Add sample comment
+                    </Button>
+                  </div>
+                </form>
+                {savedComments[selectedPr.id]?.map((comment, i) => (
+                  <p
+                    key={i}
+                    className="mt-4 border-t border-border-subtle pt-3 text-sm"
+                  >
+                    <span className="font-medium">You · </span>
+                    {comment}
+                  </p>
+                ))}
+              </TabsContent>
+              <TabsContent value="checks" className="m-0 p-5">
+                <h2 className="mb-2 text-base font-medium">
+                  {prStatus(selectedPr).checks.failing
+                    ? "One required check failed"
+                    : "All checks passed"}
+                </h2>
+                {[...selectedPr.checks]
+                  .sort(
+                    (a, b) =>
+                      Number(b.bucket === "fail") - Number(a.bucket === "fail"),
+                  )
+                  .map((check) => (
+                    <CheckRun
+                      key={check.name}
+                      check={check}
+                      log={check.bucket === "fail" ? failedLog : undefined}
+                      defaultOpen={check.bucket === "fail"}
+                      onAgent={startAgent}
+                    />
+                  ))}
+              </TabsContent>
+            </Tabs>
+          </>
+        ) : (
+          <>
+            <header className="px-5 pt-5">
+              <p className="text-xs text-muted-foreground">
+                Workspace · tidebreak
+              </p>
+              <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h1 className="text-xl font-semibold tracking-tight">
+                    Source control
+                  </h1>
+                  <p className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <GitBranch className="size-3" />
+                    <span className="font-mono">thet/review-drafts</span>
+                    <ArrowRight className="size-3" />
+                    <span className="font-mono">main</span>
+                    <span>
+                      ·{" "}
+                      {ahead
+                        ? `${ahead} commits to push`
+                        : "Up to date with origin"}
+                    </span>
+                  </p>
+                </div>
+                <Button size="sm" variant="outline" onClick={() => openPr()}>
+                  View PR #{reviewPr.number}
+                </Button>
+              </div>
+            </header>
+            {conflict && (
+              <div
+                role="alert"
+                className="notice-surface notice-critical mx-5 mt-4 p-3"
+              >
+                <p className="text-sm font-medium">
+                  Resolve one conflict before committing
+                </p>
+                <p className="mt-1 font-mono text-xs wrap-anywhere">
+                  {reviewFiles[0]!.path}
+                </p>
+                <Button
+                  className="mt-2"
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    startAgent(
+                      `Resolve the conflict in ${reviewFiles[0]!.path}. Keep unrelated changes.`,
+                    )
+                  }
+                >
+                  Ask agent to resolve
+                </Button>
+              </div>
+            )}
+            <Tabs
+              value={scope}
+              onValueChange={(value) => setScope(value as Scope)}
+              className="mt-4"
+            >
+              <TabsList
+                className="flex w-full justify-start gap-5 rounded-none border-b border-border-subtle px-5"
+                aria-label="Diff scope"
+              >
+                {(
+                  [
+                    ["unstaged", `Unstaged ${dirtyFiles.length}`],
+                    ["staged", `Staged ${staged.length}`],
+                    ["branch", "Branch"],
+                    ["turn", "Last turn"],
+                  ] as const
+                ).map(([value, label]) => (
+                  <TabsTrigger key={value} className={tabClass} value={value}>
+                    {label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              {(["unstaged", "staged", "branch", "turn"] as const).map(
+                (value) => (
+                  <TabsContent className="mt-0" key={value} value={value}>
+                    {fileArea(true)}
+                  </TabsContent>
+                ),
+              )}
+            </Tabs>
+            <CommitControls
+              stagedCount={staged.length}
+              ahead={ahead}
+              blocked={conflict}
+              onCommit={(message) => {
+                setCommitted([...committed, ...staged]);
+                setStaged([]);
+                setScope("unstaged");
+                setAhead(ahead + 1);
+                setNotice(`Sample commit created: ${message}`);
+              }}
+              onPush={() => {
+                setAhead(0);
+                setNotice("Sample push complete. Nothing was sent to GitHub.");
+              }}
+            />
+          </>
+        )}
+        {agentContext !== null && (
+          <AgentDraft
+            key={agentContext}
+            context={agentContext}
+            onClose={() => setAgentContext(null)}
+          />
+        )}
+      </main>
+      <footer className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-t border-border-subtle px-4 py-2 text-xs text-muted-foreground">
+        <span>
+          {confirmed
+            ? "Last confirmed just now"
+            : "Last confirmed 20 seconds ago"}
+        </span>
+        <span role="status" className="text-foreground" aria-live="polite">
+          {notice || "Storybook only · no GitHub or Git writes"}
+        </span>
+      </footer>
+      <Dialog open={mergeOpen} onOpenChange={setMergeOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Merge PR #{selectedPr.number}?</DialogTitle>
+            <DialogDescription>
+              Squash {selectedPr.head_branch} into {selectedPr.base_branch}.
+              This Storybook action does not contact GitHub.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="rounded-lg border border-border-subtle p-3 font-mono text-sm">
+            {selectedPr.repository.owner}/{selectedPr.repository.name}
+            <p className="mt-1 text-xs text-muted-foreground">
+              Displayed head: {selectedPr.head_sha}
+            </p>
+          </div>
+          <p className={cn("text-sm", STATUS_TEXT.ready)}>
+            Checks passed. Review approved.
+          </p>
+          <DialogFooter>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setMergeOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => {
+                setMergeOpen(false);
+                setNotice(
+                  "Sample merge confirmed. Nothing was merged on GitHub.",
+                );
+              }}
+            >
+              Confirm sample merge
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/review-proposal/ReviewPrototype.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/review-proposal/ReviewPrototype.dom.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it } from "vitest";
+import { ReviewPrototype } from "./ReviewPages";
+
+afterEach(cleanup);
+
+it("keeps an unsent comment through refresh and a trip to the inbox", async () => {
+  const user = userEvent.setup();
+  render(<ReviewPrototype scenario="discussion" />);
+  await user.type(
+    screen.getByRole("textbox", { name: "Comment" }),
+    "Keep this draft.",
+  );
+  await user.click(
+    screen.getByRole("button", { name: "Refresh pull request" }),
+  );
+  await user.click(
+    within(
+      screen.getByRole("navigation", { name: "Code navigation" }),
+    ).getByRole("button", { name: "Pull requests" }),
+  );
+  await user.click(screen.getByRole("button", { name: /Open PR 2251:/ }));
+  await user.click(screen.getByRole("tab", { name: "Discussion" }));
+  expect(screen.getByRole("textbox", { name: "Comment" })).toHaveValue(
+    "Keep this draft.",
+  );
+});
+
+it("commits the staged file while preserving other unstaged files", async () => {
+  const user = userEvent.setup();
+  render(<ReviewPrototype scenario="source" />);
+  await user.click(screen.getByRole("button", { name: "Stage file" }));
+  expect(screen.getByRole("tab", { name: "Staged 1" })).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+  await user.click(screen.getByRole("button", { name: "Commit staged (1)" }));
+  expect(screen.getByRole("tab", { name: "Unstaged 2" })).toHaveAttribute(
+    "data-state",
+    "active",
+  );
+  expect(screen.getByRole("button", { name: "Push 3 commits" })).toBeEnabled();
+  expect(
+    screen.queryByRole("button", { name: /PullRequestDetail.tsx src\/code/ }),
+  ).toBeNull();
+});
+
+it("keeps rows available while a refresh error is retried", async () => {
+  const user = userEvent.setup();
+  render(<ReviewPrototype scenario="inbox-failed" />);
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    "Your last results are still available.",
+  );
+  expect(screen.getByRole("button", { name: /Open PR 2251:/ })).toBeVisible();
+  await user.click(screen.getByRole("button", { name: "Retry refresh" }));
+  expect(screen.queryByRole("alert")).toBeNull();
+  expect(screen.getByRole("button", { name: /Open PR 2251:/ })).toBeVisible();
+});

--- a/crates/tidebreak-desktop/ui/src/stories/review-proposal/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/review-proposal/fixtures.ts
@@ -1,0 +1,122 @@
+import type {
+  CodeDeliveryPullRequestDetail,
+  CodeDeliveryPullRequestFile,
+  CodeDeliveryPullRequestSummary,
+} from "@/api/types";
+import { deliveryPullRequestDetails, deliveryPullRequests } from "../fixtures";
+
+// These fixtures extend the shared delivery data. Every action stays in React state.
+export const reviewFiles: CodeDeliveryPullRequestFile[] = [
+  {
+    path: "src/code/PullRequestDetail.tsx",
+    status: "modified",
+    additions: 3,
+    deletions: 2,
+    patch: [
+      "@@ -341,5 +341,6 @@ function PullRequestDetail() {",
+      "   useEffect(() => {",
+      '-    setDraftComment("");',
+      '+    setDraftComment(drafts[prId] ?? "");',
+      '     setTab("conversation");',
+      "-  }, [initialDetail, summary.id]);",
+      "+  }, [summary.id]);",
+      "+  // Refresh data without resetting the active review.",
+      " }",
+    ].join("\n"),
+  },
+  {
+    path: "src/code/delivery/usePullRequestQuery.ts",
+    status: "modified",
+    additions: 2,
+    deletions: 1,
+    patch: [
+      "@@ -246,3 +246,4 @@ catch (error) {",
+      '   setError("Could not refresh pull requests.");',
+      "-  setItems([]);",
+      "+  // Keep the last successful result visible.",
+      '+  setRefreshState("failed");',
+      " }",
+    ].join("\n"),
+  },
+  {
+    path: "src/code/reviewDrafts.test.tsx",
+    status: "added",
+    additions: 5,
+    deletions: 0,
+    patch: [
+      "@@ -0,0 +1,5 @@",
+      '+it("keeps an unsent review draft", () => {',
+      '+  enterDraft("Please preserve this comment.");',
+      "+  refreshSamePullRequest();",
+      '+  expectDraft("Please preserve this comment.");',
+      "+});",
+    ].join("\n"),
+  },
+];
+
+export const reviewPr: CodeDeliveryPullRequestSummary = {
+  ...deliveryPullRequests[0]!,
+  title: "Keep review drafts during refresh",
+  head_branch: "thet/review-drafts",
+  comment_count: 2,
+  checks: [
+    {
+      name: "desktop / UI tests",
+      bucket: "fail",
+      detail: "Failed · 38 seconds",
+      workflow_run_id: 4401,
+    },
+    {
+      name: "desktop / typecheck",
+      bucket: "pass",
+      detail: "Passed · 21 seconds",
+    },
+    {
+      name: "desktop / formatting",
+      bucket: "pass",
+      detail: "Passed · 7 seconds",
+    },
+  ],
+};
+export const readyPr: CodeDeliveryPullRequestSummary = {
+  ...deliveryPullRequests[1]!,
+  title: "Restore workspace navigation",
+};
+export const inboxPrs: CodeDeliveryPullRequestSummary[] = [
+  reviewPr,
+  {
+    ...reviewPr,
+    id: "storybook/lazy-files#2250",
+    number: 2250,
+    title: "Load PR files on demand",
+    head_branch: "devon/lazy-pr-files",
+    author: "devon",
+    checks: [{ name: "desktop / tests", bucket: "pass" }],
+  },
+  readyPr,
+];
+export const reviewDetail: CodeDeliveryPullRequestDetail = {
+  ...deliveryPullRequestDetails[2251]!,
+  summary: reviewPr,
+  files: reviewFiles,
+  changed_files: 3,
+  additions: 10,
+  deletions: 3,
+  commits: 2,
+  body: "Preserve comment drafts, the active file, and the selected tab while PR data refreshes.",
+};
+export const reviewComment = {
+  ...reviewDetail.comments[1]!,
+  author: "devon",
+  path: reviewFiles[0]!.path,
+  line: 345,
+  body: "Keep the active Files tab when a refresh returns. A fresh detail object does not mean a different PR.",
+};
+export const failedLog = [
+  "FAIL  preserves active file after refresh",
+  "",
+  "Expected: PullRequestDetail.tsx stays selected",
+  "Received: Conversation tab is selected",
+  "",
+  "reviewDrafts.test.tsx:42",
+].join("\n");

--- a/crates/tidebreak-desktop/ui/src/stories/review-proposal/review-proposal.css
+++ b/crates/tidebreak-desktop/ui/src/stories/review-proposal/review-proposal.css
@@ -1,0 +1,32 @@
+.review-proposal {
+  container-type: inline-size;
+}
+@container (max-width: 760px) {
+  .review-proposal-heading {
+    flex-wrap: wrap;
+  }
+  .review-proposal-files {
+    grid-template-columns: 180px minmax(0, 1fr);
+  }
+  .review-proposal-commit-row {
+    flex-wrap: wrap;
+  }
+  .review-proposal-commit-row input {
+    flex-basis: 100%;
+  }
+}
+@container (max-width: 560px) {
+  .review-proposal-files {
+    display: block;
+  }
+  .review-proposal-file-rail {
+    display: none;
+  }
+  .review-proposal-file-picker {
+    display: block;
+  }
+  .review-proposal-pr-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+  }
+}


### PR DESCRIPTION
## What changed

Adds 22 interactive Storybook stories for the code review proposal: 13 page states and nine component examples. The pages cover the PR inbox, files, discussion, checks, merge confirmation, and source control, including loading, empty, refresh failure, staged changes, clean working tree, and conflict states.

The prototype preserves comment drafts during refresh and navigation, shows failed check logs with an agent draft, and lets reviewers stage selected files before a simulated commit and push. It reuses Tidebreak tokens, primitives, PR status helpers, and typed fixtures. You can find the stories under **Code → Review proposal**.

## Validation

- TypeScript: `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- Formatting and lint: `pnpm --dir crates/tidebreak-desktop/ui exec biome check src/stories/review-proposal`
- Focused interaction and design contract tests: six passing tests in two files.
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- Reviewed every story in all four theme selections at 1100px, plus light and dark at 420px. The high-contrast selections use the existing light/dark palette mappings. Captures use the browser's available resolution.
- Exercised reply/resolve, check rerun, agent draft, and merge confirmation in the browser.

## Compatibility and risk

The changes are confined to the Storybook directory. Git, GitHub, and agent actions use local fixture state and make no backend requests. This ships the proposal for review; production code-mode behavior and loading performance do not change. There are no dependency, API, database, or persisted-format changes.
