### PR TITLE
improve: surface workspace-less sessions and trim headless dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,7 @@ jobs:
       - name: Desktop credential integration tests
         run: |
           cargo test -p tidebreak-cli --locked setup::tests
+          cargo test -p tidebreak-cli --locked --test serve
           cargo test -p tidebreak-server --features keychain --locked tests::listener
           cargo test -p tidebreak-core --features keychain --locked keychain
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,11 @@ jobs:
           save-if: false
       - name: desktop tests
         run: cargo test -p tidebreak-desktop --locked
+      - name: Desktop credential integration tests
+        run: |
+          cargo test -p tidebreak-cli --locked setup::tests
+          cargo test -p tidebreak-server --features keychain --locked tests::listener
+          cargo test -p tidebreak-core --features keychain --locked keychain
 
   windows-check:
     name: Windows cargo check
@@ -653,7 +658,7 @@ jobs:
       # runner's real Credential Manager.
       - name: Credential Manager round trip
         run: >-
-          cargo test --target x86_64-pc-windows-msvc
+          cargo test --target x86_64-pc-windows-msvc --features keychain
           -p tidebreak-core --lib keychain --locked -- --ignored
 
   test:
@@ -717,10 +722,12 @@ jobs:
       # rerunning the whole workspace the way the old shell retry loop did.
       # nextest does not run doctests; the workspace has none, and one added
       # later must move its assertion into a unit test to be covered here.
+      - name: Check headless dependency graph
+        run: bash scripts/check-headless-dependencies.sh
       - name: headless tests
         run: >-
           cargo nextest run --workspace --exclude tidebreak-desktop
-          --locked --retries 2 --partition count:${{ matrix.part }}/3
+          --locked --retries 2 --partition count:${{ matrix.part }}/3 --no-default-features
 
   test-aggregate:
     name: test

--- a/crates/tidebreak-cli/Cargo.toml
+++ b/crates/tidebreak-cli/Cargo.toml
@@ -16,12 +16,17 @@ workspace = true
 name = "tidebreak"
 path = "src/main.rs"
 
+[features]
+default = ["keychain"]
+# Normal CLI builds share persistent desktop credentials. Self-host builds opt out.
+keychain = ["tidebreak-core/keychain", "tidebreak-server/keychain"]
+
 [dependencies]
 # `default-features = false`: the CLI directly needs config/contracts plus the
 # built-in file tools for `tidebreak mcp`. `sqlite` is on so `tidebreak folder`
 # can open the product store beside a running server without embedding one
-# (and without taking `tidebreak.lock`). Keychain and blob-fs still come only
-# through `tidebreak-server`.
+# (and without taking `tidebreak.lock`). The keychain feature owns credentials;
+# blob-fs comes through `tidebreak-server`.
 tidebreak-core = { path = "../tidebreak-core", default-features = false, features = ["tools", "sqlite"] }
 # `tidebreak folder …` decides local command reach exactly as the desktop does,
 # so an operator-provisioned folder carries the same grants on the same host.

--- a/crates/tidebreak-cli/src/setup.rs
+++ b/crates/tidebreak-cli/src/setup.rs
@@ -750,7 +750,7 @@ fn providers_json(providers: &[crate::api::wire::ProviderInfo]) -> Vec<serde_jso
         .collect()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "keychain"))]
 mod tests {
     use super::*;
     use tidebreak_core::Config;

--- a/crates/tidebreak-cli/tests/serve.rs
+++ b/crates/tidebreak-cli/tests/serve.rs
@@ -1,13 +1,19 @@
 //! End-to-end smoke test of the `tidebreak` process surface.
 
+#[cfg(feature = "keychain")]
 use std::io::{BufRead, BufReader, Read, Write};
+#[cfg(feature = "keychain")]
 use std::net::TcpStream;
-use std::process::{Child, Command, Stdio};
+#[cfg(feature = "keychain")]
+use std::process::Child;
+use std::process::{Command, Stdio};
 
 /// Kills the daemon on drop — including on an assertion panic, since
 /// `std::process::Child` does not reap on its own.
+#[cfg(feature = "keychain")]
 struct Reaper(Child);
 
+#[cfg(feature = "keychain")]
 impl Drop for Reaper {
     fn drop(&mut self) {
         self.0.kill().ok();
@@ -15,13 +21,16 @@ impl Drop for Reaper {
     }
 }
 
+#[cfg(feature = "keychain")]
 #[test]
 fn serve_announces_its_address_and_answers_health() {
     let dir = tempfile::tempdir().unwrap();
     let mut child = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
         .arg("serve")
+        .env("TIDEBREAK_PROFILE", "desktop")
         .env("TIDEBREAK_DATA_DIR", dir.path())
         .env("TIDEBREAK_KEYCHAIN_MOCK", "1")
+        .env_remove("TIDEBREAK_LISTEN_ADDR")
         .env_remove("TIDEBREAK_MCP_CONFIG")
         .env_remove("ANTHROPIC_API_KEY")
         .stdout(Stdio::piped())
@@ -56,4 +65,40 @@ fn serve_announces_its_address_and_answers_health() {
 
     assert!(response.contains("200 OK"), "response: {response}");
     assert!(response.trim_end().ends_with("ok"), "response: {response}");
+}
+
+/// A headless binary must reject desktop startup before it opens local storage.
+#[cfg(not(feature = "keychain"))]
+#[test]
+fn serve_without_keychain_rejects_desktop_before_opening_storage() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .arg("serve")
+        .env("TIDEBREAK_PROFILE", "desktop")
+        .env("TIDEBREAK_DATA_DIR", dir.path())
+        .env_remove("TIDEBREAK_LISTEN_ADDR")
+        .env_remove("TIDEBREAK_MCP_CONFIG")
+        .env_remove("TIDEBREAK_VAULT_ADDR")
+        .env_remove("TIDEBREAK_VAULT_TOKEN_FILE")
+        .env_remove("TIDEBREAK_VAULT_MOUNT")
+        .env_remove("TIDEBREAK_VAULT_PATH")
+        .env_remove("TIDEBREAK_VAULT_NAMESPACE")
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run headless tidebreak serve");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("keychain feature"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("TIDEBREAK_PROFILE=self_host"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "refused server must not announce a listener"
+    );
+    assert!(!dir.path().join("tidebreak.lock").exists());
+    assert!(!dir.path().join("tidebreak.db").exists());
 }

--- a/crates/tidebreak-core/Cargo.toml
+++ b/crates/tidebreak-core/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 workspace = true
 
 [features]
-default = ["sqlite", "keychain", "tools", "blob-fs"]
+default = ["sqlite", "tools", "blob-fs"]
 # The default SeaORM-backed Store with the SQLite driver. Turn off
 # (`default-features = false`) to depend on just the trait contracts.
 sqlite = [

--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -99,30 +99,35 @@ async fn append_event_inner(
                 session.id, session.kind
             ))
         })?;
