### PR TITLE
improve(slack): resolve registered repositories before starting sessions

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/repo.rs
+++ b/crates/tidebreak-core/src/db/ops/code/repo.rs
@@ -185,6 +185,7 @@ pub async fn set_repo_origin(
         )
         .filter(entities::code_repo::Column::Id.eq(id.0))
         .filter(entities::code_repo::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_repo::Column::RemovedAt.is_null())
         .exec(&store.conn)
         .await
         .map_err(store_err)?;

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -290,6 +290,123 @@ async fn an_external_session_names_its_repository_by_origin() {
     assert_eq!(nameless.status(), reqwest::StatusCode::BAD_REQUEST);
 }
 
+/// A registered checkout resolves immediately, before the reconcile sweep.
+/// Legacy registrations acquire their origin without changing user settings.
+#[tokio::test]
+async fn registered_repository_origins_are_ready_for_external_sessions() {
+    let (router, _fake, runtime, template_id, token, dir) = external_app_with_token().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let root = super::code::init_git_repo_named(dir.path(), "registered");
+    super::code::add_github_remote(&root, "registered");
+    let response = client
+        .post(format!("http://{addr}/code/repos"))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({ "path": root }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: serde_json::Value = response.json().await.unwrap();
+    let registered_id: RepoId = body["id"].as_str().unwrap().parse().unwrap();
+    let registered = tidebreak_core::db::code::get_repo(&runtime.db, &owner, registered_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(registered.origin_host.as_deref(), Some("github.com"));
+    assert_eq!(registered.origin_owner.as_deref(), Some("acme"));
+    assert_eq!(registered.origin_name.as_deref(), Some("registered"));
+    assert_eq!(
+        runtime
+            .repo_by_origin(&owner, "ACME/Registered")
+            .await
+            .unwrap()
+            .id,
+        registered_id
+    );
+
+    let root = super::code::init_git_repo_named(dir.path(), "legacy");
+    super::code::add_github_remote(&root, "legacy");
+    let mut legacy = runtime.get_repo(&owner, template_id).await.unwrap();
+    legacy.id = RepoId::new();
+    legacy.root_path = root.display().to_string();
+    legacy.display_name = "Keep this name".into();
+    legacy.branch_prefix = "keep/".into();
+    legacy.origin_host = None;
+    legacy.origin_owner = None;
+    legacy.origin_name = None;
+    insert_repo(&runtime.db, &legacy).await.unwrap();
+    let resolved = runtime.repo_by_origin(&owner, "acme/legacy").await.unwrap();
+    assert_eq!(resolved.id, legacy.id);
+    let stored = tidebreak_core::db::code::get_repo(&runtime.db, &owner, legacy.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.origin_name.as_deref(), Some("legacy"));
+    assert_eq!(stored.display_name, "Keep this name");
+    assert_eq!(stored.branch_prefix, "keep/");
+
+    let other = OwnerId::new("other").unwrap();
+    assert!(runtime.repo_by_origin(&other, "acme/legacy").await.is_err());
+    assert!(tidebreak_core::db::code::mark_repo_removed(
+        &runtime.db,
+        &owner,
+        legacy.id,
+        chrono::Utc::now(),
+    )
+    .await
+    .unwrap());
+    assert!(runtime.repo_by_origin(&owner, "acme/legacy").await.is_err());
+}
+
+/// An unqualified GitHub name cannot choose an enterprise host or an
+/// arbitrary checkout when several registrations name the same origin.
+#[tokio::test]
+async fn external_repository_lookup_refuses_host_collisions_and_duplicate_checkouts() {
+    let (_router, _fake, runtime, repo_id, dir) = external_app().await;
+    let owner = OwnerId::local();
+    let mut other = runtime.get_repo(&owner, repo_id).await.unwrap();
+    other.id = RepoId::new();
+    other.root_path = dir.path().join("enterprise").display().to_string();
+    other.origin_host = Some("github.example.com".into());
+    insert_repo(&runtime.db, &other).await.unwrap();
+    assert_eq!(
+        runtime
+            .repo_by_origin(&owner, "acme/tools")
+            .await
+            .unwrap()
+            .id,
+        repo_id
+    );
+    assert!(tidebreak_core::db::code::mark_repo_removed(
+        &runtime.db,
+        &owner,
+        repo_id,
+        chrono::Utc::now(),
+    )
+    .await
+    .unwrap());
+    let error = runtime
+        .repo_by_origin(&owner, "acme/tools")
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "repo_unknown");
+
+    other.id = RepoId::new();
+    other.root_path = dir.path().join("first").display().to_string();
+    other.origin_host = Some("github.com".into());
+    insert_repo(&runtime.db, &other).await.unwrap();
+    other.id = RepoId::new();
+    other.root_path = dir.path().join("second").display().to_string();
+    insert_repo(&runtime.db, &other).await.unwrap();
+    let error = runtime
+        .repo_by_origin(&owner, "acme/tools")
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "repo_ambiguous");
+}
+
 /// A fake forge that lends one fixed credential for whichever repository is
 /// asked, recording the ask.
 struct LendingFake {

--- a/crates/tidebreak-server/src/code/runtime/repos.rs
+++ b/crates/tidebreak-server/src/code/runtime/repos.rs
@@ -68,6 +68,9 @@ impl CodeRuntime {
             }
             Err(other) => return Err(map_worktree(other)),
         };
