### PR TITLE
feat(code): expose bound approval details to channel adapters

### DIFF
--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -495,6 +495,10 @@ pub fn app(state: AppState) -> Router {
             axum::routing::put(routes::code::external_session_access),
         )
         .route(
+            "/external/code/sessions/{id}/approvals/{call}",
+            get(routes::code::external_approval),
+        )
+        .route(
             "/external/code/sessions/{id}/approvals/{call}/decision",
             post(routes::code::external_approval_decision),
         )

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -770,6 +770,22 @@ pub struct ExternalDecisionBody {
     pub actor: Option<ExternalDecisionActor>,
 }
 
+/// Read the complete approval after verifying its session and adapter grant.
+/// The journal can then carry a bounded reference while cards load questions
+/// and plan text from the approval row.
+pub async fn external_approval(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path((id, call)): Path<(SessionId, ApprovalId)>,
+) -> Result<Json<ApprovalSnapshot>, ServerError> {
+    let runtime = require_bound(&state, &grant, id).await?;
+    let approval = runtime.get_approval(&grant.owner, call).await?;
+    if approval.session_id != id {
+        return Err(ServerError::not_found("code session not found"));
+    }
+    Ok(Json(ApprovalSnapshot::from(approval)))
+}
+
 /// `POST /external/code/sessions/{id}/approvals/{call}/decision`
 pub async fn external_approval_decision(
     State(state): State<AppState>,

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -51,9 +51,10 @@ pub(crate) use delivery::{
     resolve_repositories as resolve_delivery_repositories, run_detail as delivery_run_detail,
 };
 pub(crate) use external::{
-    external_approval_decision, external_attach_binding, external_bindings, external_events,
-    external_get_or_create, external_interrupt, external_messages, external_plan_decision,
-    external_question_decision, external_reap, external_rotate, external_session_access,
+    external_approval, external_approval_decision, external_attach_binding, external_bindings,
+    external_events, external_get_or_create, external_interrupt, external_messages,
+    external_plan_decision, external_question_decision, external_reap, external_rotate,
+    external_session_access,
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -3221,6 +3221,115 @@ async fn a_machine_session_parks_on_an_approval_a_contributor_can_settle() {
         }
     }
 
+    // The full row stays behind the same session/grant boundary as decisions.
+    let details_url = format!(
+        "http://{addr}/external/code/sessions/{session_id}/approvals/{}",
+        approval.id
+    );
+    let details = client
+        .get(&details_url)
+        .bearer_auth(&pair.token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(details.status(), reqwest::StatusCode::OK);
+    let details: serde_json::Value = details.json().await.unwrap();
+    assert_eq!(details["kind"]["cmd"].as_str().unwrap().len(), 600);
+    assert!(details.get("server_capability").is_none());
+    assert!(details.get("decision_claim").is_none());
+    assert_eq!(
+        client.get(&details_url).send().await.unwrap().status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+    let (_, other_pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U-other", "T1")
+        .await
+        .unwrap();
+    assert_eq!(
+        client
+            .get(&details_url)
+            .bearer_auth(&other_pair.token)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    let other_session = client.post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({"external_key": "T1/C-other/1.1", "repo_id": repo_id, "permission_mode": "ask"}))
+        .send().await.unwrap();
+    assert_eq!(other_session.status(), reqwest::StatusCode::CREATED);
+    let other_session_id = bound_session_id(&runtime, &owner, "T1/C-other/1.1").await;
+    let wrong_session_url = format!(
+        "http://{addr}/external/code/sessions/{other_session_id}/approvals/{}",
+        approval.id
+    );
+    assert_eq!(
+        client
+            .get(wrong_session_url)
+            .bearer_auth(&pair.token)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+
+    let questions = vec![tidebreak_core::UserQuestion {
+        id: "target".into(),
+        header: "Target".into(),
+        question: "Where should the change run?".into(),
+        options: vec![tidebreak_core::UserQuestionOption {
+            id: "staging".into(),
+            label: "Staging".into(),
+            description: "Validate before production.".into(),
+        }],
+        question_type: tidebreak_core::UserQuestionType::SingleSelect,
+        allow_free_form: true,
+    }];
+    let plan = tidebreak_core::PlanProposalBody {
+        title: "Validate the change".into(),
+        plan: "Review the code and run the focused tests. Then publish the change for review."
+            .into(),
+    };
+    for (kind, raw) in [
+        (
+            tidebreak_core::ApprovalKind::Questions { questions },
+            serde_json::Value::Null,
+        ),
+        (
+            tidebreak_core::ApprovalKind::Plan {
+                proposed_mode: tidebreak_core::PermissionMode::Ask,
+            },
+            plan.to_raw().unwrap(),
+        ),
+    ] {
+        let mut row = approval.clone();
+        row.id = tidebreak_core::ApprovalId::new();
+        row.kind = kind.clone();
+        row.harness_raw = raw.clone();
+        row.native_call_id = None;
+        row.server_capability = None;
+        row.request_sha256 = None;
+        tidebreak_core::db::code::insert_approval(&runtime.db, &owner, &row)
+            .await
+            .unwrap();
+        let result = client
+            .get(format!(
+                "http://{addr}/external/code/sessions/{session_id}/approvals/{}",
+                row.id
+            ))
+            .bearer_auth(&pair.token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(result.status(), reqwest::StatusCode::OK);
+        let result: serde_json::Value = result.json().await.unwrap();
+        assert_eq!(result["kind"], serde_json::to_value(kind).unwrap());
+        assert_eq!(result["harness_raw_json"], raw.to_string());
+    }
+
     let grant_refused = client
         .post(format!(
             "http://{addr}/external/code/sessions/{session_id}/approvals/{}/decision",


### PR DESCRIPTION
Question and plan events carry a reference instead of the complete card. Channel adapters need the stored questions and plan body to render decisions accurately.

Adds `GET /external/code/sessions/{id}/approvals/{call}` behind the existing live adapter-grant authentication and session binding. It returns the existing approval snapshot, including complete question options and plan text. A different grant or session receives 404. Private native capabilities and decision claims remain outside the response. This is an additive API change; existing events and decision routes keep their contract.

Validation: the focused real-machine approval test passes, including complete command, question, and plan reads, unauthenticated access, another grant, and a mismatched session. Scoped Clippy for all server targets, formatting, and diff checks pass. The linker reports its existing oversized unwind-table warning during the test build.

Supports the Slack decision-card requirement in #3178. The adapter integration remains a separate dependency in the gateway repository.
