### PR TITLE
fix(mobile): load the web preview under NativeWind

### DIFF
--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: ["./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
   presets: [require("nativewind/preset")],
   theme: {


### PR DESCRIPTION
The Expo web build (`expo start --web`) crashed on load with:

    Cannot manually set color scheme, as dark mode is type 'media'. Please use StyleSheet.setFlag('darkMode', 'class')

NativeWind's web runtime sets the color scheme at startup, which its `react-native-css-interop` layer refuses while Tailwind's `darkMode` is the default `media` strategy. Setting `darkMode: "class"` in `mobile/tailwind.config.js` is the fix the error names.

The app has no `dark:` classes and never calls `useColorScheme`, so native rendering is unchanged. With this the pairing screen renders in a browser.

Checks run locally: `pnpm typecheck`, `pnpm lint`, `pnpm test` (22 files, 92 tests) in `mobile/`.