+        let origin = super::super::delivery::repository_target_from_path(&validated.toplevel)
+            .await
+            .ok();
         let repo = CodeRepo {
             id: RepoId::new(),
             owner: owner.clone(),
@@ -83,9 +86,9 @@ impl CodeRuntime {
             created_at: Utc::now(),
             removed_at: None,
             cloned_from,
-            origin_host: None,
-            origin_owner: None,
-            origin_name: None,
+            origin_host: origin.as_ref().map(|target| target.host.clone()),
+            origin_owner: origin.as_ref().map(|target| target.owner.clone()),
+            origin_name: origin.map(|target| target.name),
         };
         insert_repo(&self.db, &repo).await?;
         self.delivery_cache.invalidate_owner(owner);
@@ -113,34 +116,84 @@ impl CodeRuntime {
                 format!("{origin:?} is not a repository as owner/name"),
             ));
         };
-        self.list_repos(owner)
-            .await?
-            .into_iter()
-            .filter(|repo| repo.removed_at.is_none())
-            .find(|repo| {
-                repo.origin_owner
+        let mut matched = None;
+        for repo in self.list_repos(owner).await? {
+            let repo = self.refresh_missing_repo_origin(repo).await?;
+            if repo.removed_at.is_some()
+                || !repo
+                    .origin_host
+                    .as_deref()
+                    .is_some_and(|host| host.eq_ignore_ascii_case("github.com"))
+                || !repo
+                    .origin_owner
                     .as_deref()
                     .is_some_and(|value| value.eq_ignore_ascii_case(origin_owner))
-                    && repo
-                        .origin_name
-                        .as_deref()
-                        .is_some_and(|value| value.eq_ignore_ascii_case(origin_name))
-            })
-            .ok_or_else(|| {
-                ServerError::conflict_kind(
-                    "repo_unknown",
+                || !repo
+                    .origin_name
+                    .as_deref()
+                    .is_some_and(|value| value.eq_ignore_ascii_case(origin_name))
+            {
+                continue;
+            }
+            if matched.is_some() {
+                return Err(ServerError::conflict_kind(
+                    "repo_ambiguous",
                     format!(
-                        "{origin_owner}/{origin_name} is not registered on this machine; \
-                         clone it in Tidebreak first"
+                        "{origin_owner}/{origin_name} has multiple registered checkouts; \
+                         select one by repo_id"
                     ),
-                )
-            })
+                ));
+            }
+            matched = Some(repo);
+        }
+        matched.ok_or_else(|| {
+            ServerError::conflict_kind(
+                "repo_unknown",
+                format!(
+                    "{origin_owner}/{origin_name} is not registered on this machine; \
+                     clone it in Tidebreak first"
+                ),
+            )
+        })
     }
 
     pub async fn get_repo(&self, owner: &OwnerId, id: RepoId) -> Result<CodeRepo, ServerError> {
-        get_repo(&self.db, owner, id)
+        let repo = get_repo(&self.db, owner, id)
             .await?
-            .ok_or_else(|| ServerError::not_found(format!("repo {id} not found")))
+            .ok_or_else(|| ServerError::not_found(format!("repo {id} not found")))?;
+        self.refresh_missing_repo_origin(repo).await
+    }
+
+    /// Backfill older registrations before callers need their origin. Only the
+    /// origin columns change, so a concurrent settings edit stays intact.
+    async fn refresh_missing_repo_origin(&self, repo: CodeRepo) -> Result<CodeRepo, ServerError> {
+        if repo.removed_at.is_some()
+            || (repo.origin_host.is_some()
+                && repo.origin_owner.is_some()
+                && repo.origin_name.is_some())
+        {
+            return Ok(repo);
+        }
+        let Ok(target) =
+            super::super::delivery::repository_target_from_path(Path::new(&repo.root_path)).await
+        else {
+            // Local repositories without a forge remote remain usable by id.
+            return Ok(repo);
+        };
+        tidebreak_core::db::code::set_repo_origin(
+            &self.db,
+            &repo.owner,
+            repo.id,
+            &target.host,
+            &target.owner,
+            &target.name,
+        )
+        .await?;
+        // Re-read after git and the write: removal or a settings edit may have
+        // completed while the remote was being resolved.
+        get_repo(&self.db, &repo.owner, repo.id)
+            .await?
+            .ok_or_else(|| ServerError::not_found(format!("repo {} not found", repo.id)))
     }
 
     pub(crate) async fn save_repo(&self, repo: &CodeRepo) -> Result<(), ServerError> {


### PR DESCRIPTION
Slack could reject a repository immediately after registration because its origin was populated only by the background reconciliation sweep. Record the origin during registration and backfill older registrations before external lookup or repository approval needs it. Origin updates touch only those columns and re-read the row to preserve concurrent settings and removal.

Unqualified owner/name lookup selects github.com and refuses duplicate checkouts with a typed conflict; callers can select a checkout by repo_id. Repositories without a forge remote remain usable by ID. No schema or API-shape change.

Validation: five focused repository route tests pass, including immediate registration, legacy backfill, owner isolation, removed registrations, host collisions, and duplicate checkouts. Server Clippy passes; the PostgreSQL-enabled CLI builds; formatting and diff checks pass. The existing macOS linker unwind-size warning remains.

Supports #3178. Live Slack acceptance remains tracked separately.