### PR TITLE
improve(code): preserve workspace grouping within collapsible sources

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import { renderWithRouter } from "@/test/router";
@@ -145,6 +145,10 @@ const app: AppContextValue = {
   restartForUpdate: async () => {},
 };
 
+beforeEach(() => {
+  useCodeUiStore.setState({ collapsedWorkspaceGroups: [] });
+});
+
 afterEach(() => {
   cleanup();
   useCodeCatalogStore.getState().reset();
@@ -155,6 +159,9 @@ afterEach(() => {
     railPrefs: DEFAULT_RAIL_PREFS,
     selectedWorkspaceIds: [],
     selectionAnchorId: null,
+    addRepoOpen: false,
+    newWorkspaceOpen: false,
+    newWorkspaceRepoId: undefined,
   });
   window.localStorage.clear();
 });
@@ -253,8 +260,7 @@ describe("CodeSidebar", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Work" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Code" })).toBeInTheDocument();
-    // One header over one list: the by-repo group header is a label, and the
-    // three actions beside "Workspaces" are the whole toolbar.
+    // The repository heading remains below the workspace action toolbar.
     expect(await screen.findByTitle("app")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Workspaces" }),
@@ -306,6 +312,34 @@ describe("CodeSidebar", () => {
     ).not.toBeInTheDocument();
   });
 
+  it.each([
+    ["Add repo", "Add a repo"],
+    ["New workspace", "New workspace"],
+  ])(
+    "opens the %s dialog from the workspace toolbar",
+    async (buttonName, dialogName) => {
+      await renderWithRouter(
+        <AppContextProvider value={app}>
+          <CodeSidebar />
+        </AppContextProvider>,
+        { initialUrl: "/code" },
+      );
+      await screen.findByRole("button", { name: /^Fix login/ });
+      const toolbar = screen.getByRole("toolbar", {
+        name: "Workspace actions",
+      });
+      const button = within(toolbar).getByRole("button", { name: buttonName });
+      expect(button).toBeVisible();
+      fireEvent.click(button);
+      const dialog = await screen.findByRole("dialog", { name: dialogName });
+      expect(dialog).toBeVisible();
+      fireEvent.keyDown(dialog, { key: "Escape" });
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog", { name: dialogName })).toBeNull(),
+      );
+    },
+  );
+
   it("re-sorts and persists from the settings popover", async () => {
     await renderWithRouter(
       <AppContextProvider value={app}>
@@ -318,18 +352,29 @@ describe("CodeSidebar", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Workspace list settings" }),
     );
-    fireEvent.click(await screen.findByRole("radio", { name: "By created" }));
+    const grouping = await screen.findByRole("radiogroup", {
+      name: "Group workspaces",
+    });
+    expect(
+      within(grouping)
+        .getAllByRole("radio")
+        .map((radio) => radio.textContent),
+    ).toEqual(["Repository", "Status"]);
+    fireEvent.click(within(grouping).getByRole("radio", { name: "Status" }));
 
-    // By-created has no group headers, so the repo label goes away and the
-    // card grows its repo chip back.
     await waitFor(() =>
-      expect(screen.queryByTitle("app")).not.toBeInTheDocument(),
+      expect(
+        screen.getByRole("button", { name: "Idle, 1 workspace" }),
+      ).toBeInTheDocument(),
     );
+    expect(
+      screen.queryByRole("button", { name: "app, 1 workspace" }),
+    ).not.toBeInTheDocument();
     expect(
       JSON.parse(
         window.localStorage.getItem("tidebreak.code-rail-prefs") ?? "{}",
       ),
-    ).toMatchObject({ sortMode: "by-created" });
+    ).toMatchObject({ sortMode: "by-status" });
   });
 
   it("opens the workspace context menu from the keyboard and gives focus back", async () => {
@@ -656,94 +701,138 @@ describe("CodeSidebar", () => {
     );
   });
 
-  it("groups local, Slack DM, and Slack channel sessions as three named origins", async () => {
-    client.listCodeWorkspaces.mockResolvedValueOnce([
-      {
-        id: "ws-local",
-        repo_id: "repo-1",
-        title: "Local thread",
-        worktree_path: "/tmp/app/.worktrees/local",
-        branch_name: "tidebreak/local",
-        base_ref: "main",
-        status: "active" as const,
-        created_at: "2026-08-15T00:00:00.000Z",
-      },
-      {
-        id: "ws-dm",
-        repo_id: "repo-1",
-        title: "Slack DM thread",
-        worktree_path: "/tmp/app/.worktrees/dm",
-        branch_name: "tidebreak/dm",
-        base_ref: "main",
-        status: "active" as const,
-        created_at: "2026-08-16T00:00:00.000Z",
-      },
-      {
-        id: "ws-channel",
-        repo_id: "repo-1",
-        title: "Slack channel thread",
-        worktree_path: "/tmp/app/.worktrees/channel",
-        branch_name: "tidebreak/channel",
-        base_ref: "main",
-        status: "active" as const,
-        created_at: "2026-08-17T00:00:00.000Z",
-      },
-    ]);
-    const idle = {
-      visibility: "private" as const,
-      kind: "interactive" as const,
-      harness_kind: "claude_code" as const,
-      execution_location: "machine" as const,
-      permission_mode: "ask" as const,
-      fast_mode: false,
-      lifecycle: "idle" as const,
-      attention: {
-        state: { type: "working" as const },
-        source: "lifecycle" as const,
-      },
-      unrecognized_event_count: 0,
-      created_at: "2026-08-15T00:00:00.000Z",
-    };
-    useCodeCatalogStore.getState().rememberSession({
-      ...idle,
-      id: "sess-local",
-      workspace_id: "ws-local",
-    });
-    useCodeCatalogStore.getState().rememberSession({
-      ...idle,
-      id: "sess-dm",
-      workspace_id: "ws-dm",
-      external_origin: {
-        channel_kind: "slack",
-        external_key: "T0400000:D0898765:dm2",
-      },
-    });
-    useCodeCatalogStore.getState().rememberSession({
-      ...idle,
-      id: "sess-channel",
-      workspace_id: "ws-channel",
-      external_origin: {
-        channel_kind: "slack",
-        external_key: "T0400000:C0812345:1724900000.123456",
-      },
-    });
-
+  it("keeps repository and status headings within Local and Slack", async () => {
+    seedMixedSources();
     await renderWithRouter(
       <AppContextProvider value={app}>
         <CodeSidebar />
       </AppContextProvider>,
       { initialUrl: "/code" },
     );
+    const local = await screen.findByRole("region", { name: "Local" });
+    const slack = screen.getByRole("region", { name: "Slack" });
+    expect(local).toHaveAttribute("data-rail-section", "source:local");
+    expect(slack).toHaveAttribute("data-rail-section", "source:slack");
+    expect(
+      within(local)
+        .getByRole("button", { name: "app, 1 workspace" })
+        .closest("h3"),
+    ).toBeInTheDocument();
+    expect(
+      within(local).getByRole("button", { name: "app, 1 workspace" }),
+    ).toBeInTheDocument();
+    expect(
+      within(local).getByRole("button", { name: "lib, 1 workspace" }),
+    ).toBeInTheDocument();
+    expect(
+      within(slack).getByRole("button", { name: "app, 2 workspaces" }),
+    ).toBeInTheDocument();
+    expect(
+      within(slack).getByRole("button", { name: /^Slack DM thread/ }),
+    ).toBeVisible();
+    expect(
+      within(slack).getByRole("button", { name: /^Slack channel thread/ }),
+    ).toBeVisible();
+    expect(screen.queryByRole("region", { name: "Slack DM" })).toBeNull();
+    expect(screen.queryByRole("region", { name: "Slack channel" })).toBeNull();
 
-    const groups = await screen.findAllByTestId("rail-origin-group");
-    expect(groups.map((group) => group.getAttribute("data-origin"))).toEqual([
-      "local",
-      "slack:channel",
-      "slack:dm",
+    fireEvent.click(
+      screen.getByRole("button", { name: "Workspace list settings" }),
+    );
+    fireEvent.click(await screen.findByRole("radio", { name: "Status" }));
+    expect(
+      within(local).getByRole("button", { name: "Idle, 2 workspaces" }),
+    ).toBeInTheDocument();
+    expect(
+      within(slack).getByRole("button", { name: "Idle, 2 workspaces" }),
+    ).toBeInTheDocument();
+    expect(
+      within(local).queryByRole("button", { name: "app, 1 workspace" }),
+    ).toBeNull();
+    expect(
+      within(slack).queryByRole("button", { name: "app, 2 workspaces" }),
+    ).toBeNull();
+  });
+
+  it("preserves a folded child when its source reopens and supports expand all", async () => {
+    seedMixedSources();
+    await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    const slack = await screen.findByRole("region", { name: "Slack" });
+    const subgroup = within(slack).getByRole("button", {
+      name: "app, 2 workspaces",
+    });
+    const source = within(slack).getByRole("button", {
+      name: "Slack, 2 workspaces",
+    });
+    fireEvent.click(subgroup);
+    expect(subgroup).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByRole("button", { name: /^Slack DM thread/ }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: /^Local thread/ })).toBeVisible();
+    fireEvent.click(source);
+    expect(source).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(source);
+    expect(source).toHaveAttribute("aria-expanded", "true");
+    expect(subgroup).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByRole("button", { name: /^Slack DM thread/ }),
+    ).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse all groups" }),
+    );
+    expect(screen.queryByRole("button", { name: /^Local thread/ })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Expand all groups" }));
+    expect(screen.getByRole("button", { name: /^Local thread/ })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /^Slack DM thread/ }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /^Slack channel thread/ }),
+    ).toBeVisible();
+    expect(useCodeUiStore.getState().collapsedWorkspaceGroups).toEqual([]);
+  });
+
+  it("skips folded workspaces in select all and shift-click ranges", async () => {
+    seedMixedSources();
+    const { router } = await renderWithRouter(
+      <AppContextProvider value={app}>
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code" },
+    );
+    const local = await screen.findByRole("region", { name: "Local" });
+    fireEvent.click(
+      within(local).getByRole("button", { name: "lib, 1 workspace" }),
+    );
+    const first = screen.getByRole("button", { name: /^Local thread/ });
+    const last = screen.getByRole("button", { name: /^Slack channel thread/ });
+    expect(
+      screen.queryByRole("button", { name: /^Hidden local thread/ }),
+    ).toBeNull();
+
+    fireEvent.keyDown(first, { key: "a", ctrlKey: true });
+    expect(useCodeUiStore.getState().selectedWorkspaceIds).toEqual([
+      "ws-local",
+      "ws-dm",
+      "ws-channel",
     ]);
-    expect(screen.getByText("Local")).toBeInTheDocument();
-    expect(screen.getByText("Slack DM")).toBeInTheDocument();
-    expect(screen.getByText("Slack channel")).toBeInTheDocument();
+    fireEvent.keyDown(first, { key: "Escape" });
+    expect(useCodeUiStore.getState().selectedWorkspaceIds).toEqual([]);
+    fireEvent.click(first, { metaKey: true });
+    fireEvent.click(last, { shiftKey: true });
+    expect(useCodeUiStore.getState().selectedWorkspaceIds).toEqual([
+      "ws-local",
+      "ws-dm",
+      "ws-channel",
+    ]);
+    expect(router.state.location.pathname).toBe("/code");
   });
 
   it("opens and clears selection on an unmodified click", async () => {
@@ -763,3 +852,84 @@ describe("CodeSidebar", () => {
     expect(card).not.toHaveAttribute("aria-selected");
   });
 });
