### PR TITLE
ci: admit sbom-action 0.24.2 in the trusted release-policy pin

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -2170,9 +2170,11 @@ test("source SBOM generation is isolated from production credentials", () => {
   assert.doesNotMatch(sbomJob, /AWS_|DOWNLOADS_|RELEASE_BASE_URL|vars\.|secrets\./);
   assert.match(sbomJob, /ref: \$\{\{ needs\.validate\.outputs\.sha \}\}/);
   assert.match(sbomJob, /run: mkdir -p source-sbom/);
+  // Admit 0.24.0 (main) and 0.24.2 (Dependabot). This file is copied from
+  // the base branch, so a pin bump cannot land until both versions match.
   assert.match(
     sbomJob,
-    /uses: anchore\/sbom-action@[0-9a-f]{40} # v0\.24\.0/,
+    /uses: anchore\/sbom-action@[0-9a-f]{40} # v0\.24\.(0|2)/,
   );
   assert.match(sbomJob, /syft-version: v1\.51\.0/);
   assert.match(sbomJob, /format: spdx-json/);


### PR DESCRIPTION
Release policy copies `scripts/workflow-security.test.mjs` from the base branch and runs it against the pull request workflows. Dependabot PR #3257 bumps `anchore/sbom-action` to v0.24.2, so the trusted pin on main has to admit both 0.24.0 and 0.24.2 until that bump merges.

`node --test scripts/workflow-security.test.mjs` passed locally (49 tests).