### PR TITLE
test(slack): restore the headless E2E fixture smoke check

### DIFF
--- a/.github/workflows/publish-e2e-image.yml
+++ b/.github/workflows/publish-e2e-image.yml
@@ -66,7 +66,9 @@ jobs:
         run: |
           set +e
           output="$(docker run --rm --entrypoint /usr/local/bin/tidebreak \
-            -e TIDEBREAK_PROFILE=desktop -e TIDEBREAK_LISTEN_ADDR= \
+            -e TIDEBREAK_PROFILE=self_host \
+            -e TIDEBREAK_BLOB_STORE_URL=s3://fixture/test \
+            -e TIDEBREAK_DATABASE_URL=postgres://fixture@127.0.0.1:1/fixture \
             -e TIDEBREAK_SCRIPTED_HARNESS='{not json' \
             "$E2E_REPOSITORY:sha-${GITHUB_SHA::12}" serve 2>&1)"
           status=$?

--- a/crates/tidebreak-cli/tests/serve.rs
+++ b/crates/tidebreak-cli/tests/serve.rs
@@ -102,3 +102,33 @@ fn serve_without_keychain_rejects_desktop_before_opening_storage() {
     assert!(!dir.path().join("tidebreak.lock").exists());
     assert!(!dir.path().join("tidebreak.db").exists());
 }
+
+/// The fixture verifies its debug engine without opening self-host storage.
+#[cfg(debug_assertions)]
+#[test]
+fn malformed_script_refuses_self_host_before_opening_storage() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_tidebreak"))
+        .arg("serve")
+        .env_clear()
+        .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+        .env("TIDEBREAK_PROFILE", "self_host")
+        .env("TIDEBREAK_DATA_DIR", dir.path())
+        .env("TIDEBREAK_BLOB_STORE_URL", "s3://fixture/test")
+        .env(
+            "TIDEBREAK_DATABASE_URL",
+            "postgres://fixture@127.0.0.1:1/fixture",
+        )
+        .env("TIDEBREAK_SCRIPTED_HARNESS", "{not json")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run self-host fixture smoke check");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("TIDEBREAK_SCRIPTED_HARNESS is not a valid script"),
+        "stderr: {stderr}"
+    );
+    assert!(!dir.path().join("tidebreak.lock").exists());
+    assert!(!dir.path().join("tidebreak.db").exists());
+}

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1053,6 +1053,10 @@ async fn bind_inner(
     // reading a secret. Keep it before the lock and database so an invalid
     // Vault address leaves no local or shared resources open.
     let credential_storage = credential_storage_plan(&config)?;
+    // Parse the debug-only test engine before opening storage. Fixture smoke
+    // checks must reject a malformed script without a database or credentials.
+    #[cfg(debug_assertions)]
+    let scripted_adapter = scripted_harness::adapter_from_env()?;
     let ProfileSecrets {
         bundle: secret_bundle,
         provider: secrets,
@@ -1360,7 +1364,9 @@ async fn bind_inner(
     // publishes reaches the session's channel too.
     state.events.mirror_into(runtime.bus.clone());
     #[cfg(debug_assertions)]
-    scripted_harness::install_from_env(&mut runtime.adapters)?;
+    if let Some(adapter) = scripted_adapter {
+        runtime.adapters.register(Arc::new(adapter));
+    }
     // Remote sessions need both halves: the configured runtime endpoint and
     // a gateway to mint owner-scoped tokens through. Half a configuration is
     // a boot error, not a silently local deployment.

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -17,9 +17,9 @@ use tidebreak_core::{
 };
 use tidebreak_harness::child::ChildPid;
 use tidebreak_harness::{
-    AdapterRegistry, ApprovalCompleter, ApprovalDecision, HarnessAdapter, HarnessApprovalRef,
-    HarnessError, HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession, HostEnv,
-    ListedHarnessModel, ParkWait, ResumeInput, SessionSpec, TurnInput, TurnOutcome,
+    ApprovalCompleter, ApprovalDecision, HarnessAdapter, HarnessApprovalRef, HarnessError,
+    HarnessEvent, HarnessEventSink, HarnessProbe, HarnessSession, HostEnv, ListedHarnessModel,
+    ParkWait, ResumeInput, SessionSpec, TurnInput, TurnOutcome,
 };
 use tokio::sync::{oneshot, watch};
 
@@ -899,17 +899,6 @@ pub(crate) fn adapter_from_env() -> Result<Option<ScriptedAdapter>> {
     }
     adapter.writes = parsed.writes;
     Ok(Some(adapter))
-}
-
-/// Install the env-driven scripted engine in place of the matching built-in,
-/// so a spawned `tidebreak serve` can drive code-mode turns without a real
-/// harness binary.
-#[cfg_attr(test, allow(dead_code))]
-pub(crate) fn install_from_env(registry: &mut AdapterRegistry) -> Result<()> {
-    if let Some(adapter) = adapter_from_env()? {
-        registry.register(Arc::new(adapter));
-    }
-    Ok(())
 }
 
 #[cfg_attr(test, allow(dead_code))]


### PR DESCRIPTION
The E2E image builds successfully but its smoke check starts the headless binary in desktop mode, which fails on the keychain requirement before testing the scripted engine. Run the smoke check in self-host mode and parse the debug-only script before opening storage.

The scripted adapter still registers at the same point in runtime assembly. Release binaries remain unaffected because this path is compiled only with debug assertions.

Validation: `cargo test -p tidebreak-cli --no-default-features --test serve malformed_script_refuses_self_host_before_opening_storage` passes (1 test). Formatting and `git diff --check` pass. The existing macOS large unwind-table warning remains.

Supports the Slack adapter real-machine lane in brightwave-inc/model-gateway#1865.