### PR TITLE
improve(code): explain sandbox files in the workspace inspector

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.dom.test.tsx
@@ -709,3 +709,86 @@ it("keys the attributed set on full identity, not the number", async () => {
   expect(current).toHaveLength(1);
   expect(current[0].textContent).toContain("design-tokens");
 });
+
+function workspaceResource(
+  data: CodeWorkspacePrSnapshot | null,
+): CodeWorkspacePrResource {
+  return {
+    data,
+    error: null,
+    refreshing: data === null,
+    refresh: vi.fn(async () => undefined),
+    adopt: vi.fn(),
+    busy: null,
+    mutationError: null,
+    setMutationError: vi.fn(),
+    refreshFromHost: vi.fn(),
+    runMutation: vi.fn(),
+  } as unknown as CodeWorkspacePrResource;
+}
+
+it("waits for workspace placement before reading files and changes", async () => {
+  const client = makeClient();
+  const props = {
+    client: client as ApiClient,
+    workspaceId: "ws-1",
+    workspace: WORKSPACE,
+    contentRevision: 0,
+  };
+  const { rerender } = render(
+    <CodeInspector {...props} prResource={workspaceResource(null)} />,
+  );
+  expect(screen.getByRole("status")).toHaveTextContent("Loading workspace");
+  expect(client.listCodeWorkspaceTree).not.toHaveBeenCalled();
+  expect(client.listCodeWorkspaceFiles).not.toHaveBeenCalled();
+  rerender(
+    <CodeInspector
+      {...props}
+      prResource={workspaceResource({ ...CLEAN_PR_SNAPSHOT, remote: true })}
+    />,
+  );
+  expect(screen.getByText("Files are in the sandbox")).toBeInTheDocument();
+  expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+  await userEvent
+    .setup()
+    .click(screen.getByRole("tab", { name: "Source control" }));
+  expect(screen.getByText("Files are in the sandbox")).toBeInTheDocument();
+  expect(client.listCodeWorkspaceTree).not.toHaveBeenCalled();
+  expect(client.listCodeWorkspaceFiles).not.toHaveBeenCalled();
+  rerender(
+    <CodeInspector
+      {...props}
+      prResource={workspaceResource(CLEAN_PR_SNAPSHOT)}
+    />,
+  );
+  await waitFor(() =>
+    expect(client.listCodeWorkspaceFiles).toHaveBeenCalledOnce(),
+  );
+  await userEvent.setup().click(screen.getByRole("tab", { name: "Files" }));
+  await waitFor(() =>
+    expect(client.listCodeWorkspaceTree).toHaveBeenCalledOnce(),
+  );
+});
+
+it("keeps pull request review available for sandbox workspaces", async () => {
+  const client = makeClient();
+  render(
+    <CodeInspector
+      client={client as ApiClient}
+      workspaceId="ws-1"
+      workspace={WORKSPACE}
+      contentRevision={0}
+      prResource={workspaceResource({
+        ...CLEAN_PR_SNAPSHOT,
+        remote: true,
+        pr: PR,
+      })}
+    />,
+  );
+  await userEvent
+    .setup()
+    .click(screen.getByRole("button", { name: "Review pull request" }));
+  await screen.findByText("Fix login flow");
+  expect(client.listCodeWorkspaceTree).not.toHaveBeenCalled();
+  expect(client.listCodeWorkspaceFiles).not.toHaveBeenCalled();
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -4,6 +4,7 @@ import {
   CircleCheck,
   CircleDashed,
   CircleMinus,
+  Cloud,
   ExternalLink,
   EyeOff,
   Files,
@@ -43,6 +44,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useConfirm } from "@/components/ConfirmDialog";
@@ -130,11 +138,14 @@ export function CodeInspector({
   );
   const [file, setFile] = useState<string | undefined>();
   const turnId = scope?.turnId;
+  const remote = prResource?.data?.remote === true;
+  const worktreeReady = !prResource || (prResource.data !== null && !remote);
   const changedFiles = useChangedFilesResource({
     client,
     workspaceId,
     turnId,
     contentRevision,
+    enabled: worktreeReady,
   });
 
   useEffect(() => {
@@ -254,26 +265,44 @@ export function CodeInspector({
           value="files"
           className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
         >
-          <FilesPanel
-            client={client}
-            workspaceId={workspaceId}
-            contentRevision={contentRevision}
-            selected={file}
-            onOpenFile={openFile}
-          />
+          {worktreeReady ? (
+            <FilesPanel
+              client={client}
+              workspaceId={workspaceId}
+              contentRevision={contentRevision}
+              selected={file}
+              onOpenFile={openFile}
+            />
+          ) : (
+            <WorkspaceFilesUnavailable
+              remote={remote}
+              error={prResource?.error}
+              hasPr={Boolean(pr)}
+              onReview={() => setTab("pr")}
+            />
+          )}
         </TabsContent>
         <TabsContent
           value="source"
           className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden"
         >
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            <DiffOverviewContent
-              resource={changedFiles}
-              turnId={turnId}
-              turnLabel={scope?.label}
-              selected={file}
-              onOpenFile={openDiff}
-            />
+            {worktreeReady ? (
+              <DiffOverviewContent
+                resource={changedFiles}
+                turnId={turnId}
+                turnLabel={scope?.label}
+                selected={file}
+                onOpenFile={openDiff}
+              />
+            ) : (
+              <WorkspaceFilesUnavailable
+                remote={remote}
+                error={prResource?.error}
+                hasPr={Boolean(pr)}
+                onReview={() => setTab("pr")}
+              />
+            )}
           </div>
         </TabsContent>
         <TabsContent
@@ -291,6 +320,57 @@ export function CodeInspector({
         </TabsContent>
       </Tabs>
     </aside>
+  );
+}
+
+function WorkspaceFilesUnavailable({
+  remote,
+  error,
+  hasPr,
+  onReview,
+}: {
+  remote: boolean;
+  error?: string | null;
+  hasPr: boolean;
+  onReview: () => void;
+}) {
+  if (!remote) {
+    return error ? (
+      <p
+        role="alert"
+        className="notice-surface notice-critical m-4 rounded-md p-3 text-sm"
+      >
+        {error}
+      </p>
+    ) : (
+      <div
+        role="status"
+        className="flex items-center gap-2 p-4 text-sm text-muted-foreground"
+      >
+        <Spinner className="size-3.5" /> Loading workspace…
+      </div>
+    );
+  }
+  return (
+    <Empty className="rounded-none px-5 md:px-5">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Cloud />
+        </EmptyMedia>
+        <EmptyTitle>Files are in the sandbox</EmptyTitle>
+        <EmptyDescription>
+          Ask in chat to inspect files or changes.{" "}
+          {hasPr
+            ? "You can also review the pull request."
+            : "When the task opens a pull request, you can review it here."}
+        </EmptyDescription>
+      </EmptyHeader>
+      {hasPr && (
+        <Button variant="outline" size="sm" onClick={onReview}>
+          Review pull request
+        </Button>
+      )}
+    </Empty>
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/DiffOverview.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DiffOverview.tsx
@@ -88,11 +88,13 @@ export function useChangedFilesResource({
   workspaceId,
   turnId,
   contentRevision = 0,
+  enabled = true,
 }: {
   client: Pick<ApiClient, "listCodeWorkspaceFiles">;
   workspaceId: string;
   turnId?: string;
   contentRevision?: number;
+  enabled?: boolean;
 }): LiveResource<CodeWorkspaceFiles> {
   const load = useCallback(
     () => client.listCodeWorkspaceFiles(workspaceId, turnId),
@@ -102,6 +104,7 @@ export function useChangedFilesResource({
     key: `${workspaceId}:${turnId ?? "workspace"}`,
     revision: contentRevision,
     load,
+    enabled,
     errorMessage: "Could not load changed files",
   });
 }

--- a/crates/tidebreak-desktop/ui/src/code/useLiveContent.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/useLiveContent.dom.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { useLiveResource } from "./useLiveContent";
+
+it("retires an in-flight read when disabled and reloads when enabled", async () => {
+  let finish: (value: string) => void = () => {};
+  const load = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finish = resolve;
+        }),
+    )
+    .mockResolvedValue("fresh");
+  const { result, rerender } = renderHook(
+    ({ enabled, revision }) =>
+      useLiveResource({
+        key: "workspace",
+        revision,
+        enabled,
+        load,
+        errorMessage: "Read failed",
+      }),
+    { initialProps: { enabled: true, revision: 0 } },
+  );
+  expect(load).toHaveBeenCalledOnce();
+  rerender({ enabled: false, revision: 1 });
+  await act(async () => {
+    finish("stale");
+  });
+  expect(result.current.data).toBeNull();
+  expect(result.current.refreshing).toBe(false);
+  await act(async () => {
+    await result.current.refresh();
+  });
+  expect(load).toHaveBeenCalledOnce();
+  rerender({ enabled: true, revision: 1 });
+  await waitFor(() => expect(result.current.data).toBe("fresh"));
+});

--- a/crates/tidebreak-desktop/ui/src/code/useLiveContent.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useLiveContent.ts
@@ -79,6 +79,7 @@ export function useLiveResource<T>({
   load,
   errorMessage,
   debounceMs = DEFAULT_DEBOUNCE_MS,
+  enabled = true,
 }: {
   /** Identity of what is being loaded; a change clears `data` and reloads. */
   key: string;
@@ -86,6 +87,8 @@ export function useLiveResource<T>({
   load: () => Promise<T>;
   errorMessage: string;
   debounceMs?: number;
+  /** Do not read or retain worktree data while the workspace is remote. */
+  enabled?: boolean;
 }): LiveResource<T> {
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -98,6 +101,8 @@ export function useLiveResource<T>({
 
   // Every load carries the generation it started in; a response from an older
   // generation belongs to a key we have moved off, or to an unmounted view.
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
   const generationRef = useRef(0);
   const inFlightRef = useRef<{
     generation: number;
@@ -108,6 +113,7 @@ export function useLiveResource<T>({
   const seenRef = useRef<{ key: string; revision: number }>({ key, revision });
 
   const run = useCallback(function run(): Promise<void> {
+    if (!enabledRef.current) return Promise.resolve();
     const inFlight = inFlightRef.current;
     if (inFlight) {
       pendingRef.current = true;
@@ -154,15 +160,17 @@ export function useLiveResource<T>({
     pendingRef.current = false;
     setData(null);
     setError(null);
-    void run();
+    setRefreshing(enabled);
+    if (enabled) void run();
     return () => {
       // Retire this generation so a late response cannot land on the next key
       // or on an unmounted view.
       generationRef.current += 1;
     };
-  }, [key, run]);
+  }, [key, run, enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (seenRef.current.key !== key) {
       // The reset effect above already reloaded for this key.
       seenRef.current = { key, revision };
@@ -181,7 +189,7 @@ export function useLiveResource<T>({
         timerRef.current = null;
       }
     };
-  }, [key, revision, debounceMs, run]);
+  }, [key, revision, debounceMs, run, enabled]);
 
   return { data, error, refreshing, refresh: run, adopt };
 }

--- a/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeInspector.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 import type { ApiClient } from "@/api/client";
 import type {
   CodeWorkspacePrSnapshot,
@@ -10,6 +10,10 @@ import { CodeInspector, type InspectorTab } from "@/code/CodeInspector";
 import type { CodeWorkspacePrResource } from "@/code/useCodeWorkspacePr";
 
 type InspectorScenario =
+  | "sandbox"
+  | "sandbox-pr"
+  | "placement-loading"
+  | "placement-failure"
   | "ready"
   | "merge-ready"
   | "merge-queued"
@@ -363,8 +367,29 @@ function InspectorStory({
           }
         : pullRequest;
   const storyWorkspace =
-    scenario === "empty" ? workspace : { ...workspace, pr: storyPr };
-  const storySnapshot = { ...prSnapshot, pr: storyPr };
+    scenario === "empty" ||
+    scenario === "sandbox" ||
+    scenario.startsWith("placement-")
+      ? workspace
+      : { ...workspace, pr: storyPr };
+  const storySnapshot = {
+    ...prSnapshot,
+    remote: scenario.startsWith("sandbox"),
+    pr: scenario === "sandbox" ? undefined : storyPr,
+  };
+  const resource = resourceFor(
+    scenario === "empty"
+      ? { ...prSnapshot, dirty: false, ahead: 0, pr: undefined }
+      : storySnapshot,
+  );
+  if (scenario.startsWith("placement-")) {
+    resource.data = null;
+    resource.refreshing = scenario === "placement-loading";
+    resource.error =
+      scenario === "placement-failure"
+        ? "Could not load workspace status. Check your connection."
+        : null;
+  }
 
   return (
     <div className="h-[720px] min-w-0 overflow-hidden rounded-xl border border-border-subtle bg-background shadow-sm">
@@ -374,11 +399,7 @@ function InspectorStory({
         workspaceId={workspace.id}
         workspace={storyWorkspace}
         contentRevision={0}
-        prResource={resourceFor(
-          scenario === "empty"
-            ? { ...prSnapshot, dirty: false, ahead: 0, pr: undefined }
-            : storySnapshot,
-        )}
+        prResource={resource}
         initialTab={tab}
         onOpenFile={fn()}
         onOpenDiff={fn()}
@@ -473,4 +494,29 @@ export const Compact: Story = {
       </div>
     ),
   ],
+};
+
+export const SandboxFiles: Story = {
+  args: { scenario: "sandbox" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Files are in the sandbox")).toBeVisible();
+    await expect(canvas.queryByRole("searchbox")).not.toBeInTheDocument();
+  },
+};
+
+export const SandboxChanges: Story = {
+  args: { tab: "source", scenario: "sandbox" },
+};
+
+export const SandboxWithPullRequest: Story = {
+  args: { scenario: "sandbox-pr" },
+};
+
+export const WorkspacePlacementLoading: Story = {
+  args: { scenario: "placement-loading" },
+};
+
+export const WorkspacePlacementFailure: Story = {
+  args: { scenario: "placement-failure" },
 };


### PR DESCRIPTION
Opening a Slack sandbox workspace loads its file tree and changes from the hosted server, which has no checkout for that session. The inspector now waits for workspace placement and shows a sandbox explanation with a pull request review action. Local workspaces retain the existing file browser.

The shared live reader can pause reads, retire in-flight results, and resume when local files are available. No API or data migration changes.

Validation: 35 focused tests pass, including placement transitions, stale read suppression, and remote PR review. TypeScript, Storybook build, formatting, and diff checks pass. Inspected all five added states at 720px and 390px under all four Storybook theme choices; the high-contrast choices use the existing light/dark palettes. Preview: `pnpm --dir crates/tidebreak-desktop/ui storybook --port 6008`.

This fixes the inspector error observed during the Slack runtime canary. Remote file browsing remains unavailable; chat and pull request review are the supported paths.