-        // A session with no workspace mints no notification yet: the record
-        // names the workspace the turn ran in, and one without a workspace
-        // has nothing to name until the entity merge reshapes it.
-        if let Some(workspace_id) = session
-            .workspace_id
-            .map(WorkspaceId)
-            .filter(|_| crate::code_session_mints_notification(session_kind))
-        {
-            let workspace_title = entities::code_workspace::Entity::find_by_id(workspace_id.0)
-                .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
-                .one(&transaction)
-                .await
-                .map_err(store_err)?
-                .map(|workspace| workspace.title);
-            super::super::notification::record_code_turn_notification_on(
-                &transaction,
-                owner,
-                session_id,
-                workspace_id,
-                turn_id,
-                workspace_title.as_deref(),
-                kind,
-            )
-            .await?;
+        if crate::code_session_mints_notification(session_kind) {
+            if let Some(workspace_id) = session.workspace_id.map(WorkspaceId) {
+                let workspace_title = entities::code_workspace::Entity::find_by_id(workspace_id.0)
+                    .filter(entities::code_workspace::Column::Owner.eq(owner.as_str()))
+                    .one(&transaction)
+                    .await
+                    .map_err(store_err)?
+                    .map(|workspace| workspace.title);
+                super::super::notification::record_code_turn_notification_on(
+                    &transaction,
+                    owner,
+                    session_id,
+                    workspace_id,
+                    turn_id,
+                    workspace_title.as_deref(),
+                    kind,
+                )
+                .await?;
+            } else {
+                // Internal sessions open through the chat route. Share its
+                // dedupe key so a native terminal write cannot mint a second row.
+                super::super::notification::record_work_turn_notification_on(
+                    &transaction,
+                    session_id,
+                    turn_id,
+                    kind,
+                )
+                .await?;
+            }
         }
     }
     transaction.commit().await.map_err(store_err)?;

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -1767,6 +1767,75 @@ async fn a_terminal_code_event_mints_one_notification_in_its_transaction() {
     );
 }
 