+
+function seedMixedSources() {
+  const repos = [
+    {
+      id: "repo-1",
+      root_path: "/tmp/app",
+      display_name: "app",
+      default_base_ref: "main",
+      branch_prefix: "tidebreak",
+      quick_actions: [],
+      created_at: "2026-08-15T00:00:00.000Z",
+    },
+    {
+      id: "repo-2",
+      root_path: "/tmp/lib",
+      display_name: "lib",
+      default_base_ref: "main",
+      branch_prefix: "tidebreak",
+      quick_actions: [],
+      created_at: "2026-08-15T00:00:00.000Z",
+    },
+  ];
+  client.listCodeRepos.mockResolvedValueOnce(repos);
+  client.listCodeWorkspaces.mockResolvedValueOnce(
+    [
+      {
+        id: "ws-local",
+        repo_id: "repo-1",
+        title: "Local thread",
+        branch_name: "tidebreak/local",
+        created_at: "2026-08-15T00:00:00.000Z",
+      },
+      {
+        id: "ws-hidden",
+        repo_id: "repo-2",
+        title: "Hidden local thread",
+        branch_name: "tidebreak/hidden",
+        created_at: "2026-08-15T00:00:00.000Z",
+      },
+      {
+        id: "ws-dm",
+        repo_id: "repo-1",
+        title: "Slack DM thread",
+        branch_name: "tidebreak/dm",
+        created_at: "2026-08-16T00:00:00.000Z",
+      },
+      {
+        id: "ws-channel",
+        repo_id: "repo-1",
+        title: "Slack channel thread",
+        branch_name: "tidebreak/channel",
+        created_at: "2026-08-17T00:00:00.000Z",
+      },
+    ].map((workspace) => ({
+      ...workspace,
+      worktree_path: `/tmp/${workspace.id}`,
+      base_ref: "main",
+      status: "active" as const,
+    })),
+  );
+  for (const [workspaceId, externalKey] of [
+    ["ws-dm", "T0400000:D0898765:dm2"],
+    ["ws-channel", "T0400000:C0812345:1724900000.123456"],
+  ] as const) {
+    useCodeCatalogStore.getState().rememberSession({
+      visibility: "private",
+      id: `sess-${workspaceId}`,
+      workspace_id: workspaceId,
+      kind: "interactive",
+      harness_kind: "claude_code",
+      execution_location: "machine",
+      permission_mode: "ask",
+      fast_mode: false,
+      lifecycle: "idle",
+      attention: { state: { type: "working" }, source: "lifecycle" },
+      unrecognized_event_count: 0,
+      created_at: "2026-08-15T00:00:00.000Z",
+      external_origin: { channel_kind: "slack", external_key: externalKey },
+    });
+  }
+}

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useState, type ComponentProps } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import {
-  Archive,
-  BarChart3,
-  FolderPlus,
-  GitPullRequest,
-  Plus,
-} from "lucide-react";
+import { Archive, BarChart3, GitPullRequest } from "lucide-react";
 import { toast } from "sonner";
 
 import { useApp } from "@/AppContext";
@@ -28,22 +22,24 @@ import {
   useWorkspaceDigests,
   watchChildren,
 } from "./CodeUpdatesStore";
-import { FOCUS_RING, HOVER_TINT, RAIL_ICON_BUTTON } from "./interactive";
+import { FOCUS_RING, HOVER_TINT } from "./interactive";
 import { findCodeTerminalTab } from "./codeChrome";
 import { canOpenLocalCodeWorktree } from "./codeWorktreeHost";
 import { NewWorkspaceDialog } from "./NewWorkspaceDialog";
 import { WorkspaceLessSessionRow } from "./WorkspaceLessSessionRow";
-import { RailSettingsMenu } from "./RailSettingsMenu";
+import { WorkspaceRailToolbar } from "./WorkspaceRailToolbar";
+import { WorkspaceRailGroups } from "./WorkspaceRailGroups";
 import {
   useWorkspaceCardCommands,
   workspaceBulkCommands,
   workspaceCommands,
 } from "./workspaceActions";
-import { WorkspaceCard, WorkspaceStatusMark } from "./WorkspaceCard";
+import { WorkspaceCard } from "./WorkspaceCard";
 import {
-  arrangeWorkspaces,
+  arrangeWorkspaceSections,
+  visibleWorkspaceGroups,
+  workspaceCollapseKeys,
   isPutAway,
-  isWorkspaceStatusRank,
   workspaceStackParent,
 } from "./workspaceCards";
 import {
@@ -69,7 +65,7 @@ import { useCodeWorkspacePr } from "./useCodeWorkspacePr";
  * what later convergence merges rather than translates.
  *
  * The rail spends no section on the repo catalog: workspaces are the only
- * list, and by-repo group headers are labels rather than links. What each card
+ * list. Source and repository/status headers fold their own rows. What each card
  * draws is the reader's `railPrefs` choice; what each card *says* (the
  * aria-label) never shrinks with those choices.
  *
@@ -112,6 +108,13 @@ export function CodeSidebar() {
   );
   const setAddRepoOpen = useCodeUiStore((state) => state.setAddRepoOpen);
   const prefs = useCodeUiStore((state) => state.railPrefs);
+  const collapsedKeys = useCodeUiStore(
+    (state) => state.collapsedWorkspaceGroups,
+  );
+  const setCollapsedKeys = useCodeUiStore(
+    (state) => state.setCollapsedWorkspaceGroups,
+  );
+  const toggleGroup = useCodeUiStore((state) => state.toggleWorkspaceGroup);
   const runComposerPrompt = useCodeUiStore((state) => state.runComposerPrompt);
   const { run, runBulk, dialogs } = useWorkspaceCardCommands();
   const layout = useLayoutState();