+#[tokio::test]
+async fn a_workspace_less_terminal_event_uses_the_chat_notification_and_dedupe_key() {
+    let (_dir, store, session_id, turn_id) = seeded_session().await;
+    let owner = OwnerId::local();
+    entities::session::Entity::update_many()
+        .col_expr(
+            entities::session::Column::WorkspaceId,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::session::Column::HarnessKind,
+            sea_orm::sea_query::Expr::value("internal"),
+        )
+        .col_expr(
+            entities::session::Column::Title,
+            sea_orm::sea_query::Expr::value("Research notes"),
+        )
+        .filter(entities::session::Column::Id.eq(session_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    for (event, kind) in [
+        (
+            Event::TurnCompleted {
+                usage: Default::default(),
+                checkpoint: None,
+                stop_reason: None,
+            },
+            crate::NotificationKind::AgentCompleted,
+        ),
+        (
+            Event::TurnFailed {
+                error: crate::code::BoundedError {
+                    message: "provider failed".into(),
+                },
+                detail: None,
+            },
+            crate::NotificationKind::AgentFailed,
+        ),
+    ] {
+        append_event_with_notification(&store, &owner, session_id, 0, turn_id, &event)
+            .await
+            .unwrap();
+        store
+            .record_work_turn_notification(session_id, turn_id, kind)
+            .await
+            .unwrap();
+    }
+    let notifications = store
+        .list_notifications_scoped(&owner, None, 50)
+        .await
+        .unwrap();
+    assert_eq!(notifications.len(), 2);
+    for notification in notifications {
+        assert_eq!(
+            notification.context,
+            crate::NotificationContext::Chat {
+                chat_id: session_id
+            }
+        );
+        assert!(notification.title.starts_with("Research notes "));
+    }
+    assert!(store
+        .list_notifications_scoped(&OwnerId::new("other").unwrap(), None, 50)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
 /// Archive marks the row Ended without bumping spawn_epoch. A same-epoch
 /// worker persist of Running or Idle must not revive it, or a late write
 /// leaves an archived workspace with a live-looking session (and pid).

--- a/crates/tidebreak-desktop/Cargo.toml
+++ b/crates/tidebreak-desktop/Cargo.toml
@@ -29,6 +29,9 @@ test = false
 tauri-build = { version = "=2.6.3", features = [] }
 serde_json = { workspace = true }
 
+[features]
+default = ["tidebreak-server/keychain"]
+
 [dependencies]
 async-trait.workspace = true
 base64.workspace = true

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -160,6 +160,86 @@ afterEach(() => {
 });
 
 describe("CodeSidebar", () => {
+  it("opens a conversation without a workspace from its live rail row", async () => {
+    client.openCodeUpdates.mockImplementationOnce((onNotice) => {
+      queueMicrotask(() =>
+        onNotice({
+          type: "snapshot",
+          sessions: [
+            {
+              workspace: null,
+              session: "internal-1",
+              can_open_chat: true,
+              kind: "interactive",
+              harness_kind: "internal",
+              lifecycle: "running",
+              attention: { state: { type: "working" }, source: "lifecycle" },
+              title: "Research feedback",
+              turn_count: 1,
+            },
+          ],
+        }),
+      );
+      return {
+        close() {},
+        addEventListener() {},
+        removeEventListener() {},
+      } as unknown as WebSocket;
+    });
+    const { router } = await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Research feedback, Agent working",
+      }),
+    );
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/c/internal-1"),
+    );
+  });
+
+  it("does not link shared internal sessions to the owner-only chat route", async () => {
+    useCodeUpdatesStore.setState({
+      conversationsWithoutWorkspace: {
+        shared: {
+          workspace: null,
+          session: "shared",
+          can_open_chat: false,
+          kind: "interactive",
+          lifecycle: "running",
+          attention: { state: { type: "working" }, source: "lifecycle" },
+          title: "Shared conversation",
+          turn_count: 1,
+        },
+        legacy: {
+          workspace: null,
+          session: "legacy",
+          kind: "interactive",
+          lifecycle: "running",
+          attention: { state: { type: "working" }, source: "lifecycle" },
+          title: "Legacy conversation",
+          turn_count: 1,
+        },
+      },
+    });
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    expect(
+      screen.queryByRole("button", { name: /Shared conversation/ }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /Legacy conversation/ }),
+    ).toBeNull();
+  });
+
   it("renders the code rail without chat stores initialized", async () => {
     await renderWithRouter(
       <AppContextProvider value={app}>

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -32,6 +32,7 @@ import { FOCUS_RING, HOVER_TINT, RAIL_ICON_BUTTON } from "./interactive";
 import { findCodeTerminalTab } from "./codeChrome";
 import { canOpenLocalCodeWorktree } from "./codeWorktreeHost";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
+import { WorkspaceLessSessionRow } from "./WorkspaceLessSessionRow";
 import { RailSettingsMenu } from "./RailSettingsMenu";
 import {
   useWorkspaceCardCommands,
@@ -91,8 +92,14 @@ export function CodeSidebar() {
   const sessions = useCodeCatalogStore((state) => state.sessionsByWorkspace);
   const refresh = useCodeCatalogStore((state) => state.refresh);
   const digests = useWorkspaceDigests();
+  const conversationsWithoutWorkspace = useCodeUpdatesStore(
+    (state) => state.conversationsWithoutWorkspace,
+  );
   const childrenByWorkspace = useCodeUpdatesStore(
     (state) => state.childrenByWorkspace,
+  );
+  const chatConversations = Object.values(conversationsWithoutWorkspace).filter(
+    (digest) => digest.can_open_chat === true,
   );
   const newWorkspaceOpen = useCodeUiStore((state) => state.newWorkspaceOpen);
   const newWorkspaceRepoId = useCodeUiStore(
@@ -271,6 +278,25 @@ export function CodeSidebar() {
           }
         }}
       >
+        {chatConversations.length > 0 && (
+          <section aria-label="Conversations" className="flex flex-col gap-1">
+            <div className="px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground">
+              Conversations
+            </div>
+            {chatConversations.map((digest) => (
+              <WorkspaceLessSessionRow
+                key={digest.session}
+                digest={digest}
+                onOpen={(sessionId) =>
+                  void navigate({
+                    to: "/c/$chatId",
+                    params: { chatId: sessionId },
+                  })
+                }
+              />
+            ))}
+          </section>
+        )}
         {groups.map((group) => (
           <div
             key={group.key}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.test.ts
@@ -25,6 +25,7 @@ import {
   workspaceDigest,
   type CodeUpdatesState,
 } from "./CodeUpdatesStore";
+import { useRefreshSignals } from "../RefreshSignals";
 import { useCodeUiStore } from "./CodeUiStore";
 
 vi.mock("sonner", () => ({
@@ -56,6 +57,7 @@ function digest(overrides: Partial<CodeSessionDigest> = {}): CodeSessionDigest {
 
 const EMPTY_STATE: CodeUpdatesState = {
   conversationsByWorkspace: {},
+  conversationsWithoutWorkspace: {},
   childrenByWorkspace: {},
   cloneJobs: {},
   cloneTracking: {},
@@ -697,5 +699,70 @@ describe("turn rewrite notices", () => {
       sessions: [digest()],
     });
     expect(snapped.turnRewrites).toEqual({});
+  });
+});
+
+describe("conversations without a workspace", () => {
+  it("keeps snapshots and live settlements, and removes absent sessions on reconnect", () => {
+    const session = digest({ workspace: null, harness_kind: "internal" });
+    const snapshot = reduceCodeUpdates(EMPTY_STATE, {
+      type: "snapshot",
+      sessions: [session],
+    });
+    expect(snapshot.conversationsWithoutWorkspace[session.session]).toEqual(
+      session,
+    );
+    expect(snapshot.conversationsByWorkspace).toEqual({});
+    const settled = reduceCodeUpdates(snapshot, {
+      type: "digest",
+      digest: { ...session, lifecycle: "ended" },
+    });
+    expect(
+      settled.conversationsWithoutWorkspace[session.session].lifecycle,
+    ).toBe("ended");
+    expect(
+      reduceCodeUpdates(settled, { type: "snapshot", sessions: [] })
+        .conversationsWithoutWorkspace,
+    ).toEqual({});
+  });
+
+  it.each(["idle", "done_unreviewed", "needs_you"] as const)(
+    "refreshes notifications when a workspace-less turn settles as %s",
+    (state) => {
+      const before = useRefreshSignals.getState().notifications;
+      const session = digest({ workspace: null });
+      useCodeUpdatesStore
+        .getState()
+        .apply({ type: "snapshot", sessions: [session] });
+      useCodeUpdatesStore.getState().apply({
+        type: "digest",
+        digest: {
+          ...session,
+          attention: {
+            state:
+              state === "needs_you"
+                ? {
+                    type: state,
+                    prompt: "Provider failed",
+                    source: "structured",
+                  }
+                : { type: state },
+            source: "lifecycle",
+          },
+        },
+      });
+      expect(useRefreshSignals.getState().notifications).toBe(before + 1);
+    },
+  );
+
+  it("never promotes workspace-less watches into conversation rows", () => {
+    const watch = digest({ workspace: null, kind: "watch" });
+    expect(
+      reduceCodeUpdates(EMPTY_STATE, { type: "snapshot", sessions: [watch] })
+        .conversationsWithoutWorkspace,
+    ).toEqual({});
+    expect(
+      reduceCodeUpdates(EMPTY_STATE, { type: "digest", digest: watch }),
+    ).toEqual(EMPTY_STATE);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -65,6 +65,8 @@ export type CodeUpdatesState = {
    * conversation tabs.
    */
   conversationsByWorkspace: DigestsByWorkspace;
+  /** Conversations that open through the chat route. */
+  conversationsWithoutWorkspace: Record<string, CodeSessionDigest>;
   /**
    * Watch digests, keyed workspace → session. Children beside the
    * conversations, never among them — ADR 0050's rule, kept by construction:
@@ -128,6 +130,7 @@ export type CodeUpdatesAction =
 
 const EMPTY: CodeUpdatesState = {
   conversationsByWorkspace: {},
+  conversationsWithoutWorkspace: {},
   childrenByWorkspace: {},
   cloneJobs: {},
   cloneTracking: {},
@@ -152,23 +155,40 @@ export function reduceCodeUpdates(
       // rewriting onto a turn snapshot that already stored the rewrite.
       const conversationsByWorkspace: DigestsByWorkspace = {};
       const childrenByWorkspace: DigestsByWorkspace = {};
+      const conversationsWithoutWorkspace: Record<string, CodeSessionDigest> =
+        {};
       for (const digest of action.sessions) {
         const map =
           digest.kind === "watch"
             ? childrenByWorkspace
             : conversationsByWorkspace;
-        // A digest for a session with no workspace has no rail row yet.
-        if (digest.workspace === null) continue;
+        if (digest.workspace === null) {
+          if (digest.kind !== "watch") {
+            conversationsWithoutWorkspace[digest.session] = digest;
+          }
+          continue;
+        }
         (map[digest.workspace] ??= {})[digest.session] = digest;
       }
       return {
         ...state,
         conversationsByWorkspace,
+        conversationsWithoutWorkspace,
         childrenByWorkspace,
         turnRewrites: {},
       };
     }
     case "digest": {
+      if (action.digest.workspace === null) {
+        if (action.digest.kind === "watch") return state;
+        return {
+          ...state,
+          conversationsWithoutWorkspace: {
+            ...state.conversationsWithoutWorkspace,
+            [action.digest.session]: action.digest,
+          },
+        };
+      }
       if (action.digest.kind === "watch") {
         return {
           ...state,
@@ -838,12 +858,18 @@ function maybeBumpAgentNotifications(
   previous: CodeUpdatesState,
   digest: CodeSessionDigest,
 ): void {
-  if (digest.kind === "watch" || digest.workspace === null) return;
-  const prior =
-    previous.conversationsByWorkspace[digest.workspace]?.[digest.session]
-      ?.attention;
+  if (digest.kind === "watch") return;
+  const prior = (
+    digest.workspace === null
+      ? previous.conversationsWithoutWorkspace[digest.session]
+      : previous.conversationsByWorkspace[digest.workspace]?.[digest.session]
+  )?.attention;
   const wasWorking = prior?.state.type === "working";
-  const settled = digest.attention.state.type === "idle";
+  const settled =
+    digest.attention.state.type === "idle" ||
+    digest.attention.state.type === "done_unreviewed" ||
+    (digest.lifecycle !== "running" &&
+      digest.attention.state.type === "needs_you");
   if (wasWorking && settled) {
     useRefreshSignals.getState().signal("notifications");
   }

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -889,7 +889,7 @@ function WorkspaceActivityLine({
  * that is alive but parked on something else: a bot for subagents and a
  * radar for a monitor, both in the live tone with the live pulse.
  */
-function SessionStateGlyph({
+export function SessionStateGlyph({
   digest,
   pr,
 }: {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceLessSessionRow.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceLessSessionRow.tsx
@@ -1,0 +1,41 @@
+import type { CodeSessionDigest } from "../api/types";
+import { cn } from "../lib/utils";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
+import { SessionStateGlyph } from "./WorkspaceCard";
+import { sessionRowLabel } from "./workspaceCards";
+
+/** An index row for a conversation that has no repository workspace. */
+export function WorkspaceLessSessionRow({
+  digest,
+  onOpen,
+}: {
+  digest: CodeSessionDigest;
+  onOpen: (sessionId: string) => void;
+}) {
+  const title = digest.title?.trim() || "Untitled conversation";
+  const status = sessionRowLabel(digest);
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full min-w-0 cursor-pointer items-start gap-2 rounded-md px-2.5 py-2 text-left hover:bg-muted",
+        FOCUS_RING,
+        HOVER_TINT,
+      )}
+      aria-label={`${title}, ${status}`}
+      onClick={() => onOpen(digest.session)}
+    >
+      <span className="mt-1 shrink-0">
+        <SessionStateGlyph digest={digest} />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate text-sm" title={title}>
+          {title}
+        </span>
+        <span className="truncate text-xs text-muted-foreground" title={status}>
+          {status}
+        </span>
+      </span>
+    </button>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -928,6 +928,16 @@ describe("pull request state in live updates", () => {
     ).toEqual({ type: "snapshot", sessions: [digest] });
   });
 
+  it("preserves chat-route availability and rejects malformed values", () => {
+    for (const can_open_chat of [true, false]) {
+      const input = { ...digest, workspace: null, can_open_chat };
+      expect(parseCodeSessionDigest(input)).toEqual(input);
+    }
+    expect(
+      parseCodeSessionDigest({ ...digest, can_open_chat: "true" }),
+    ).toBeNull();
+  });
+
   it("keeps a digest whose session binds no workspace", () => {
     const orphan = { ...digest, workspace: null };
     expect(parseCodeSessionDigest(orphan)).toEqual(orphan);

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -4353,6 +4353,7 @@ export function parseCodeSessionDigest(
     !isRecord(value) ||
     !onlyKeys<WireCodeSessionDigest>(value, [
       "workspace",
+      "can_open_chat",
       "session",
       "kind",
       "harness_kind",
@@ -4373,6 +4374,8 @@ export function parseCodeSessionDigest(
       "recap",
     ]) ||
     !nullableWireId(value.workspace) ||
+    (value.can_open_chat !== undefined &&
+      typeof value.can_open_chat !== "boolean") ||
     !wireId(value.session) ||
     !isMember(value.kind, SESSION_KINDS) ||
     (value.harness_kind !== undefined &&
@@ -4405,6 +4408,9 @@ export function parseCodeSessionDigest(
   if (value.subagents !== undefined && !subagents) return null;
   return {
     workspace: value.workspace,
+    ...(value.can_open_chat !== undefined
+      ? { can_open_chat: value.can_open_chat }
+      : {}),
     session: value.session,
     kind: value.kind,
     ...(value.harness_kind !== undefined

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -4800,7 +4800,11 @@ export type SessionDigest = {
 /**
  * `None` for a session that binds no workspace.
  */
-workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
+workspace: WorkspaceId | null,
+/**
+ * Whether this viewer can open the owner-scoped chat route.
+ */
+can_open_chat?: boolean, session: SessionId, kind: SessionKind,
 /**
  * Engine identity for list surfaces that collapse several sessions into
  * one workspace row. Optional on the wire so a desktop can still read a

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceLessSessionRow.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceLessSessionRow.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { WorkspaceLessSessionRow } from "../code/WorkspaceLessSessionRow";
+import {
+  idleCompleteDigest,
+  needsYouDigest,
+  runningDigest,
+  stalledDigest,
+} from "./fixtures";
+
+const meta = {
+  title: "Code/Conversation without workspace",
+  component: WorkspaceLessSessionRow,
+  args: {
+    digest: {
+      ...runningDigest,
+      workspace: null,
+      harness_kind: "internal",
+      title: "Research product feedback",
+    },
+    onOpen: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-72 max-w-full bg-sidebar p-2">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WorkspaceLessSessionRow>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Running: Story = {
+  play: async ({ canvasElement, args }) => {
+    await userEvent.click(within(canvasElement).getByRole("button"));
+    await expect(args.onOpen).toHaveBeenCalledWith(args.digest.session);
+  },
+};
+export const Completed: Story = {
+  args: {
+    digest: {
+      ...idleCompleteDigest,
+      workspace: null,
+      title: "Research product feedback",
+    },
+  },
+};
+export const NeedsYou: Story = {
+  args: {
+    digest: { ...needsYouDigest, workspace: null, title: "Review the draft" },
+  },
+};
+export const Failed: Story = {
+  args: {
+    digest: {
+      ...stalledDigest,
+      workspace: null,
+      title: "Research product feedback",
+    },
+  },
+};
+export const LongTitle: Story = {
+  args: {
+    digest: {
+      ...runningDigest,
+      workspace: null,
+      title:
+        "Compare the customer feedback across every release and identify the most common requests",
+    },
+  },
+};
+export const Untitled: Story = {
+  args: { digest: { ...runningDigest, workspace: null, title: "" } },
+};

--- a/crates/tidebreak-server-api/Cargo.toml
+++ b/crates/tidebreak-server-api/Cargo.toml
@@ -15,6 +15,8 @@ doctest = false
 workspace = true
 
 [features]
+# Desktop credential storage is enabled by the embedding client.
+keychain = ["tidebreak-core/keychain", "tidebreak-server-core/keychain"]
 postgres = ["tidebreak-server-core/postgres"]
 
 [dependencies]

--- a/crates/tidebreak-server-api/src/tests.rs
+++ b/crates/tidebreak-server-api/src/tests.rs
@@ -81,6 +81,7 @@ mod documents;
 mod gateway_drafts;
 mod image_attachment;
 mod lifecycle;
+#[cfg(feature = "keychain")]
 mod listener;
 mod memory;
 mod outputs;

--- a/crates/tidebreak-server-api/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server-api/src/wire_code_fixtures.rs
@@ -239,6 +239,7 @@ fn queued_turn() -> QueuedTurn {
 
 fn digest() -> SessionDigest {
     SessionDigest {
+        can_open_chat: None,
         workspace: Some(workspace_id()),
         session: session_id(),
         kind: SessionKind::Interactive,
@@ -268,6 +269,7 @@ fn digest() -> SessionDigest {
 /// The in-process engine's session binds no workspace (decision 0048 step 5).
 fn internal_digest() -> SessionDigest {
     SessionDigest {
+        can_open_chat: None,
         workspace: None,
         session: SessionId(id(0x22)),
         harness_kind: Some(HarnessKind::Internal),

--- a/crates/tidebreak-server-api/tests/postgres_store_ownership.rs
+++ b/crates/tidebreak-server-api/tests/postgres_store_ownership.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use sea_orm::sqlx::{Connection, PgConnection};
-use tidebreak_core::{Config, KeychainSecretProvider, Profile};
+use tidebreak_core::{Config, Profile};
 
 const ADMIN_TOKEN: &str = "store-owner-test-token-padded-to-32";
 const OWNERSHIP_APPLICATION_NAME: &str = "tidebreak-store-owner";
@@ -52,7 +52,6 @@ async fn postgres_store_ownership_is_exclusive_and_outlives_a_dead_owner() {
         Err(_) => return,
     };
     let _database_url = EnvRestore::set("TIDEBREAK_DATABASE_URL", &url);
-    KeychainSecretProvider::use_mock();
 
     let first_dir = tempfile::tempdir().expect("first data dir");
     let second_dir = tempfile::tempdir().expect("second data dir");

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -15,6 +15,8 @@ doctest = false
 workspace = true
 
 [features]
+# Desktop credential storage is enabled by the embedding client.
+keychain = ["tidebreak-core/keychain"]
 # Compile the PostgreSQL driver in, so a self-host boot can open the store
 # `TIDEBREAK_DATABASE_URL` names. Off by default: the desktop profile is
 # SQLite-only and the driver is a heavy build-time dependency.
@@ -30,13 +32,7 @@ tidebreak-code-delivery = { path = "../tidebreak-code-delivery" }
 tidebreak-code-remote = { path = "../tidebreak-code-remote" }
 tidebreak-harness = { path = "../tidebreak-harness" }
 tidebreak-managed-node = { path = "../tidebreak-managed-node" }
-# Default features on purpose: the server wants exactly core's default set
-# (`sqlite`, `tools`, `keychain`, `blob-fs`), and asking for the parts with
-# `default-features = false` would drop the `default` pseudo-feature that a
-# `--workspace` build (where core is its own build root) turns on — producing
-# a second, byte-identical core rlib. Leaner dependents still say
-# `default-features = false`; feature unification ORs `default` back in
-# whenever the server is in the graph.
+# Core defaults provide SQLite, tools, and local blobs without an OS keychain.
 tidebreak-core = { path = "../tidebreak-core" }
 tidebreak-egress = { path = "../tidebreak-egress" }
 tidebreak-gateway-runtime = { path = "../tidebreak-gateway-runtime" }

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -18,7 +18,7 @@ use tidebreak_core::db::code::{
 use tidebreak_core::{
     preview_formatting_character, ApprovalState, Attention, AttentionSource, AttentionState,
     CodeSubagentStatus, DbStore, Event, OwnerId, Session, SessionActivity, SessionId, SessionKind,
-    SessionLifecycle, ToolDetail, TurnStatus, WorkspaceId,
+    SessionLifecycle, Store, ToolDetail, TurnStatus, WorkspaceId,
 };
 
 use super::bus::{CodeEventBus, CodeLiveUpdate, SessionDigest};
@@ -368,7 +368,9 @@ pub async fn emit_digest(db: &DbStore, bus: &CodeEventBus, session: &Session) {
         }
     };
     for reader in digest_readers(db, bus, session).await {
-        bus.publish_update(&reader, CodeLiveUpdate::Digest(Box::new(digest.clone())));
+        let mut visible = digest.clone();
+        visible.can_open_chat &= reader == session.owner;
+        bus.publish_update(&reader, CodeLiveUpdate::Digest(Box::new(visible)));
     }
 }
 
@@ -447,7 +449,9 @@ pub async fn list_accessible_digests(
     let mut out = Vec::new();
     for session in tidebreak_core::db::code::list_accessible_sessions(db, principal).await? {
         if session.lifecycle != SessionLifecycle::Ended {
-            out.push(build_digest(db, &session).await?);
+            let mut digest = build_digest(db, &session).await?;
+            digest.can_open_chat &= principal == &session.owner;
+            out.push(digest);
         }
     }
     Ok(out)
@@ -525,14 +529,21 @@ async fn build_digest(
     } else {
         turns.into_iter().rev().find_map(|turn| turn.narrative)
     };
-    // A session with no workspace is titled by its conversation, which
-    // nothing names yet; the client falls back to its own label.
+    // Internal sessions share their title with the chat route.
     let (title, pr_state) = match workspace {
         Some(workspace) => (workspace.title, workspace.pr),
-        None => (String::new(), None),
+        None => (
+            db.get_chat_scoped(&session.owner, session.id)
+                .await?
+                .and_then(|chat| chat.title)
+                .unwrap_or_default(),
+            None,
+        ),
     };
     Ok(SessionDigest {
         workspace: session.workspace_id,
+        can_open_chat: session.workspace_id.is_none()
+            && session.harness_kind == tidebreak_core::HarnessKind::Internal,
         session: session.id,
         kind: session.kind,
         harness_kind: session.harness_kind,
@@ -752,6 +763,79 @@ mod tests {
     use tidebreak_core::{
         should_replace, CodeSubagentSummary, FenceReason, SessionKind, ToolOutcome, WorkspaceId,
     };
+
+    #[tokio::test]
+    async fn workspace_less_digest_uses_its_conversation_title() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("digest.db").display()
+        ))
+        .await
+        .unwrap();
+        let mut session = session_with(auto_working());
+        session.workspace_id = None;
+        session.harness_kind = tidebreak_core::HarnessKind::Internal;
+        tidebreak_core::db::code::insert_session(&db, &session)
+            .await
+            .unwrap();
+        db.set_chat_title(session.id, Some("Research notes".into()))
+            .await
+            .unwrap();
+        let digest = build_digest(&db, &session).await.unwrap();
+        assert_eq!(digest.title, "Research notes");
+        assert_eq!(digest.workspace, None);
+        assert_eq!(digest.session, session.id);
+        assert!(digest.can_open_chat);
+        let reader = OwnerId::new("reader").unwrap();
+        tidebreak_core::db::code::grant_session_access(
+            &db,
+            &session.owner,
+            session.id,
+            "principal:reader",
+            tidebreak_core::SessionAccessLevel::View,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(list_accessible_digests(&db, &session.owner).await.unwrap()[0].can_open_chat);
+        let shared = list_accessible_digests(&db, &reader).await.unwrap();
+        assert_eq!(shared.len(), 1);
+        assert!(!shared[0].can_open_chat);
+        let bus = CodeEventBus::default();
+        let mut owner_updates = bus.subscribe_updates(&session.owner);
+        let mut reader_updates = bus.subscribe_updates(&reader);
+        emit_digest(&db, &bus, &session).await;
+        assert!(
+            matches!(owner_updates.try_recv().unwrap(), CodeLiveUpdate::Digest(digest) if digest.can_open_chat)
+        );
+        assert!(
+            matches!(reader_updates.try_recv().unwrap(), CodeLiveUpdate::Digest(digest) if !digest.can_open_chat)
+        );
+        session.visibility = tidebreak_core::SessionVisibility::Deployment;
+        tidebreak_core::db::code::set_session_visibility(
+            &db,
+            &session.owner,
+            session.id,
+            session.visibility,
+        )
+        .await
+        .unwrap();
+        let public_reader = OwnerId::new("public-reader").unwrap();
+        let public = list_accessible_digests(&db, &public_reader).await.unwrap();
+        assert_eq!(public.len(), 1);
+        assert!(!public[0].can_open_chat);
+        let mut public_updates = bus.subscribe_updates(&public_reader);
+        emit_digest(&db, &bus, &session).await;
+        assert!(
+            matches!(public_updates.try_recv().unwrap(), CodeLiveUpdate::Digest(digest) if !digest.can_open_chat)
+        );
+
+        let mut foreign = session.clone();
+        foreign.owner = OwnerId::new("other").unwrap();
+        assert_eq!(build_digest(&db, &foreign).await.unwrap().title, "");
+    }
 
     fn auto_working() -> Attention {
         Attention::working(AttentionSource::Lifecycle)

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -49,6 +49,8 @@ const UPDATES_BUFFER: usize = 256;
 pub struct SessionDigest {
     /// `None` for a session that binds no workspace.
     pub workspace: Option<WorkspaceId>,
+    /// Whether this viewer can open the owner-scoped chat route.
+    pub can_open_chat: bool,
     pub session: SessionId,
     pub kind: SessionKind,
     /// Engine identity for list surfaces that collapse several sessions into

--- a/crates/tidebreak-server/src/code/types.rs
+++ b/crates/tidebreak-server/src/code/types.rs
@@ -1783,6 +1783,10 @@ pub struct CodeTerminalActivityNotice {
 pub struct SessionDigest {
     /// `None` for a session that binds no workspace.
     pub workspace: Option<WorkspaceId>,
+    /// Whether this viewer can open the owner-scoped chat route.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub can_open_chat: Option<bool>,
     pub session: tidebreak_core::SessionId,
     pub kind: SessionKind,
     /// Engine identity for list surfaces that collapse several sessions into
@@ -1850,6 +1854,7 @@ impl From<crate::code::bus::SessionDigest> for SessionDigest {
     fn from(digest: crate::code::bus::SessionDigest) -> Self {
         Self {
             workspace: digest.workspace,
+            can_open_chat: Some(digest.can_open_chat),
             session: digest.session,
             kind: digest.kind,
             harness_kind: Some(digest.harness_kind),

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -193,9 +193,11 @@ use tidebreak_core::{
     validate_write_output_to_connected_folder_arguments,
     write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, ApprovalClass, BlobStore,
     BundledSecretProvider, CachingSecretProvider, Config, CreateAppTool, DbStore, FsBlobStore,
-    KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool,
-    ToolRegistry, WriteFile,
+    ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
 };
+
+#[cfg(feature = "keychain")]
+use tidebreak_core::KeychainSecretProvider;
 
 /// Public contract for desktop browser adapters. The desktop implements
 /// [`BrowserRuntime`] behind an `Arc` and installs it with
@@ -856,8 +858,9 @@ async fn bind_configured_with_desktop_executor_and_folder_grants_and_browser_par
 /// restart. Its misses re-ask the store instead; an absent item answers
 /// `NoEntry` without an ACL prompt, so the slow-path rereads are cheap.
 enum CredentialStoragePlan {
+    #[cfg(feature = "keychain")]
     Desktop(Option<String>),
-    Vault(vault_secrets::ValidatedVaultConfig),
+    Vault(Box<vault_secrets::ValidatedVaultConfig>),
     UnavailableSelfHost,
 }
 
@@ -868,13 +871,18 @@ fn credential_storage_plan(config: &Config) -> Result<CredentialStoragePlan> {
         ));
     }
     match config.profile {
+        #[cfg(feature = "keychain")]
         Profile::Desktop => Ok(CredentialStoragePlan::Desktop(
             config.keychain_service.clone(),
         )),
+        #[cfg(not(feature = "keychain"))]
+        Profile::Desktop => Err(AgentError::config(
+            "the desktop profile requires a build with the keychain feature; use TIDEBREAK_PROFILE=self_host for a headless build",
+        )),
         Profile::SelfHost => match &config.vault_secrets {
-            Some(vault) => Ok(CredentialStoragePlan::Vault(
+            Some(vault) => Ok(CredentialStoragePlan::Vault(Box::new(
                 vault_secrets::VaultSecretProvider::validate(vault)?,
-            )),
+            ))),
             None => Ok(CredentialStoragePlan::UnavailableSelfHost),
         },
         _ => Err(AgentError::config(
@@ -885,12 +893,13 @@ fn credential_storage_plan(config: &Config) -> Result<CredentialStoragePlan> {
 
 fn secret_provider(plan: CredentialStoragePlan) -> ProfileSecrets {
     let storage: Arc<dyn SecretProvider> = match plan {
+        #[cfg(feature = "keychain")]
         CredentialStoragePlan::Desktop(keychain_service) => Arc::new(match keychain_service {
             Some(service) => KeychainSecretProvider::with_service(service),
             None => KeychainSecretProvider::new(),
         }),
         CredentialStoragePlan::Vault(config) => {
-            Arc::new(vault_secrets::VaultSecretProvider::new(config))
+            Arc::new(vault_secrets::VaultSecretProvider::new(*config))
         }
         CredentialStoragePlan::UnavailableSelfHost => {
             Arc::new(vault_secrets::UnavailableSelfHostSecretProvider)
@@ -982,6 +991,20 @@ mod profile_secret_tests {
             .to_string();
         assert!(error.contains("desktop profile"));
         assert!(error.contains("OS keychain"));
+    }
+
+    #[cfg(not(feature = "keychain"))]
+    #[test]
+    fn headless_build_rejects_desktop_before_opening_storage() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = Config::desktop(directory.path());
+        let error = match credential_storage_plan(&config) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("headless build accepted desktop credentials"),
+        };
+        assert!(error.contains("keychain feature"));
+        assert!(error.contains("TIDEBREAK_PROFILE=self_host"));
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 0);
     }
 
     #[test]

--- a/deploy/self-host/Dockerfile
+++ b/deploy/self-host/Dockerfile
@@ -73,15 +73,13 @@ ARG CARGO_PROFILE=release
 # Debug info is dead weight in a container and triples the dev binary.
 ENV CARGO_PROFILE_DEV_DEBUG=0
 
-# `--features tidebreak-server/postgres` reaches through the CLI into the
-# server crate's feature, because the feature lives there and the CLI takes
-# tidebreak-server with default features. Without it the self-host boot has no
-# PostgreSQL driver compiled in. The binary lands in `/out` so the runtime
-# stage copies one path whichever profile built it (cargo writes `dev` to
-# `target/debug`).
+# PostgreSQL and object storage support come from the server's postgres feature.
+# Disable CLI defaults to exclude desktop credential storage from this image.
+# The binary lands in `/out` so the runtime stage copies one path whichever
+# profile built it (cargo writes `dev` to `target/debug`).
 RUN set -eu; \
     cargo build --profile "${CARGO_PROFILE}" --locked -p tidebreak-cli -p tidebreak-supervised-agent \
-        --features tidebreak-server/postgres; \
+        --no-default-features --features tidebreak-server/postgres; \
     case "${CARGO_PROFILE}" in dev) target_dir=debug ;; *) target_dir="${CARGO_PROFILE}" ;; esac; \
     install -D "target/${target_dir}/tidebreak" /out/tidebreak; \
     install -D "target/${target_dir}/tidebreak-supervised-agent" /out/tidebreak-supervised-agent

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -11,6 +11,11 @@ This guide covers running that deployment from the packaging in
 `deploy/self-host/`. It describes only behavior verified in the code on this
 branch; where something is not built yet, it says so.
 
+The self-host Docker image builds the CLI with `--no-default-features` and
+`tidebreak-server/postgres`. It excludes the OS keychain and its Linux D-Bus
+dependencies. Standard CLI and desktop builds keep persistent OS credentials.
+A build without `keychain` refuses the desktop profile at startup.
+
 ## What the self-host profile is
 
 Selecting `TIDEBREAK_PROFILE=self_host` changes five things about the server:

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -4800,7 +4800,11 @@ export type SessionDigest = {
 /**
  * `None` for a session that binds no workspace.
  */
-workspace: WorkspaceId | null, session: SessionId, kind: SessionKind,
+workspace: WorkspaceId | null,
+/**
+ * Whether this viewer can open the owner-scoped chat route.
+ */
+can_open_chat?: boolean, session: SessionId, kind: SessionKind,
 /**
  * Engine identity for list surfaces that collapse several sessions into
  * one workspace row. Optional on the wire so a desktop can still read a

--- a/scripts/check-headless-dependencies.sh
+++ b/scripts/check-headless-dependencies.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Keep the self-host image and headless CI free of desktop credential backends.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+check_graph() {
+    local label="$1"
+    shift
+    local graph
+    graph=$(cargo tree --locked --target x86_64-unknown-linux-gnu --prefix none "$@")
+    if [[ -z "$graph" ]]; then
+        echo "$label returned an empty dependency graph" >&2
+        return 1
+    fi
+    local forbidden
+    forbidden=$(printf '%s\n' "$graph" | grep -E '^(keyring|secret-service|zbus|async-executor|async-io) v' || true)
+    if [[ -n "$forbidden" ]]; then
+        printf '%s includes desktop credential dependencies:\n%s\n' "$label" "$forbidden" >&2
+        return 1
+    fi
+    echo "$label excludes desktop credential dependencies"
+}
+
+check_graph "Self-host image" -p tidebreak-cli -p tidebreak-supervised-agent \
+    --no-default-features --features tidebreak-server/postgres
+check_graph "Headless tests" --workspace --exclude tidebreak-desktop --no-default-features
+
+# Desktop clients must keep the persistent backend and the server boot path.
+for client in tidebreak-cli tidebreak-desktop; do
+    graph=$(cargo tree --locked --target x86_64-unknown-linux-gnu -p "$client" \
+        --prefix none --format '{p} {f}')
+    if ! grep -Eq '^keyring v' <<<"$graph" || \
+       ! grep -Eq '^tidebreak-server-core v.* keychain(,|$)' <<<"$graph"; then
+        echo "$client must enable persistent keychain storage in the server" >&2
+        exit 1
+    fi
+    echo "$client retains persistent keychain storage"
+done

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -558,7 +558,7 @@ test("PR lanes are scope-gated, never label-gated", () => {
   );
   assert.match(
     testPartitions,
-    /cargo nextest run --workspace --exclude tidebreak-desktop\n\s+--locked --retries 2 --partition count:\$\{\{ matrix\.part \}\}\/3/,
+    /cargo nextest run --workspace --exclude tidebreak-desktop\n\s+--locked --retries 2 --partition count:\$\{\{ matrix\.part \}\}\/3 --no-default-features/,
   );
   assert.match(testAggregate, /name: test\n/);
   assert.match(testAggregate, /needs: \[changes, test\]/);


### PR DESCRIPTION
Sessions without a workspace now appear in the Code rail and refresh notifications when a turn finishes. Self-host builds and headless CI no longer pull in Linux keychain dependencies.

Implementation:
- Reuse chat notification routing and the existing turn dedupe key. Retain standalone session digests and conversation titles in the rail.
- Compute chat access per viewer for snapshots and live updates, so shared sessions do not link to an owner-only chat route.
- Make keychain support explicit in the server, retain it by default in CLI and desktop builds, and exclude it from the self-host image and headless tests. Move credential tests into desktop CI and add a Linux dependency graph guard.

Compatibility and risk: can_open_chat is optional on the wire; older payloads remain readable. No database migration. Default CLI and desktop credential storage remains persistent. Builds without keychain reject the desktop profile before opening storage. Linux compilation runs in CI; local Rust validation ran on macOS.

Validation: focused notification and viewer-access Rust regressions pass; generated bindings and mobile sync pass; TypeScript and 145 UI tests pass; Storybook builds, with workspace-less states inspected across four themes and desktop/narrow widths. Dependency graph assertions and all 49 workflow policy tests pass. Formatting and diff checks pass. Prior focused profile-secret tests, server clippy, and desktop compilation also pass.

Closes #3015
Closes #3139

#3198 already shipped independently in #3246.