@@ -136,13 +139,19 @@ export function CodeSidebar() {
 
   useEffect(() => connectCodeUpdates(client), [client]);
 
-  const groups = arrangeWorkspaces(
+  const sections = arrangeWorkspaceSections(
     prefs.sortMode,
     repos,
     workspaces,
     digests,
     sessions,
   );
+  const groups = visibleWorkspaceGroups(
+    sections,
+    prefs.sortMode,
+    collapsedKeys,
+  );
+  const collapseKeys = workspaceCollapseKeys(sections, prefs.sortMode);
   const canOpenWorktree = canOpenLocalCodeWorktree();
   const selectedWorkspaceIds = useCodeUiStore(
     (state) => state.selectedWorkspaceIds,
@@ -162,8 +171,21 @@ export function CodeSidebar() {
     (workspace) =>
       selectedWorkspaceIds.includes(workspace.id) &&
       workspace.status !== "creating" &&
-      !isPutAway(workspace),
+      !isPutAway(workspace) &&
+      selectableIds.includes(workspace.id),
   );
+
+  useEffect(() => {
+    const visibleSelection = selectedWorkspaceIds.filter((id) =>
+      selectableIds.includes(id),
+    );
+    if (visibleSelection.length === selectedWorkspaceIds.length) return;
+    const anchor = useCodeUiStore.getState().selectionAnchorId;
+    replaceWorkspaceSelection(
+      visibleSelection,
+      anchor && selectableIds.includes(anchor) ? anchor : null,
+    );
+  }, [selectedWorkspaceIds, selectableIds, replaceWorkspaceSelection]);
 
   function applyPointerSelect(
     workspaceId: string,
@@ -223,7 +245,13 @@ export function CodeSidebar() {
         />
       </nav>
 
-      <div className="flex shrink-0 items-center gap-0.5 px-1 pt-1 pb-1.5">
+      <WorkspaceRailToolbar
+        collapseKeys={collapseKeys}
+        collapsedKeys={collapsedKeys}
+        onCollapsedChange={setCollapsedKeys}
+        onAddRepo={() => setAddRepoOpen(true)}
+        onNewWorkspace={() => startNewWorkspace()}
+      >
         <button
           type="button"
           className={cn(
@@ -239,24 +267,7 @@ export function CodeSidebar() {
         >
           Workspaces
         </button>
-        <RailSettingsMenu />
-        <button
-          type="button"
-          className={RAIL_ICON_BUTTON}
-          aria-label="Add repo"
-          onClick={() => setAddRepoOpen(true)}
-        >
-          <FolderPlus size={15} />
-        </button>
-        <button
-          type="button"
-          className={RAIL_ICON_BUTTON}
-          aria-label="New workspace"
-          onClick={() => startNewWorkspace()}
-        >
-          <Plus size={15} />
-        </button>
-      </div>
+      </WorkspaceRailToolbar>
 
       <div
         className="flex min-h-0 flex-col gap-1"
@@ -297,241 +308,183 @@ export function CodeSidebar() {
             ))}
           </section>
         )}
-        {groups.map((group) => (
-          <div
-            key={group.key}
-            className="flex flex-col gap-1"
-            data-testid={
-              group.key === "local" || group.key.includes(":")
-                ? "rail-origin-group"
-                : undefined
-            }
-            data-origin={
-              group.key === "local" || group.key.includes(":")
-                ? group.key
-                : undefined
-            }
-          >
-            {group.label &&
-              (isWorkspaceStatusRank(group.key) ? (
-                <div className="flex items-center gap-1.5 px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90">
-                  <WorkspaceStatusMark rank={group.key} />
-                  <span className="min-w-0 truncate" title={group.label}>
-                    {group.label} · {group.workspaces.length}
-                  </span>
-                </div>
-              ) : (
-                <div
-                  className="truncate px-2 pt-3 pb-1 text-xs font-medium text-muted-foreground/90"
-                  title={group.label}
-                >
-                  {group.key === "archived"
-                    ? `${group.label} · ${group.workspaces.length}`
-                    : group.label}
-                </div>
-              ))}
-            {group.workspaces.map((workspace) => {
-              const digest = digests[workspace.id];
-              const pr = digest?.pr_state ?? workspace.pr;
-              const creating = workspace.status === "creating";
-              const selected = selectedWorkspaceIds.includes(workspace.id);
-              const bulk = selected && selectedWorkspaces.length > 1;
-              return (
-                <LiveWorkspaceCard
-                  key={workspace.id}
-                  workspace={workspace}
-                  digest={digest}
-                  session={sessions[workspace.id]}
-                  repoName={
-                    repos.find((repo) => repo.id === workspace.repo_id)
-                      ?.display_name ?? workspace.repo_id
-                  }
-                  active={pathname === `/code/w/${workspace.id}`}
-                  selected={selected}
-                  terminalOpen={
-                    terminalOpen && viewedWorkspaceId === workspace.id
-                  }
-                  density={prefs.density}
-                  visibleMeta={{
-                    // The group header already names the repo in by-repo
-                    // order; the chip would say it twice on every row.
-                    repoChip:
-                      prefs.showRepoChip && prefs.sortMode !== "by-repo",
-                    branch: prefs.showBranch && !creating,
-                  }}
-                  contextMenuLabel={bulk ? "Workspace" : undefined}
-                  commands={
-                    creating
-                      ? []
-                      : bulk
-                        ? workspaceBulkCommands(selectedWorkspaces.length)
-                        : workspaceCommands({
-                            hasPr: Boolean(pr),
-                            archived: isPutAway(workspace),
-                            hasSession: Boolean(sessions[workspace.id]),
-                            attentionPinned:
-                              (
-                                digest?.attention ??
-                                sessions[workspace.id]?.attention
-                              )?.state.type === "manual",
-                            canOpenWorktree,
-                            setupFailed: workspace.status === "setup_failed",
-                          })
-                  }
-                  childSessions={watchChildren(
-                    { childrenByWorkspace },
-                    workspace.id,
-                  )}
-                  stackParent={workspaceStackParent(workspace, workspaces)}
-                  onOpenStackParent={(workspaceId) =>
-                    void navigate({
-                      to: "/code/w/$workspaceId",
-                      params: { workspaceId },
-                      search: workspacePanelSearch(workspaceId),
-                    })
-                  }
-                  onOpen={() => {
-                    if (creating) return;
-                    clearWorkspaceSelection();
-                    void navigate({
-                      to: "/code/w/$workspaceId",
-                      params: { workspaceId: workspace.id },
-                      search: workspacePanelSearch(workspace.id),
+        <WorkspaceRailGroups
+          sections={sections}
+          mode={prefs.sortMode}
+          collapsedKeys={collapsedKeys}
+          onToggle={toggleGroup}
+          renderWorkspace={(workspace) => {
+            const digest = digests[workspace.id];
+            const pr = digest?.pr_state ?? workspace.pr;
+            const creating = workspace.status === "creating";
+            const selected = selectedWorkspaceIds.includes(workspace.id);
+            const bulk = selected && selectedWorkspaces.length > 1;
+            return (
+              <LiveWorkspaceCard
+                key={workspace.id}
+                workspace={workspace}
+                digest={digest}
+                session={sessions[workspace.id]}
+                repoName={
+                  repos.find((repo) => repo.id === workspace.repo_id)
+                    ?.display_name ?? workspace.repo_id
+                }
+                active={pathname === `/code/w/${workspace.id}`}
+                selected={selected}
+                terminalOpen={
+                  terminalOpen && viewedWorkspaceId === workspace.id
+                }
+                density={prefs.density}
+                visibleMeta={{
+                  // The group header already names the repo in by-repo
+                  // order; the chip would say it twice on every row.
+                  repoChip: prefs.showRepoChip && prefs.sortMode !== "by-repo",
+                  branch: prefs.showBranch && !creating,
+                }}
+                contextMenuLabel={bulk ? "Workspace" : undefined}
+                commands={
+                  creating
+                    ? []
+                    : bulk
+                      ? workspaceBulkCommands(selectedWorkspaces.length)
+                      : workspaceCommands({
+                          hasPr: Boolean(pr),
+                          archived: isPutAway(workspace),
+                          hasSession: Boolean(sessions[workspace.id]),
+                          attentionPinned:
+                            (
+                              digest?.attention ??
+                              sessions[workspace.id]?.attention
+                            )?.state.type === "manual",
+                          canOpenWorktree,
+                          setupFailed: workspace.status === "setup_failed",
+                        })
+                }
+                childSessions={watchChildren(
+                  { childrenByWorkspace },
+                  workspace.id,
+                )}
+                stackParent={workspaceStackParent(workspace, workspaces)}
+                onOpenStackParent={(workspaceId) =>
+                  void navigate({
+                    to: "/code/w/$workspaceId",
+                    params: { workspaceId },
+                    search: workspacePanelSearch(workspaceId),
+                  })
+                }
+                onOpen={() => {
+                  if (creating) return;
+                  clearWorkspaceSelection();
+                  void navigate({
+                    to: "/code/w/$workspaceId",
+                    params: { workspaceId: workspace.id },
+                    search: workspacePanelSearch(workspace.id),
+                  });
+                }}
+                onSelectPointer={(event) =>
+                  applyPointerSelect(workspace.id, event)
+                }
+                onMenuOpen={() => {
+                  if (selectedWorkspaceIds.includes(workspace.id)) return;
+                  replaceWorkspaceSelection([workspace.id], workspace.id);
+                }}
+                onOpenChildSession={(sessionId) =>
+                  void navigate({
+                    to: "/code/w/$workspaceId",
+                    params: { workspaceId: workspace.id },
+                    search: {
+                      ...workspacePanelSearch(workspace.id),
+                      task: sessionId,
+                    },
+                  })
+                }
+                onOpenSubagent={(callId) =>
+                  void navigate({
+                    to: "/code/w/$workspaceId",
+                    params: { workspaceId: workspace.id },
+                    search: {
+                      ...workspacePanelSearch(workspace.id),
+                      subagent: callId,
+                    },
+                  })
+                }
+                onWorkflowAction={(
+                  action: WorkspaceWorkflowAction,
+                  currentPr,
+                ) => {
+                  const pr = currentPr;
+                  if (action === "open_pr") {
+                    run("open-pr", {
+                      workspace,
+                      title: digest?.title ?? workspace.title,
+                      pr,
+                      session: sessions[workspace.id],
                     });
-                  }}
-                  onSelectPointer={(event) =>
-                    applyPointerSelect(workspace.id, event)
+                    return;
                   }
-                  onMenuOpen={() => {
-                    if (selectedWorkspaceIds.includes(workspace.id)) return;
-                    replaceWorkspaceSelection([workspace.id], workspace.id);
-                  }}
-                  onOpenChildSession={(sessionId) =>
+                  if (action === "archive") {
+                    run("archive", {
+                      workspace,
+                      title: digest?.title ?? workspace.title,
+                      pr,
+                      session: sessions[workspace.id],
+                    });
+                    return;
+                  }
+                  if (
+                    action === "compose_pr" ||
+                    action === "update_pr" ||
+                    action === "follow_up_pr" ||
+                    action === "sync_branch" ||
+                    action === "resolve_divergence" ||
+                    action === "resolve_local_conflicts"
+                  ) {
+                    const prompt = workspaceActionPrompt(
+                      action,
+                      pr,
+                      workspace.base_ref,
+                    );
+                    if (prompt && !runComposerPrompt(workspace.id, prompt)) {
+                      toast.error("Another agent action is already running");
+                      return;
+                    }
                     void navigate({
                       to: "/code/w/$workspaceId",
                       params: { workspaceId: workspace.id },
-                      search: {
-                        ...workspacePanelSearch(workspace.id),
-                        task: sessionId,
-                      },
-                    })
+                    });
+                    return;
                   }
-                  onOpenSubagent={(callId) =>
+                  if (
+                    action === "open_source" ||
+                    action === "push" ||
+                    action === "create_pr" ||
+                    action === "merge" ||
+                    action === "mark_ready"
+                  ) {
+                    // Local-git stages never arise from the digest-only
+                    // model; the workspace page is where they resolve.
+                    // Merging and readying go there too: decision 42 makes
+                    // both the reader's call, and a card in a rail is the
+                    // wrong place to land a shared branch or open work for
+                    // review from — the header puts the pull request in
+                    // front of them first.
                     void navigate({
                       to: "/code/w/$workspaceId",
                       params: { workspaceId: workspace.id },
-                      search: {
-                        ...workspacePanelSearch(workspace.id),
-                        subagent: callId,
-                      },
-                    })
+                    });
+                    return;
                   }
-                  onWorkflowAction={(
-                    action: WorkspaceWorkflowAction,
-                    currentPr,
-                  ) => {
-                    const pr = currentPr;
-                    if (action === "open_pr") {
-                      run("open-pr", {
-                        workspace,
-                        title: digest?.title ?? workspace.title,
-                        pr,
-                        session: sessions[workspace.id],
-                      });
-                      return;
-                    }
-                    if (action === "archive") {
-                      run("archive", {
-                        workspace,
-                        title: digest?.title ?? workspace.title,
-                        pr,
-                        session: sessions[workspace.id],
-                      });
-                      return;
-                    }
+                  if (!pr) return;
+                  // Same prepared prompt the header control composes; the
+                  // navigation makes the started turn visible.
+                  //
+                  // Fix-errors downloads the failing jobs' logs first, and
+                  // that read takes a second or two the rail cannot show —
+                  // so it navigates first and the turn starts on the
+                  // workspace the reader is already looking at.
+                  if (action === "fix_errors") {
                     if (
-                      action === "compose_pr" ||
-                      action === "update_pr" ||
-                      action === "follow_up_pr" ||
-                      action === "sync_branch" ||
-                      action === "resolve_divergence" ||
-                      action === "resolve_local_conflicts"
-                    ) {
-                      const prompt = workspaceActionPrompt(
-                        action,
-                        pr,
-                        workspace.base_ref,
-                      );
-                      if (prompt && !runComposerPrompt(workspace.id, prompt)) {
-                        toast.error("Another agent action is already running");
-                        return;
-                      }
-                      void navigate({
-                        to: "/code/w/$workspaceId",
-                        params: { workspaceId: workspace.id },
-                      });
-                      return;
-                    }
-                    if (
-                      action === "open_source" ||
-                      action === "push" ||
-                      action === "create_pr" ||
-                      action === "merge" ||
-                      action === "mark_ready"
-                    ) {
-                      // Local-git stages never arise from the digest-only
-                      // model; the workspace page is where they resolve.
-                      // Merging and readying go there too: decision 42 makes
-                      // both the reader's call, and a card in a rail is the
-                      // wrong place to land a shared branch or open work for
-                      // review from — the header puts the pull request in
-                      // front of them first.
-                      void navigate({
-                        to: "/code/w/$workspaceId",
-                        params: { workspaceId: workspace.id },
-                      });
-                      return;
-                    }
-                    if (!pr) return;
-                    // Same prepared prompt the header control composes; the
-                    // navigation makes the started turn visible.
-                    //
-                    // Fix-errors downloads the failing jobs' logs first, and
-                    // that read takes a second or two the rail cannot show —
-                    // so it navigates first and the turn starts on the
-                    // workspace the reader is already looking at.
-                    if (action === "fix_errors") {
-                      if (
-                        useCodeUiStore.getState().composerActionScope !== null
-                      ) {
-                        toast.error("Another agent action is already running");
-                        return;
-                      }
-                      void navigate({
-                        to: "/code/w/$workspaceId",
-                        params: { workspaceId: workspace.id },
-                      });
-                      void fetchFixErrorsLogs(client, workspace.id).then(
-                        (logs) => {
-                          if (
-                            !runComposerPrompt(
-                              workspace.id,
-                              prWorkflowPrompt(action, pr, logs),
-                            )
-                          ) {
-                            toast.error(
-                              "Another agent action is already running",
-                            );
-                          }
-                        },
-                      );
-                      return;
-                    }
-                    if (
-                      !runComposerPrompt(
-                        workspace.id,
-                        prWorkflowPrompt(action, pr),
-                      )
+                      useCodeUiStore.getState().composerActionScope !== null
                     ) {
                       toast.error("Another agent action is already running");
                       return;
@@ -540,40 +493,67 @@ export function CodeSidebar() {
                       to: "/code/w/$workspaceId",
                       params: { workspaceId: workspace.id },
                     });
-                  }}
-                  onCommand={(command) => {
-                    if (
-                      bulk &&
-                      (command === "archive" || command === "force-archive")
-                    ) {
-                      runBulk(command, selectedWorkspaces);
-                      return;
-                    }
-                    run(command, {
-                      workspace,
-                      title: digest?.title ?? workspace.title,
-                      pr,
-                      session: sessions[workspace.id],
-                    });
-                  }}
-                />
-              );
-            })}
-          </div>
-        ))}
+                    void fetchFixErrorsLogs(client, workspace.id).then(
+                      (logs) => {
+                        if (
+                          !runComposerPrompt(
+                            workspace.id,
+                            prWorkflowPrompt(action, pr, logs),
+                          )
+                        ) {
+                          toast.error(
+                            "Another agent action is already running",
+                          );
+                        }
+                      },
+                    );
+                    return;
+                  }
+                  if (
+                    !runComposerPrompt(
+                      workspace.id,
+                      prWorkflowPrompt(action, pr),
+                    )
+                  ) {
+                    toast.error("Another agent action is already running");
+                    return;
+                  }
+                  void navigate({
+                    to: "/code/w/$workspaceId",
+                    params: { workspaceId: workspace.id },
+                  });
+                }}
+                onCommand={(command) => {
+                  if (
+                    bulk &&
+                    (command === "archive" || command === "force-archive")
+                  ) {
+                    runBulk(command, selectedWorkspaces);
+                    return;
+                  }
+                  run(command, {
+                    workspace,
+                    title: digest?.title ?? workspace.title,
+                    pr,
+                    session: sessions[workspace.id],
+                  });
+                }}
+              />
+            );
+          }}
+        />
         {repos.length === 0 && (
           <SidebarEmptyAction
             label="Add a repo"
             onClick={() => setAddRepoOpen(true)}
           />
         )}
-        {repos.length > 0 &&
-          groups.every((group) => group.workspaces.length === 0) && (
-            <SidebarEmptyAction
-              label="New workspace"
-              onClick={() => startNewWorkspace()}
-            />
-          )}
+        {repos.length > 0 && sections.length === 0 && (
+          <SidebarEmptyAction
+            label="New workspace"
+            onClick={() => startNewWorkspace()}
+          />
+        )}
       </div>
 
       {dialogs}

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.dom.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const COLLAPSED_KEY = "tidebreak.code-workspace-collapsed-groups";
+const PREFS_KEY = "tidebreak.code-rail-prefs";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("workspace rail preferences", () => {
+  it("restores source and subgroup collapse choices independently", async () => {
+    window.localStorage.setItem(
+      COLLAPSED_KEY,
+      JSON.stringify(["source:slack", "slack:by-repo:app"]),
+    );
+    const { useCodeUiStore } = await import("./CodeUiStore");
+    expect(useCodeUiStore.getState().collapsedWorkspaceGroups).toEqual([
+      "source:slack",
+      "slack:by-repo:app",
+    ]);
+
+    useCodeUiStore.getState().toggleWorkspaceGroup("source:slack");
+    expect(useCodeUiStore.getState().collapsedWorkspaceGroups).toEqual([
+      "slack:by-repo:app",
+    ]);
+    expect(JSON.parse(window.localStorage.getItem(COLLAPSED_KEY)!)).toEqual([
+      "slack:by-repo:app",
+    ]);
+
+    useCodeUiStore.getState().toggleWorkspaceGroup("source:slack");
+    expect(useCodeUiStore.getState().collapsedWorkspaceGroups).toEqual([
+      "slack:by-repo:app",
+      "source:slack",
+    ]);
+  });
+
+  it("persists a copied, distinct set of collapsed keys", async () => {
+    const { useCodeUiStore } = await import("./CodeUiStore");
+    const keys = ["source:local", "source:local", "slack:by-status:idle"];
+    useCodeUiStore.getState().setCollapsedWorkspaceGroups(keys);
+    keys.push("source:slack");
+    expect(useCodeUiStore.getState().collapsedWorkspaceGroups).toEqual([
+      "source:local",
+      "slack:by-status:idle",
+    ]);
+    expect(JSON.parse(window.localStorage.getItem(COLLAPSED_KEY)!)).toEqual([
+      "source:local",
+      "slack:by-status:idle",
+    ]);
+    useCodeUiStore.getState().setCollapsedWorkspaceGroups([]);
+    expect(window.localStorage.getItem(COLLAPSED_KEY)).toBe("[]");
+  });
+
+  it.each(["{broken", "null", '"source:slack"', '["source:slack", 1]'])(
+    "ignores invalid collapse storage %s",
+    async (raw) => {
+      window.localStorage.setItem(COLLAPSED_KEY, raw);
+      const { useCodeUiStore } = await import("./CodeUiStore");
+      expect(useCodeUiStore.getState().collapsedWorkspaceGroups).toEqual([]);
+    },
+  );
+
+  it("keeps collapse controls working when persistence fails", async () => {
+    const { useCodeUiStore } = await import("./CodeUiStore");
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("Storage unavailable");
+    });
+    expect(() =>
+      useCodeUiStore.getState().toggleWorkspaceGroup("source:slack"),
+    ).not.toThrow();
+    expect(useCodeUiStore.getState().collapsedWorkspaceGroups).toEqual([
+      "source:slack",
+    ]);
+  });
+
+  it("uses repository grouping for an old Created preference and preserves card choices", async () => {
+    window.localStorage.setItem(
+      PREFS_KEY,
+      JSON.stringify({
+        sortMode: "by-created",
+        density: "compact",
+        showRepoChip: false,
+        showBranch: true,
+      }),
+    );
+    const { useCodeUiStore } = await import("./CodeUiStore");
+    expect(useCodeUiStore.getState().railPrefs).toEqual({
+      sortMode: "by-repo",
+      density: "compact",
+      showRepoChip: false,
+      showBranch: true,
+    });
+  });
+
+  it("falls back from the legacy Created sort key", async () => {
+    window.localStorage.setItem("tidebreak.code-workspace-sort", "by-created");
+    const { useCodeUiStore } = await import("./CodeUiStore");
+    expect(useCodeUiStore.getState().railPrefs.sortMode).toBe("by-repo");
+  });
+
+  it("clears selection on host change and keeps rail preferences", async () => {
+    const { resetCodeUiHostState, useCodeUiStore } = await import(
+      "./CodeUiStore"
+    );
+    useCodeUiStore.getState().setCollapsedWorkspaceGroups(["source:slack"]);
+    useCodeUiStore.getState().setRailPrefs({ density: "compact" });
+    useCodeUiStore.getState().replaceWorkspaceSelection(["ws-a"], "ws-a");
+    resetCodeUiHostState();
+    expect(useCodeUiStore.getState().selectedWorkspaceIds).toEqual([]);
+    expect(useCodeUiStore.getState().selectionAnchorId).toBeNull();
+    expect(useCodeUiStore.getState().collapsedWorkspaceGroups).toEqual([
+      "source:slack",
+    ]);
+    expect(useCodeUiStore.getState().railPrefs.density).toBe("compact");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -19,6 +19,8 @@ const REVIEW_SIDEBAR_OPEN_KEY = "tidebreak.code-review-sidebar-open";
 const LAST_CREATE_KEY = "tidebreak.code-last-create";
 const WORKSPACE_SORT_KEY = "tidebreak.code-workspace-sort";
 const RAIL_PREFS_KEY = "tidebreak.code-rail-prefs";
+const COLLAPSED_WORKSPACE_GROUPS_KEY =
+  "tidebreak.code-workspace-collapsed-groups";
 const HARNESS_KINDS: readonly HarnessKind[] = [
   "claude_code",
   "codex",
@@ -298,6 +300,34 @@ function readStoredRailPrefs(): CodeRailPrefs {
   }
 }
 
+function readStoredCollapsedWorkspaceGroups(): string[] {
+  try {
+    const raw = window.localStorage.getItem(COLLAPSED_WORKSPACE_GROUPS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !Array.isArray(parsed) ||
+      !parsed.every((key): key is string => typeof key === "string")
+    ) {
+      return [];
+    }
+    return [...new Set(parsed)];
+  } catch {
+    return [];
+  }
+}
+
+function storeCollapsedWorkspaceGroups(keys: readonly string[]): void {
+  try {
+    window.localStorage.setItem(
+      COLLAPSED_WORKSPACE_GROUPS_KEY,
+      JSON.stringify(keys),
+    );
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
 function storeRailPrefs(prefs: CodeRailPrefs): void {
   try {
     window.localStorage.setItem(RAIL_PREFS_KEY, JSON.stringify(prefs));
@@ -339,6 +369,10 @@ export type CodeUiStore = {
   /** Files and diff scoped to one turn, or the whole worktree when null. */
   inspectorScope: InspectorScope | null;
   railPrefs: CodeRailPrefs;
+  /** Source and subgroup preferences use independent keys. */
+  collapsedWorkspaceGroups: string[];
+  setCollapsedWorkspaceGroups: (keys: readonly string[]) => void;
+  toggleWorkspaceGroup: (key: string) => void;
   lastCreate: CodeCreateDefaults | null;
   /** Optimistic first-agent handoffs, keyed by the workspace that owns them. */
   workspaceStartups: Record<string, WorkspaceStartup>;
@@ -493,6 +527,20 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   reviewSidebarOpen: readStoredReviewSidebarOpen(),
   inspectorScope: null,
   railPrefs: readStoredRailPrefs(),
+  collapsedWorkspaceGroups: readStoredCollapsedWorkspaceGroups(),
+  setCollapsedWorkspaceGroups: (keys) => {
+    const collapsedWorkspaceGroups = [...new Set(keys)];
+    storeCollapsedWorkspaceGroups(collapsedWorkspaceGroups);
+    set({ collapsedWorkspaceGroups });
+  },
+  toggleWorkspaceGroup: (key) => {
+    const collapsed = get().collapsedWorkspaceGroups;
+    get().setCollapsedWorkspaceGroups(
+      collapsed.includes(key)
+        ? collapsed.filter((candidate) => candidate !== key)
+        : [...collapsed, key],
+    );
+  },
   lastCreate: readStoredCreateDefaults(),
   workspaceStartups: {},
   setWorkspaceStartup: (workspaceId, startup) =>

--- a/crates/tidebreak-desktop/ui/src/code/RailSettingsMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RailSettingsMenu.dom.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_RAIL_PREFS, useCodeUiStore } from "./CodeUiStore";
+import { RailSettingsMenu } from "./RailSettingsMenu";
+
+afterEach(() => {
+  cleanup();
+  useCodeUiStore.setState({ railPrefs: DEFAULT_RAIL_PREFS });
+  window.localStorage.clear();
+});
+
+describe("RailSettingsMenu", () => {
+  it("keeps repository and status grouping in the settings popover", () => {
+    render(<RailSettingsMenu />);
+    expect(
+      screen.queryByRole("radiogroup", { name: "Group workspaces" }),
+    ).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Workspace list settings" }),
+    );
+    const group = screen.getByRole("radiogroup", { name: "Group workspaces" });
+    expect(
+      within(group)
+        .getAllByRole("radio")
+        .map((radio) => radio.textContent),
+    ).toEqual(["Repository", "Status"]);
+    fireEvent.click(within(group).getByRole("radio", { name: "Status" }));
+    expect(useCodeUiStore.getState().railPrefs.sortMode).toBe("by-status");
+    expect(
+      within(group).getByRole("radio", { name: "Status" }),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("uses supplied preferences and actions without changing the shared store", () => {
+    const onPrefsChange = vi.fn();
+    const { rerender } = render(
+      <RailSettingsMenu
+        prefs={{ ...DEFAULT_RAIL_PREFS, sortMode: "by-status" }}
+        onPrefsChange={onPrefsChange}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Workspace list settings" }),
+    );
+    const group = screen.getByRole("radiogroup", { name: "Group workspaces" });
+    expect(
+      within(group).getByRole("radio", { name: "Status" }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(within(group).getByRole("radio", { name: "Repository" }));
+    expect(onPrefsChange).toHaveBeenCalledWith({ sortMode: "by-repo" });
+    fireEvent.click(screen.getByRole("radio", { name: "Compact" }));
+    expect(onPrefsChange).toHaveBeenCalledWith({ density: "compact" });
+    expect(useCodeUiStore.getState().railPrefs).toEqual(DEFAULT_RAIL_PREFS);
+    rerender(
+      <RailSettingsMenu
+        prefs={DEFAULT_RAIL_PREFS}
+        onPrefsChange={onPrefsChange}
+      />,
+    );
+    expect(
+      within(group).getByRole("radio", { name: "Repository" }),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/RailSettingsMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RailSettingsMenu.tsx
@@ -19,14 +19,7 @@ import {
   WORKSPACE_SORT_MODES,
 } from "./workspaceCards";
 
-/**
- * The rail's one settings surface: order, density, and card metadata.
- *
- * A popover with real controls, not a menu: sort and density are radio
- * choices and the meta rows are switches, none of which a `DropdownMenu`
- * models without faking. Every control writes through `setRailPrefs`, so a
- * choice made here is the choice every window opens with.
- */
+/** Grouping, density, and card metadata share one settings popover. */
 
 const SORT_OPTIONS: readonly SegmentedOption<CodeRailPrefs["sortMode"]>[] =
   WORKSPACE_SORT_MODES.map((mode) => ({
@@ -40,9 +33,17 @@ const DENSITY_OPTIONS: readonly SegmentedOption<CodeRailPrefs["density"]>[] =
     label: CARD_DENSITY_LABELS[density],
   }));
 
-export function RailSettingsMenu() {
-  const prefs = useCodeUiStore((state) => state.railPrefs);
-  const setRailPrefs = useCodeUiStore((state) => state.setRailPrefs);
+export function RailSettingsMenu({
+  prefs: suppliedPrefs,
+  onPrefsChange,
+}: {
+  prefs?: CodeRailPrefs;
+  onPrefsChange?: (patch: Partial<CodeRailPrefs>) => void;
+} = {}) {
+  const storedPrefs = useCodeUiStore((state) => state.railPrefs);
+  const setStoredPrefs = useCodeUiStore((state) => state.setRailPrefs);
+  const prefs = suppliedPrefs ?? storedPrefs;
+  const setRailPrefs = onPrefsChange ?? setStoredPrefs;
 
   return (
     <Popover>
@@ -63,10 +64,10 @@ export function RailSettingsMenu() {
       >
         <div className="flex flex-col gap-1.5">
           <span className="text-xs font-medium text-muted-foreground">
-            Sort
+            Group by
           </span>
           <SegmentedControl
-            aria-label="Sort workspaces"
+            aria-label="Group workspaces"
             value={prefs.sortMode}
             onValueChange={(sortMode) => setRailPrefs({ sortMode })}
             options={SORT_OPTIONS}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceRailGroups.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceRailGroups.tsx
@@ -1,0 +1,156 @@
+import { useId, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import type { CodeWorkspaceSnapshot } from "@/api/types";
+import { cn } from "@/lib/utils";
+import { FOCUS_RING_INSET } from "./interactive";
+import { WorkspaceStatusMark } from "./WorkspaceCard";
+import {
+  isWorkspaceStatusRank,
+  workspaceGroupCollapseKey,
+  workspaceSourceCollapseKey,
+  type WorkspaceSortMode,
+  type WorkspaceSourceSection,
+} from "./workspaceCards";
+
+function Disclosure({
+  label,
+  count,
+  expanded,
+  onToggle,
+  level,
+  children,
+  mark,
+  sectionKey,
+}: {
+  label: string;
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+  level: "source" | "group";
+  children: ReactNode;
+  mark?: ReactNode;
+  sectionKey: string;
+}) {
+  const id = useId();
+  return (
+    <section
+      data-rail-section={sectionKey}
+      aria-label={label}
+      className={cn(
+        "min-w-0",
+        level === "source" ? "mb-3 last:mb-0" : "mb-1 last:mb-0",
+      )}
+    >
+      <h3 className="min-w-0">
+        <button
+          type="button"
+          aria-label={`${label}, ${count} ${count === 1 ? "workspace" : "workspaces"}`}
+          aria-expanded={expanded}
+          aria-controls={id}
+          onClick={onToggle}
+          className={cn(
+            "flex w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-2 text-left hover:bg-muted/70",
+            FOCUS_RING_INSET,
+            level === "source"
+              ? "h-8 text-sm font-semibold text-foreground"
+              : "h-7 text-xs font-medium text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <ChevronDown
+            aria-hidden
+            className={cn(
+              "size-3 shrink-0 text-muted-foreground motion-safe:transition-transform",
+              !expanded && "-rotate-90",
+            )}
+          />
+          {mark && (
+            <span aria-hidden className="shrink-0">
+              {mark}
+            </span>
+          )}
+          <span className="min-w-0 flex-1 truncate" title={label}>
+            {label}
+          </span>
+          <span className="shrink-0 font-mono text-2xs font-normal tabular-nums text-muted-foreground">
+            {count}
+          </span>
+        </button>
+      </h3>
+      <div
+        id={id}
+        hidden={!expanded}
+        className={level === "source" ? "pl-2" : "pl-3"}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}
+
+/** Source headings appear only when the list contains more than one source. */
+export function WorkspaceRailGroups({
+  sections,
+  mode,
+  collapsedKeys,
+  onToggle,
+  renderWorkspace,
+}: {
+  sections: readonly WorkspaceSourceSection[];
+  mode: WorkspaceSortMode;
+  collapsedKeys: readonly string[];
+  onToggle: (key: string) => void;
+  renderWorkspace: (workspace: CodeWorkspaceSnapshot) => ReactNode;
+}) {
+  const multipleSources = sections.length > 1;
+  function renderGroups(section: WorkspaceSourceSection) {
+    return section.groups.map((group) => {
+      const key = workspaceGroupCollapseKey(section.key, mode, group.key);
+      const rows = group.workspaces.map(renderWorkspace);
+      return group.label ? (
+        <Disclosure
+          key={key}
+          sectionKey={key}
+          label={group.label}
+          count={group.workspaces.length}
+          expanded={!collapsedKeys.includes(key)}
+          onToggle={() => onToggle(key)}
+          level="group"
+          mark={
+            isWorkspaceStatusRank(group.key) ? (
+              <WorkspaceStatusMark rank={group.key} />
+            ) : undefined
+          }
+        >
+          {rows}
+        </Disclosure>
+      ) : (
+        <div key={key} className="min-w-0">
+          {rows}
+        </div>
+      );
+    });
+  }
+  return sections.map((section) => {
+    const sourceKey = workspaceSourceCollapseKey(section.key);
+    return multipleSources ? (
+      <Disclosure
+        key={section.key}
+        sectionKey={sourceKey}
+        label={section.label}
+        count={section.groups.reduce(
+          (total, group) => total + group.workspaces.length,
+          0,
+        )}
+        expanded={!collapsedKeys.includes(sourceKey)}
+        onToggle={() => onToggle(sourceKey)}
+        level="source"
+      >
+        {renderGroups(section)}
+      </Disclosure>
+    ) : (
+      <div key={section.key} data-rail-source={section.key}>
+        {renderGroups(section)}
+      </div>
+    );
+  });
+}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceRailToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceRailToolbar.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode, ComponentProps } from "react";
+import { ChevronsDownUp, ChevronsUpDown, FolderPlus, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { RAIL_ICON_BUTTON } from "./interactive";
+import { RailSettingsMenu } from "./RailSettingsMenu";
+
+/** Keep workspace creation controls beside grouping and display settings. */
+export function WorkspaceRailToolbar({
+  children,
+  collapseKeys,
+  collapsedKeys,
+  onCollapsedChange,
+  onAddRepo,
+  onNewWorkspace,
+  settings,
+  className,
+}: {
+  children: ReactNode;
+  collapseKeys: readonly string[];
+  collapsedKeys: readonly string[];
+  onCollapsedChange: (keys: readonly string[]) => void;
+  onAddRepo: () => void;
+  onNewWorkspace: () => void;
+  settings?: ComponentProps<typeof RailSettingsMenu>;
+  className?: string;
+}) {
+  const allCollapsed =
+    collapseKeys.length > 0 &&
+    collapseKeys.every((key) => collapsedKeys.includes(key));
+  const collapseLabel = allCollapsed
+    ? "Expand all groups"
+    : "Collapse all groups";
+  return (
+    <div
+      role="toolbar"
+      aria-label="Workspace actions"
+      className={cn(
+        "flex shrink-0 items-center gap-0.5 px-1 pt-1 pb-1.5",
+        className,
+      )}
+    >
+      {children}
+      <button
+        type="button"
+        className={RAIL_ICON_BUTTON}
+        aria-label={collapseLabel}
+        title={collapseLabel}
+        disabled={collapseKeys.length === 0}
+        onClick={() =>
+          onCollapsedChange(
+            allCollapsed
+              ? collapsedKeys.filter((key) => !collapseKeys.includes(key))
+              : [...new Set([...collapsedKeys, ...collapseKeys])],
+          )
+        }
+      >
+        {allCollapsed ? (
+          <ChevronsUpDown size={15} />
+        ) : (
+          <ChevronsDownUp size={15} />
+        )}
+      </button>
+      <RailSettingsMenu {...settings} />
+      <button
+        type="button"
+        className={RAIL_ICON_BUTTON}
+        aria-label="Add repo"
+        title="Add repo"
+        onClick={onAddRepo}
+      >
+        <FolderPlus size={15} />
+      </button>
+      <button
+        type="button"
+        className={RAIL_ICON_BUTTON}
+        aria-label="New workspace"
+        title="New workspace"
+        onClick={onNewWorkspace}
+      >
+        <Plus size={15} />
+      </button>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { nextWorkspaceAfterLeaving, stepWorkspaceId } from "./railNavigation";
+import type { CodeSessionSnapshot, CodeWorkspaceSnapshot } from "../api/types";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { DEFAULT_RAIL_PREFS, useCodeUiStore } from "./CodeUiStore";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
+
+import {
+  nextWorkspaceAfterLeaving,
+  railWorkspaceIds,
+  stepRailWorkspace,
+  stepWorkspaceId,
+} from "./railNavigation";
 
 describe("stepWorkspaceId", () => {
   const rail = ["a", "b", "c"];
@@ -50,5 +60,101 @@ describe("nextWorkspaceAfterLeaving", () => {
     expect(
       nextWorkspaceAfterLeaving(["a", "b", "c"], "b", new Set(["a", "b", "c"])),
     ).toBeNull();
+  });
+});
+
+function workspace(id: string, repoId: string): CodeWorkspaceSnapshot {
+  return {
+    id,
+    repo_id: repoId,
+    title: id,
+    worktree_path: `/tmp/${id}`,
+    branch_name: id,
+    base_ref: "main",
+    status: "active",
+    created_at: "2026-08-15T00:00:00.000Z",
+  };
+}
+
+function slackSession(workspaceId: string): CodeSessionSnapshot {
+  return {
+    id: `session-${workspaceId}`,
+    workspace_id: workspaceId,
+    kind: "interactive",
+    harness_kind: "codex",
+    permission_mode: "ask",
+    fast_mode: false,
+    unrecognized_event_count: 0,
+    visibility: "private",
+    execution_location: "machine",
+    lifecycle: "idle",
+    attention: { state: { type: "idle" }, source: "lifecycle" },
+    created_at: "2026-08-15T00:00:00.000Z",
+    external_origin: {
+      channel_kind: "slack",
+      external_key: "T123:C123:1",
+    },
+  };
+}
+
+describe("railWorkspaceIds", () => {
+  afterEach(() => {
+    useCodeCatalogStore.getState().reset();
+    useCodeUpdatesStore.getState().reset();
+    useCodeUiStore.setState({
+      railPrefs: DEFAULT_RAIL_PREFS,
+      collapsedWorkspaceGroups: [],
+    });
+  });
+
+  it("navigates only expanded sources and subgroups", () => {
+    useCodeCatalogStore.setState({
+      repos: ["app", "lib"].map((id) => ({
+        id,
+        root_path: `/tmp/${id}`,
+        display_name: id,
+        default_base_ref: "main",
+        branch_prefix: "tidebreak",
+        quick_actions: [],
+        created_at: "2026-08-15T00:00:00.000Z",
+      })),
+      workspaces: [
+        workspace("local-app", "app"),
+        workspace("local-lib", "lib"),
+        workspace("slack-app", "app"),
+      ],
+      sessionsByWorkspace: { "slack-app": slackSession("slack-app") },
+    });
+    useCodeUiStore.setState({
+      railPrefs: { ...DEFAULT_RAIL_PREFS, sortMode: "by-repo" },
+      collapsedWorkspaceGroups: [],
+    });
+    expect(railWorkspaceIds()).toEqual(["local-app", "local-lib", "slack-app"]);
+
+    useCodeUiStore.getState().toggleWorkspaceGroup("local:by-repo:app");
+    expect(railWorkspaceIds()).toEqual(["local-lib", "slack-app"]);
+    expect(stepRailWorkspace("local-app", 1)).toBe("local-lib");
+    useCodeUiStore.getState().toggleWorkspaceGroup("source:slack");
+    expect(railWorkspaceIds()).toEqual(["local-lib"]);
+    expect(stepRailWorkspace("local-lib", 1)).toBe("local-lib");
+    useCodeUiStore.getState().toggleWorkspaceGroup("source:local");
+    expect(stepRailWorkspace("local-lib", 1)).toBeNull();
+
+    useCodeUiStore.getState().toggleWorkspaceGroup("source:local");
+    expect(railWorkspaceIds()).toEqual(["local-lib"]);
+  });
+
+  it("ignores a collapsed source when only that source remains", () => {
+    useCodeCatalogStore.setState({
+      workspaces: [workspace("slack-app", "app")],
+      sessionsByWorkspace: { "slack-app": slackSession("slack-app") },
+    });
+    useCodeUiStore.setState({
+      railPrefs: { ...DEFAULT_RAIL_PREFS, sortMode: "by-status" },
+      collapsedWorkspaceGroups: ["source:slack", "slack:by-repo:app"],
+    });
+    expect(railWorkspaceIds()).toEqual(["slack-app"]);
+    useCodeUiStore.getState().toggleWorkspaceGroup("slack:by-status:idle");
+    expect(railWorkspaceIds()).toEqual([]);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/railNavigation.ts
@@ -1,12 +1,15 @@
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore } from "./CodeUiStore";
 import { useCodeUpdatesStore, workspaceDigests } from "./CodeUpdatesStore";
-import { arrangeWorkspaces } from "./workspaceCards";
+import {
+  arrangeWorkspaceSections,
+  visibleWorkspaceGroups,
+} from "./workspaceCards";
 
 /**
  * Walking the workspace rail from the keyboard.
  *
- * The order is the rail's own — the same `arrangeWorkspaces` call the rail
+ * The order is the rail's own — the same grouping and collapse state the rail
  * renders, read from the same stores. Recomputing it here rather than caching
  * a list is what keeps the chord landing on the card the reader can see: sort
  * order, repo grouping, and archiving all move rows, and a remembered order
@@ -36,14 +39,20 @@ export function stepWorkspaceId(
 export function railWorkspaceIds(): string[] {
   const { repos, workspaces, sessionsByWorkspace } =
     useCodeCatalogStore.getState();
-  const { sortMode } = useCodeUiStore.getState().railPrefs;
+  const { railPrefs, collapsedWorkspaceGroups } = useCodeUiStore.getState();
+  const { sortMode } = railPrefs;
   const digests = workspaceDigests(useCodeUpdatesStore.getState());
-  return arrangeWorkspaces(
+  const sections = arrangeWorkspaceSections(
     sortMode,
     repos,
     workspaces,
     digests,
     sessionsByWorkspace,
+  );
+  return visibleWorkspaceGroups(
+    sections,
+    sortMode,
+    collapsedWorkspaceGroups,
   ).flatMap((group) => group.workspaces.map((workspace) => workspace.id));
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -9,6 +9,14 @@ import type {
 } from "../api/types";
 import {
   arrangeWorkspaces,
+  arrangeWorkspaceSections,
+  isWorkspaceSortMode,
+  visibleWorkspaceGroups,
+  workspaceCollapseKeys,
+  workspaceGroupCollapseKey,
+  workspaceSourceCollapseKey,
+  WORKSPACE_SORT_MODES,
+  WORKSPACE_SORT_MODE_LABELS,
   formatCompactAge,
   groupWorkspacesByRepo,
   listArchivedWorkspaces,
@@ -298,7 +306,7 @@ describe("arrangeWorkspaces", () => {
     ).toEqual(["needs_you", "idle"]);
   });
 
-  it("groups Slack DM and channel sessions apart from local ones", () => {
+  it("keeps subgroup metadata when flattening Local and Slack sources", () => {
     const rows = [
       workspace("ws-local", "app", "active", "2026-08-14T00:00:00.000Z"),
       workspace("ws-dm", "app", "active", "2026-08-16T00:00:00.000Z"),
@@ -322,10 +330,286 @@ describe("arrangeWorkspaces", () => {
         group.workspaces.map((item) => item.id),
       ]),
     ).toEqual([
-      ["local", "Local", ["ws-local"]],
-      ["slack:channel", "Slack channel", ["ws-channel"]],
-      ["slack:dm", "Slack DM", ["ws-dm"]],
+      ["created", null, ["ws-local"]],
+      ["created", null, ["ws-channel", "ws-dm"]],
     ]);
+  });
+});
+
+describe("arrangeWorkspaceSections", () => {
+  const repos = [repo("lib"), repo("app")];
+  const rows = [
+    workspace("ws-channel", "app", "active", "2026-08-17T00:00:00.000Z"),
+    workspace("ws-local-new", "app", "active", "2026-08-17T00:00:00.000Z"),
+    workspace("ws-dm", "lib", "active", "2026-08-16T00:00:00.000Z"),
+    workspace("ws-local-old", "app", "active", "2026-08-14T00:00:00.000Z"),
+    workspace("ws-dm-old", "app", "active", "2026-08-14T00:00:00.000Z"),
+    workspace("ws-archived", "app", "archived"),
+    workspace("ws-released", "lib", "released"),
+  ];
+  const sessions = {
+    "ws-channel": sessionOn("ws-channel", {
+      channel_kind: "slack",
+      external_key: "T0400000:C0812345:1724900000.123456",
+    }),
+    "ws-dm": sessionOn("ws-dm", {
+      channel_kind: "slack",
+      external_key: "T0400000:D0898765:dm2",
+    }),
+    "ws-dm-old": sessionOn("ws-dm-old", {
+      channel_kind: "slack",
+      external_key: "T0400000:D0898765:dm1",
+    }),
+    "ws-archived": sessionOn("ws-archived", {
+      channel_kind: "another_source",
+      external_key: "archived",
+    }),
+  };
+  const digests = {
+    "ws-local-new": digest("ws-local-new", { lifecycle: "running" }),
+    "ws-dm": digest("ws-dm", { lifecycle: "running" }),
+  };
+
+  it("keeps repository headings inside Local and a shared Slack section", () => {
+    const sections = arrangeWorkspaceSections(
+      "by-repo",
+      repos,
+      rows,
+      {},
+      sessions,
+    );
+    expect(
+      sections.map((section) => [
+        section.key,
+        section.label,
+        section.groups.map((group) => [
+          group.key,
+          group.label,
+          group.repoId,
+          idsOf([group]),
+        ]),
+      ]),
+    ).toEqual([
+      [
+        "local",
+        "Local",
+        [["app", "app", "app", ["ws-local-old", "ws-local-new"]]],
+      ],
+      [
+        "slack",
+        "Slack",
+        [
+          ["lib", "lib", "lib", ["ws-dm"]],
+          ["app", "app", "app", ["ws-dm-old", "ws-channel"]],
+        ],
+      ],
+    ]);
+    expect(arrangeWorkspaces("by-repo", repos, rows, {}, sessions)).toEqual(
+      sections.flatMap((section) => section.groups),
+    );
+  });
+
+  it("keeps status headings and rank order inside each source", () => {
+    const sections = arrangeWorkspaceSections(
+      "by-status",
+      repos,
+      rows,
+      digests,
+      sessions,
+    );
+    expect(
+      sections.map((section) => [
+        section.label,
+        section.groups.map((group) => [group.label, idsOf([group])]),
+      ]),
+    ).toEqual([
+      [
+        "Local",
+        [
+          ["Running", ["ws-local-new"]],
+          ["Idle", ["ws-local-old"]],
+        ],
+      ],
+      [
+        "Slack",
+        [
+          ["Running", ["ws-dm"]],
+          ["Idle", ["ws-channel", "ws-dm-old"]],
+        ],
+      ],
+    ]);
+  });
+
+  it("keeps row order when catalog and session insertion order changes", () => {
+    for (const mode of ["by-repo", "by-status"] as const) {
+      const original = arrangeWorkspaceSections(
+        mode,
+        repos,
+        rows,
+        digests,
+        sessions,
+      );
+      const reordered = arrangeWorkspaceSections(
+        mode,
+        repos,
+        [...rows].reverse(),
+        Object.fromEntries(Object.entries(digests).reverse()),
+        Object.fromEntries(Object.entries(sessions).reverse()),
+      );
+      expect(reordered).toEqual(original);
+    }
+  });
+
+  it("omits empty and archived-only sources", () => {
+    for (const mode of ["by-repo", "by-status", "by-created"] as const) {
+      expect(arrangeWorkspaceSections(mode, repos, [], {}, sessions)).toEqual(
+        [],
+      );
+      expect(
+        arrangeWorkspaceSections(
+          mode,
+          repos,
+          rows.filter(
+            (row) => row.status === "archived" || row.status === "released",
+          ),
+          {},
+          sessions,
+        ),
+      ).toEqual([]);
+    }
+  });
+
+  it("labels future source kinds without exposing identifier separators", () => {
+    const sections = arrangeWorkspaceSections(
+      "by-repo",
+      repos,
+      [workspace("ws-other", "app")],
+      {},
+      {
+        "ws-other": sessionOn("ws-other", {
+          channel_kind: "team_chat",
+          external_key: "thread",
+        }),
+      },
+    );
+    expect(sections.map(({ key, label }) => ({ key, label }))).toEqual([
+      { key: "team_chat", label: "Team chat" },
+    ]);
+  });
+
+  it("collapses each source and subgroup independently", () => {
+    const sections = arrangeWorkspaceSections(
+      "by-repo",
+      repos,
+      rows,
+      {},
+      sessions,
+    );
+    const localGroup = workspaceGroupCollapseKey("local", "by-repo", "app");
+    const slackGroup = workspaceGroupCollapseKey("slack", "by-repo", "app");
+    const slackSource = workspaceSourceCollapseKey("slack");
+    expect(workspaceCollapseKeys(sections, "by-repo")).toEqual([
+      "source:local",
+      "local:by-repo:app",
+      "source:slack",
+      "slack:by-repo:lib",
+      "slack:by-repo:app",
+    ]);
+    expect(
+      idsOf(visibleWorkspaceGroups(sections, "by-repo", [localGroup])),
+    ).toEqual(["ws-dm", "ws-dm-old", "ws-channel"]);
+    expect(
+      idsOf(visibleWorkspaceGroups(sections, "by-repo", [slackGroup])),
+    ).toEqual(["ws-local-old", "ws-local-new", "ws-dm"]);
+    const collapsed = [slackGroup, slackSource];
+    expect(
+      idsOf(visibleWorkspaceGroups(sections, "by-repo", collapsed)),
+    ).toEqual(["ws-local-old", "ws-local-new"]);
+    expect(
+      idsOf(
+        visibleWorkspaceGroups(
+          sections,
+          "by-repo",
+          collapsed.filter((key) => key !== slackSource),
+        ),
+      ),
+    ).toEqual(["ws-local-old", "ws-local-new", "ws-dm"]);
+    expect(
+      visibleWorkspaceGroups(
+        sections,
+        "by-repo",
+        workspaceCollapseKeys(sections, "by-repo"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not apply a repository collapse choice to a status group", () => {
+    const statusSections = arrangeWorkspaceSections(
+      "by-status",
+      repos,
+      rows,
+      digests,
+      sessions,
+    );
+    expect(
+      visibleWorkspaceGroups(statusSections, "by-status", [
+        workspaceGroupCollapseKey("slack", "by-repo", "idle"),
+      ]),
+    ).toEqual(statusSections.flatMap((section) => section.groups));
+  });
+
+  it("ignores a saved source collapse when only one source remains", () => {
+    const slackRows = rows.filter(
+      (row) =>
+        sessions[row.id as keyof typeof sessions]?.external_origin
+          ?.channel_kind === "slack",
+    );
+    const sections = arrangeWorkspaceSections(
+      "by-repo",
+      repos,
+      slackRows,
+      {},
+      sessions,
+    );
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.key).toBe("slack");
+    expect(workspaceCollapseKeys(sections, "by-repo")).toEqual([
+      "slack:by-repo:lib",
+      "slack:by-repo:app",
+    ]);
+    expect(
+      idsOf(visibleWorkspaceGroups(sections, "by-repo", ["source:slack"])),
+    ).toEqual(["ws-dm", "ws-dm-old", "ws-channel"]);
+  });
+
+  it("does not collapse compatibility groups without a heading", () => {
+    const sections = arrangeWorkspaceSections(
+      "by-created",
+      repos,
+      rows,
+      {},
+      sessions,
+    );
+    expect(workspaceCollapseKeys(sections, "by-created")).toEqual([
+      "source:local",
+      "source:slack",
+    ]);
+    expect(
+      visibleWorkspaceGroups(sections, "by-created", [
+        "local:by-created:created",
+      ]),
+    ).toEqual(sections.flatMap((section) => section.groups));
+  });
+});
+
+describe("workspace grouping settings", () => {
+  it("offers only Repository and Status and rejects a saved Created setting", () => {
+    expect(
+      WORKSPACE_SORT_MODES.map((mode) => WORKSPACE_SORT_MODE_LABELS[mode]),
+    ).toEqual(["Repository", "Status"]);
+    expect(isWorkspaceSortMode("by-repo")).toBe(true);
+    expect(isWorkspaceSortMode("by-status")).toBe(true);
+    expect(isWorkspaceSortMode("by-created")).toBe(false);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -8,10 +8,6 @@ import type {
 } from "../api/types";
 import { attentionLabel, LIFECYCLE_LABELS } from "./labels";
 import {
-  sessionOriginGroupLabel,
-  slackConversationKind,
-} from "./SessionOriginBanner";
-import {
   prCompactStatusLabel,
   pullRequestLifecycle,
   type PrStateInput,
@@ -79,13 +75,12 @@ export type WorkspaceSortMode = "by-repo" | "by-status" | "by-created";
 export const WORKSPACE_SORT_MODES: readonly WorkspaceSortMode[] = [
   "by-repo",
   "by-status",
-  "by-created",
 ];
 
 export const WORKSPACE_SORT_MODE_LABELS: Record<WorkspaceSortMode, string> = {
-  "by-repo": "By repo",
-  "by-status": "By status",
-  "by-created": "By created",
+  "by-repo": "Repository",
+  "by-status": "Status",
+  "by-created": "Created",
 };
 
 export function isWorkspaceSortMode(value: string): value is WorkspaceSortMode {
@@ -302,15 +297,41 @@ export type ArrangedWorkspaceGroup = {
   workspaces: CodeWorkspaceSnapshot[];
 };
 
+export type WorkspaceSourceSection = {
+  key: string;
+  label: string;
+  groups: ArrangedWorkspaceGroup[];
+};
+
 /**
- * The one function the rail reads. Ordering is a pure function of created_at,
- * repo catalog order, and status rank — never catalog array order or digest
- * insertion order.
- *
- * Archived workspaces are always off the rail. Their full catalog lives on
- * the dedicated Archive page, so put-away work never interleaves with live
- * triage.
+ * Group live workspaces by source, then by repository or status. Local comes
+ * first; Slack channels and DMs share one source. Each source keeps the same
+ * repository, status, and creation order as a rail with only local work.
  */
+export function arrangeWorkspaceSections(
+  mode: WorkspaceSortMode,
+  repos: readonly CodeRepoSnapshot[],
+  workspaces: readonly CodeWorkspaceSnapshot[],
+  digests: Readonly<Record<string, CodeSessionDigest | undefined>>,
+  sessions: Readonly<Record<string, CodeSessionSnapshot | undefined>> = {},
+): WorkspaceSourceSection[] {
+  const buckets = new Map<string, CodeWorkspaceSnapshot[]>();
+  for (const workspace of workspaces) {
+    if (isPutAway(workspace)) continue;
+    const key =
+      sessions[workspace.id]?.external_origin?.channel_kind ?? "local";
+    const listed = buckets.get(key);
+    if (listed) listed.push(workspace);
+    else buckets.set(key, [workspace]);
+  }
+  return orderedSourceKeys(buckets.keys()).map((key) => ({
+    key,
+    label: sourceLabel(key),
+    groups: arrangeLiveWorkspaces(mode, repos, buckets.get(key) ?? [], digests),
+  }));
+}
+
+/** Flatten sources in display order while preserving their group metadata. */
 export function arrangeWorkspaces(
   mode: WorkspaceSortMode,
   repos: readonly CodeRepoSnapshot[],
@@ -318,56 +339,72 @@ export function arrangeWorkspaces(
   digests: Readonly<Record<string, CodeSessionDigest | undefined>>,
   sessions: Readonly<Record<string, CodeSessionSnapshot | undefined>> = {},
 ): ArrangedWorkspaceGroup[] {
-  const live = workspaces.filter((workspace) => !isPutAway(workspace));
-  const originKeys = new Set(
-    live.map((workspace) => originGroupKey(sessions[workspace.id])),
-  );
-  const usesOriginGroups =
-    originKeys.size > 1 || (originKeys.size === 1 && !originKeys.has("local"));
-  if (!usesOriginGroups) {
-    return arrangeLiveWorkspaces(mode, repos, workspaces, digests);
-  }
-  const buckets = new Map<string, CodeWorkspaceSnapshot[]>();
-  for (const workspace of live) {
-    const key = originGroupKey(sessions[workspace.id]);
-    const listed = buckets.get(key);
-    if (listed) listed.push(workspace);
-    else buckets.set(key, [workspace]);
-  }
-  const groups: ArrangedWorkspaceGroup[] = [];
-  for (const key of orderedOriginKeys(buckets.keys())) {
-    const listed = buckets.get(key);
-    if (!listed || listed.length === 0) continue;
-    groups.push({
-      key,
-      label: originGroupHeader(key, sessions[listed[0]!.id]),
-      workspaces: arrangeLiveWorkspaces(mode, repos, listed, digests).flatMap(
-        (group) => group.workspaces,
-      ),
-    });
-  }
-  return groups;
+  return arrangeWorkspaceSections(
+    mode,
+    repos,
+    workspaces,
+    digests,
+    sessions,
+  ).flatMap((section) => section.groups);
 }
 
-function originGroupKey(session: CodeSessionSnapshot | undefined): string {
-  const origin = session?.external_origin;
-  if (!origin) return "local";
-  return `${origin.channel_kind}:${slackConversationKind(origin.external_key)}`;
+export function workspaceSourceCollapseKey(sectionKey: string): string {
+  return `source:${sectionKey}`;
 }
 
-function originGroupHeader(
-  key: string,
-  session: CodeSessionSnapshot | undefined,
+export function workspaceGroupCollapseKey(
+  sectionKey: string,
+  mode: WorkspaceSortMode,
+  groupKey: string,
 ): string {
-  if (key === "local") return "Local";
-  if (session?.external_origin) {
-    return sessionOriginGroupLabel(session.external_origin);
-  }
-  return key;
+  return `${sectionKey}:${mode}:${groupKey}`;
 }
 
-function orderedOriginKeys(keys: Iterable<string>): string[] {
+/** Only visible headings participate in collapse-all and expand-all. */
+export function workspaceCollapseKeys(
+  sections: readonly WorkspaceSourceSection[],
+  mode: WorkspaceSortMode,
+): string[] {
+  return sections.flatMap((section) => [
+    ...(sections.length > 1 ? [workspaceSourceCollapseKey(section.key)] : []),
+    ...section.groups
+      .filter((group) => group.label !== null)
+      .map((group) => workspaceGroupCollapseKey(section.key, mode, group.key)),
+  ]);
+}
+
+/** Match visible rows for rendering, selection, and keyboard navigation. */
+export function visibleWorkspaceGroups(
+  sections: readonly WorkspaceSourceSection[],
+  mode: WorkspaceSortMode,
+  collapsedKeys: readonly string[],
+): ArrangedWorkspaceGroup[] {
+  const collapsed = new Set(collapsedKeys);
+  return sections.flatMap((section) => {
+    if (
+      sections.length > 1 &&
+      collapsed.has(workspaceSourceCollapseKey(section.key))
+    ) {
+      return [];
+    }
+    return section.groups.filter(
+      (group) =>
+        group.label === null ||
+        !collapsed.has(workspaceGroupCollapseKey(section.key, mode, group.key)),
+    );
+  });
+}
+
+function sourceLabel(key: string): string {
+  if (key === "local") return "Local";
+  if (key === "slack") return "Slack";
+  const words = key.replace(/[-_:]+/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function orderedSourceKeys(keys: Iterable<string>): string[] {
   return [...keys].sort((left, right) => {
+    if (left === right) return 0;
     if (left === "local") return -1;
     if (right === "local") return 1;
     return left.localeCompare(right);

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceRail.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceRail.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { WorkspaceRailDraft } from "./workspace-rail/WorkspaceRailDraft";
+
+async function checkWorkspaceActions(canvasElement: HTMLElement) {
+  const toolbar = within(
+    within(canvasElement).getByRole("toolbar", { name: "Workspace actions" }),
+  );
+  await expect(toolbar.getByRole("button", { name: "Add repo" })).toBeVisible();
+  await expect(
+    toolbar.getByRole("button", { name: "New workspace" }),
+  ).toBeVisible();
+  return toolbar;
+}
+
+const meta = {
+  title: "Code/Workspace list draft",
+  component: WorkspaceRailDraft,
+  args: {
+    scenario: "repository",
+    onAddRepo: fn(),
+    onNewWorkspace: fn(),
+  },
+  parameters: { layout: "fullscreen" },
+  play: async ({ canvasElement }) => {
+    await checkWorkspaceActions(canvasElement);
+    canvasElement.dataset.railReady = "true";
+  },
+  render: (args) => <WorkspaceRailDraft key={args.scenario} {...args} />,
+} satisfies Meta<typeof WorkspaceRailDraft>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ByRepository: Story = {
+  play: async ({ canvasElement }) => {
+    await checkWorkspaceActions(canvasElement);
+    const canvas = within(canvasElement);
+    const local = within(canvas.getByRole("region", { name: "Local" }));
+    const slack = within(canvas.getByRole("region", { name: "Slack" }));
+    await expect(
+      local.getByRole("button", { name: "tidebreak, 2 workspaces" }),
+    ).toBeVisible();
+    await expect(
+      slack.getByRole("button", { name: "tidebreak, 3 workspaces" }),
+    ).toBeVisible();
+    await userEvent.click(
+      local.getByRole("button", { name: "model-gateway, 2 workspaces" }),
+    );
+    await expect(
+      local.queryByRole("button", { name: /^Fix credential refresh retries/ }),
+    ).not.toBeInTheDocument();
+    await expect(
+      slack.getByRole("button", { name: /^Finish Slack decision cards/ }),
+    ).toBeVisible();
+    await userEvent.click(
+      local.getByRole("button", { name: "Local, 4 workspaces" }),
+    );
+    await userEvent.click(
+      local.getByRole("button", { name: "Local, 4 workspaces" }),
+    );
+    await expect(
+      local.getByRole("button", { name: "model-gateway, 2 workspaces" }),
+    ).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(
+      local.getByRole("button", { name: "model-gateway, 2 workspaces" }),
+    );
+    canvasElement.dataset.railReady = "true";
+  },
+};
+export const ByStatus: Story = {
+  args: { scenario: "status" },
+  play: async ({ canvasElement, args }) => {
+    const toolbar = await checkWorkspaceActions(canvasElement);
+    await userEvent.click(toolbar.getByRole("button", { name: "Add repo" }));
+    await expect(args.onAddRepo).toHaveBeenCalled();
+    await userEvent.click(
+      toolbar.getByRole("button", { name: "New workspace" }),
+    );
+    await expect(args.onNewWorkspace).toHaveBeenCalled();
+    const canvas = within(canvasElement);
+    for (const label of ["Local", "Slack"]) {
+      const source = within(canvas.getByRole("region", { name: label }));
+      await expect(
+        source.getByRole("button", { name: "Needs you, 1 workspace" }),
+      ).toBeVisible();
+      await expect(
+        source.getByRole("button", { name: "Running, 2 workspaces" }),
+      ).toBeVisible();
+    }
+    canvasElement.dataset.railReady = "true";
+  },
+};
+export const OneSource: Story = {
+  args: { scenario: "single-source" },
+  play: async ({ canvasElement }) => {
+    await checkWorkspaceActions(canvasElement);
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByRole("region", { name: "Slack" }),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", { name: "tidebreak, 3 workspaces" }),
+    ).toBeVisible();
+    canvasElement.dataset.railReady = "true";
+  },
+};
+export const Collapsed: Story = { args: { scenario: "collapsed" } };
+export const NarrowLongNames: Story = { args: { scenario: "long-names" } };
+export const Empty: Story = { args: { scenario: "empty" } };
+export const Loading: Story = { args: { scenario: "loading" } };
+export const LoadFailure: Story = { args: { scenario: "error" } };

--- a/crates/tidebreak-desktop/ui/src/stories/workspace-rail/WorkspaceRailDraft.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/workspace-rail/WorkspaceRailDraft.tsx
@@ -1,0 +1,339 @@
+import { useState } from "react";
+import { FolderGit2, MessageCircle, Monitor, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { SegmentedControl } from "@/components/ui/segmented";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Logomark } from "@/Logomark";
+import { cn } from "@/lib/utils";
+import { WorkspaceCard } from "@/code/WorkspaceCard";
+import {
+  arrangeWorkspaceSections,
+  workspaceCollapseKeys,
+  type CardDensity,
+  type WorkspaceSortMode,
+} from "@/code/workspaceCards";
+import { WorkspaceRailGroups } from "@/code/WorkspaceRailGroups";
+import { WorkspaceRailToolbar } from "@/code/WorkspaceRailToolbar";
+import { railEntries, railRepositories } from "./fixtures";
+
+export type RailScenario =
+  | "repository"
+  | "status"
+  | "single-source"
+  | "collapsed"
+  | "long-names"
+  | "empty"
+  | "loading"
+  | "error";
+export function WorkspaceRailDraft({
+  scenario,
+  onAddRepo,
+  onNewWorkspace,
+}: {
+  scenario: RailScenario;
+  onAddRepo: () => void;
+  onNewWorkspace: () => void;
+}) {
+  const [mode, setMode] = useState<WorkspaceSortMode>(
+    scenario === "status" ? "by-status" : "by-repo",
+  );
+  const [density, setDensity] = useState<CardDensity>(
+    scenario === "long-names" ? "compact" : "detailed",
+  );
+  const [showRepoChip, setShowRepoChip] = useState(true);
+  const [showBranch, setShowBranch] = useState(false);
+  const [sourceChoice, setSourceChoice] = useState<"mixed" | "slack">(
+    scenario === "single-source" ? "slack" : "mixed",
+  );
+  const [collapsed, setCollapsed] = useState<Set<string>>(
+    () =>
+      new Set(
+        scenario === "collapsed"
+          ? ["source:slack", "local:by-repo:repo-model-gateway"]
+          : [],
+      ),
+  );
+  const [selected, setSelected] = useState("workspace-grouping");
+  const [recovered, setRecovered] = useState(false);
+  const state = recovered ? "repository" : scenario;
+  const repos = railRepositories.map((repo, index) =>
+    scenario === "long-names" && index === 1
+      ? { ...repo, display_name: "platform-infrastructure-and-model-gateway" }
+      : repo,
+  );
+  const entries =
+    state === "empty"
+      ? []
+      : railEntries
+          .filter(
+            (entry) =>
+              sourceChoice === "mixed" || entry.session.external_origin,
+          )
+          .map((entry) =>
+            scenario === "long-names"
+              ? {
+                  ...entry,
+                  workspace: {
+                    ...entry.workspace,
+                    title: `${entry.workspace.title} across every connected machine and repository`,
+                  },
+                  digest: entry.digest
+                    ? {
+                        ...entry.digest,
+                        title: `${entry.workspace.title} across every connected machine and repository`,
+                      }
+                    : undefined,
+                }
+              : entry,
+          );
+  const sections = arrangeWorkspaceSections(
+    mode,
+    repos,
+    entries.map((entry) => entry.workspace),
+    Object.fromEntries(
+      entries.map((entry) => [entry.workspace.id, entry.digest]),
+    ),
+    Object.fromEntries(
+      entries.map((entry) => [entry.workspace.id, entry.session]),
+    ),
+  );
+  const multipleSources = sections.length > 1;
+  const entryById = new Map(
+    entries.map((entry) => [entry.workspace.id, entry]),
+  );
+  const selectedEntry = entryById.get(selected);
+  const collapseKeys = workspaceCollapseKeys(sections, mode);
+  function toggle(key: string) {
+    setCollapsed((before) => {
+      const next = new Set(before);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+  return (
+    <div
+      className="flex h-full min-h-0 w-full overflow-hidden"
+      data-testid="workspace-rail-draft"
+    >
+      <aside
+        aria-label="Workspace navigation"
+        className={cn(
+          "flex h-full min-h-0 shrink-0 flex-col border-r border-border-subtle bg-page-background",
+          scenario === "long-names" ? "w-[240px]" : "w-[300px] max-sm:w-full",
+        )}
+      >
+        <div className="flex h-12 shrink-0 items-center gap-2.5 px-4">
+          <Logomark width="30" height="16" />
+          <span className="font-mono text-sm font-medium">Tidebreak</span>
+          <span className="ml-auto text-xs text-muted-foreground">Code</span>
+        </div>
+        <WorkspaceRailToolbar
+          className="px-4 pt-2 pb-2"
+          collapseKeys={collapseKeys}
+          collapsedKeys={[...collapsed]}
+          onCollapsedChange={(keys) => setCollapsed(new Set(keys))}
+          onAddRepo={onAddRepo}
+          onNewWorkspace={onNewWorkspace}
+          settings={{
+            prefs: { sortMode: mode, density, showRepoChip, showBranch },
+            onPrefsChange: (patch) => {
+              if (patch.sortMode) setMode(patch.sortMode);
+              if (patch.density) setDensity(patch.density);
+              if (patch.showRepoChip !== undefined)
+                setShowRepoChip(patch.showRepoChip);
+              if (patch.showBranch !== undefined)
+                setShowBranch(patch.showBranch);
+            },
+          }}
+        >
+          <h2 className="min-w-0 flex-1 text-sm font-medium">Workspaces</h2>
+        </WorkspaceRailToolbar>
+        <div
+          className="min-h-0 flex-1 overflow-y-auto px-2 pb-4"
+          data-testid="workspace-list"
+        >
+          {state === "loading" ? (
+            <div
+              role="status"
+              aria-label="Loading workspaces"
+              className="space-y-5 px-2 pt-3"
+            >
+              {[0, 1].map((index) => (
+                <div key={index} className="space-y-3">
+                  <Skeleton className="h-3 w-20" />
+                  {[0, 1, 2].map((row) => (
+                    <div key={row} className="space-y-2 pl-5">
+                      <Skeleton className="h-3 w-4/5" />
+                      <Skeleton className="h-2 w-3/5" />
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          ) : state === "error" ? (
+            <div
+              role="alert"
+              className="notice-surface notice-critical mx-1 mt-2 rounded-md px-3 py-3"
+            >
+              <p className="text-sm font-medium">Workspaces could not load</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Check your connection and try again.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                className="mt-3"
+                onClick={() => setRecovered(true)}
+              >
+                Try again
+              </Button>
+            </div>
+          ) : entries.length === 0 ? (
+            <Empty className="min-h-56 px-3">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <FolderGit2 />
+                </EmptyMedia>
+                <EmptyTitle>No workspaces yet</EmptyTitle>
+                <EmptyDescription>
+                  Start a workspace when you are ready to work in a repository.
+                </EmptyDescription>
+              </EmptyHeader>
+              <Button size="sm" variant="outline" onClick={onNewWorkspace}>
+                <Plus />
+                New workspace
+              </Button>
+            </Empty>
+          ) : (
+            <WorkspaceRailGroups
+              sections={sections}
+              mode={mode}
+              collapsedKeys={[...collapsed]}
+              onToggle={toggle}
+              renderWorkspace={(workspace) => {
+                const entry = entryById.get(workspace.id)!;
+                return (
+                  <WorkspaceCard
+                    key={workspace.id}
+                    workspace={workspace}
+                    digest={entry.digest}
+                    session={entry.session}
+                    repoName={
+                      repos.find((repo) => repo.id === workspace.repo_id)
+                        ?.display_name ?? workspace.repo_id
+                    }
+                    active={selected === workspace.id}
+                    terminalOpen={false}
+                    density={density}
+                    visibleMeta={{
+                      repoChip: showRepoChip && mode !== "by-repo",
+                      branch: showBranch,
+                    }}
+                    commands={[]}
+                    onOpen={() => setSelected(workspace.id)}
+                    onCommand={() => {}}
+                  />
+                );
+              }}
+            />
+          )}
+        </div>
+        <div className="flex h-9 shrink-0 items-center border-t border-border-subtle px-4 text-xs text-muted-foreground">
+          {state === "loading"
+            ? "Loading workspaces…"
+            : state === "error"
+              ? "Connection unavailable"
+              : `${entries.length} workspaces`}
+          <span className="ml-auto">
+            {multipleSources ? "2 sources" : entries.length ? "1 source" : ""}
+          </span>
+        </div>
+      </aside>
+      <main className="hidden min-w-0 flex-1 overflow-y-auto bg-background sm:block">
+        <header className="flex h-12 items-center border-b border-border-subtle px-6 text-xs text-muted-foreground">
+          Storybook draft<span className="ml-auto">Workspace navigation</span>
+        </header>
+        <div className="mx-auto max-w-xl px-8 pt-12 pb-8">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Source, then your grouping
+          </h1>
+          <p className="mt-3 text-md leading-relaxed text-muted-foreground">
+            Local and Slack stay distinct. Each source keeps the repository or
+            status headings you choose. With one source, the extra heading
+            disappears.
+          </p>
+          <div className="mt-7 flex flex-col gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Preview sources
+            </span>
+            <SegmentedControl
+              aria-label="Preview sources"
+              value={sourceChoice}
+              onValueChange={setSourceChoice}
+              options={[
+                { value: "mixed", label: "Local + Slack" },
+                { value: "slack", label: "Slack only" },
+              ]}
+            />
+          </div>
+          <div className="mt-5 flex flex-col gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Card density
+            </span>
+            <SegmentedControl
+              aria-label="Preview card density"
+              value={density}
+              onValueChange={setDensity}
+              options={[
+                { value: "detailed", label: "Detailed" },
+                { value: "compact", label: "Compact" },
+              ]}
+            />
+          </div>
+          <div className="mt-8 border-t border-border-subtle pt-6">
+            <p className="text-xs font-medium text-muted-foreground">
+              Selected workspace
+            </p>
+            <p className="mt-2 text-lg font-medium">
+              {selectedEntry?.workspace.title ??
+                "Choose a workspace in the list"}
+            </p>
+            {selectedEntry && (
+              <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                {selectedEntry.session.external_origin ? (
+                  <MessageCircle className="size-3.5" />
+                ) : (
+                  <Monitor className="size-3.5" />
+                )}
+                <span>
+                  {selectedEntry.session.external_origin ? "Slack" : "Local"}
+                </span>
+                <span aria-hidden>·</span>
+                <span>
+                  {
+                    repos.find(
+                      (repo) => repo.id === selectedEntry.workspace.repo_id,
+                    )?.display_name
+                  }
+                </span>
+              </div>
+            )}
+          </div>
+          <p className="mt-8 text-sm leading-relaxed text-muted-foreground">
+            Collapse a source to put that work away. Collapse a repository or
+            status to shorten just that group. Counts remain visible, and
+            reopening a source preserves the groups you folded inside it.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/workspace-rail/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/workspace-rail/fixtures.ts
@@ -1,0 +1,124 @@
+import type {
+  CodeSessionDigest,
+  CodeSessionSnapshot,
+  CodeWorkspaceSnapshot,
+} from "@/api/types";
+import {
+  codeRepositories,
+  codeSession,
+  codeWorkspace,
+  doneDigest,
+  needsYouDigest,
+  runningDigest,
+} from "../fixtures";
+
+export type RailEntry = {
+  workspace: CodeWorkspaceSnapshot;
+  session: CodeSessionSnapshot;
+  digest?: CodeSessionDigest;
+};
+
+export const railRepositories = codeRepositories.slice(0, 2);
+
+function entry(
+  id: string,
+  title: string,
+  repo: number,
+  source: "local" | "channel" | "dm",
+  state: "running" | "needs-you" | "done" | "idle",
+  index: number,
+): RailEntry {
+  const workspace: CodeWorkspaceSnapshot = {
+    ...codeWorkspace,
+    id,
+    title,
+    repo_id: railRepositories[repo]!.id,
+    branch_name: `thet/${id}`,
+    created_at: new Date(Date.UTC(2026, 8, 9, 8, index * 10)).toISOString(),
+  };
+  const template =
+    state === "running"
+      ? runningDigest
+      : state === "needs-you"
+        ? needsYouDigest
+        : state === "done"
+          ? doneDigest
+          : undefined;
+  const digest = template
+    ? {
+        ...template,
+        workspace: id,
+        session: `session-${id}`,
+        title,
+        activity_detail:
+          state === "running" ? "Running focused tests" : undefined,
+        recap: state === "done" ? "Changes are ready to review" : undefined,
+      }
+    : undefined;
+  const session: CodeSessionSnapshot = {
+    ...codeSession,
+    id: `session-${id}`,
+    workspace_id: id,
+    lifecycle: digest?.lifecycle ?? "created",
+    attention: digest?.attention ?? codeSession.attention,
+    created_at: workspace.created_at,
+    external_origin:
+      source === "local"
+        ? undefined
+        : {
+            channel_kind: "slack",
+            external_key:
+              source === "dm"
+                ? `T0123456:D0123456:${index}`
+                : `T0123456:C0123456:1788950000.00000${index}`,
+          },
+  };
+  return { workspace, session, digest };
+}
+
+export const railEntries: RailEntry[] = [
+  entry(
+    "workspace-grouping",
+    "Restore workspace group headings",
+    0,
+    "local",
+    "running",
+    1,
+  ),
+  entry(
+    "browser-recovery",
+    "Review browser recovery",
+    0,
+    "local",
+    "needs-you",
+    2,
+  ),
+  entry(
+    "gateway-retry",
+    "Fix credential refresh retries",
+    1,
+    "local",
+    "running",
+    3,
+  ),
+  entry("gateway-usage", "Clarify usage reporting", 1, "local", "done", 4),
+  entry(
+    "slack-no-repo",
+    "Start without a repository",
+    0,
+    "channel",
+    "running",
+    5,
+  ),
+  entry("slack-share", "Check channel access", 0, "channel", "needs-you", 6),
+  entry("slack-triage", "Triage the desktop issues", 0, "dm", "idle", 7),
+  entry(
+    "slack-cards",
+    "Finish Slack decision cards",
+    1,
+    "channel",
+    "running",
+    8,
+  ),
+  entry("slack-setup", "Review the private app setup", 1, "dm", "done", 9),
+];


### PR DESCRIPTION
The workspace sidebar now keeps repository or status headings inside Local and Slack sections. Source headings appear only when more than one source is present; Slack DMs and channels share one section.

Source and group rows collapse independently, keep their counts, and remember their state. Keyboard navigation and bulk selection skip folded workspaces. The original settings popover offers Repository and Status, and the Add repo and New workspace buttons keep their existing dialogs. Saved Created preferences fall back to Repository without changing density or metadata preferences.

The production sidebar and eight Storybook states share the grouping and toolbar components. This changes presentation and local preferences only; server APIs and session permissions stay unchanged.

Validation: 115 focused tests pass, TypeScript and Storybook build pass, formatting and diff checks pass. Captured and inspected all eight states in desktop/narrow layouts across all four Storybook theme settings. Independent review found no P1/P2 defects.
