### PR TITLE
fix(ui): match gateway model search labels and uploading image chips

### DIFF
--- a/crates/tidebreak-desktop/ui/src/Composer.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.test.tsx
@@ -466,6 +466,14 @@ describe("Composer", () => {
     expect(markup).toContain('aria-label="Remove brief.pdf"');
   });
 
+  it("treats a just-pasted image as uploading, not waiting", () => {
+    const markup = composerWithImages({ items: [attached("a", "chart.png")] });
+
+    expect(markup).toContain("chart.png");
+    expect(markup).toContain("Uploading");
+    expect(markup).not.toContain("Waiting to upload");
+  });
+
   it("previews an uploading image from the local file with determinate progress", () => {
     const uploading = withUploadProgress(
       withUploadStarted([attached("a", "chart.png")], "a"),

--- a/crates/tidebreak-desktop/ui/src/ImageAttachments.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ImageAttachments.test.ts
@@ -52,6 +52,7 @@ describe("image attachment state machine", () => {
     expect(list[0].status).toBe("queued");
     expect(imageUploadsInFlight(list)).toBe(true);
     expect(readyImageAttachmentIds(list)).toEqual([]);
+    expect(describeImageAttachment(list[0])).toBe("Uploading");
 
     list = withUploadStarted(list, "a");
     expect(list[0].status).toBe("uploading");

--- a/crates/tidebreak-desktop/ui/src/ImageAttachments.ts
+++ b/crates/tidebreak-desktop/ui/src/ImageAttachments.ts
@@ -300,10 +300,12 @@ export function imageUploadPercent(attachment: ImageAttachment): number {
 export function describeImageAttachment(attachment: ImageAttachment): string {
   switch (attachment.status) {
     case "queued":
-      return "Waiting to upload";
     case "uploading":
-      // A host publish moves the bytes over IPC in one step and has no progress
-      // to report, so quoting 0% would read as a stall rather than as work.
+      // Queued is the instant before the host publish starts — paste already
+      // put the bytes in hand — so it reads as the same in-flight work.
+      // A host publish moves those bytes over IPC in one step and has no
+      // progress to report, so quoting 0% would read as a stall rather than
+      // as work.
       return attachment.uploadedBytes === 0
         ? "Uploading"
         : `Uploading ${imageUploadPercent(attachment)}%`;

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.dom.test.tsx
@@ -184,6 +184,47 @@ it("splits a mixed gateway catalog into vendor tabs", async () => {
   expect(screen.getByRole("menuitem", { name: "Mystery Model" })).toBeTruthy();
 });
 
+it("searches a gateway catalog by vendor and family tab labels", async () => {
+  const gatewayModels: ModelInfo[] = [
+    {
+      ...MODELS[0],
+      key: "model_gateway::claude-sonnet-4",
+      provider: "model_gateway",
+      vendor: "anthropic",
+    },
+    {
+      ...MODELS[2],
+      key: "model_gateway::glm-5.2",
+      id: "glm-5.2",
+      display_name: "GLM 5.2",
+      provider: "model_gateway",
+      vendor: null,
+    },
+  ];
+  render(
+    <ModelMenu
+      models={gatewayModels}
+      value={gatewayModels[0].key}
+      onSetUpProvider={() => {}}
+      onChange={() => {}}
+    />,
+  );
+
+  const user = userEvent.setup();
+  await user.click(
+    screen.getByRole("button", { name: "Model: Claude Sonnet 4" }),
+  );
+  await user.keyboard("z.ai");
+
+  expect(screen.getByRole("searchbox", { name: "Search models" })).toHaveValue(
+    "z.ai",
+  );
+  expect(screen.getByRole("menuitem", { name: /GLM 5.2/ })).toBeTruthy();
+  expect(
+    screen.queryByRole("menuitem", { name: /Claude Sonnet 4/ }),
+  ).toBeNull();
+});
+
 it("opens when the first-task walkthrough is on the model step", () => {
   useFirstTaskGuide.getState().setSurface("model");
   render(

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.test.tsx
@@ -261,6 +261,14 @@ describe("matchingModels", () => {
     provider: "model_gateway",
     vendor: "anthropic",
   };
+  const gatewayGlm: ModelInfo = {
+    ...MODELS[0],
+    key: "model_gateway::glm-5.2",
+    id: "glm-5.2",
+    display_name: "GLM 5.2",
+    provider: "model_gateway",
+    vendor: null,
+  };
 
   it("matches model, serving-provider, and vendor text across groups", () => {
     const groups = visibleModelGroups([MODELS[1], gatewayClaude], null);
@@ -273,6 +281,30 @@ describe("matchingModels", () => {
     expect(
       matchingModels(groups, "anthropic").map((model) => model.key),
     ).toEqual([gatewayClaude.key]);
+  });
+
+  it("matches a gateway family tab even when the id does not contain the label", () => {
+    const groups = visibleModelGroups([gatewayClaude, gatewayGlm], null);
+    expect(matchingModels(groups, "z.ai").map((model) => model.key)).toEqual([
+      gatewayGlm.key,
+    ]);
+    expect(matchingModels(groups, "glm").map((model) => model.key)).toEqual([
+      gatewayGlm.key,
+    ]);
+  });
+
+  it("matches a gateway row with no curated vendor from its id", () => {
+    const gatewayGpt: ModelInfo = {
+      ...MODELS[1],
+      key: "model_gateway::gpt-5",
+      id: "gpt-5",
+      provider: "model_gateway",
+      vendor: null,
+    };
+    const groups = visibleModelGroups([gatewayGpt, gatewayGlm], null);
+    expect(matchingModels(groups, "openai").map((model) => model.key)).toEqual([
+      gatewayGpt.key,
+    ]);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ModelMenu.tsx
@@ -15,7 +15,11 @@ import {
   providerLabel,
 } from "./ModelSelection";
 import { useManagedPolicy } from "./managedPolicy";
-import { familyForModelId, MODEL_ID_FAMILIES } from "./modelFamilies";
+import {
+  familyForModelId,
+  MODEL_ID_FAMILIES,
+  vendorForModelId,
+} from "./modelFamilies";
 import { Button } from "@/components/ui/button";
 import { ProviderIcon } from "./ProviderIcons";
 import {
@@ -304,19 +308,27 @@ export function visibleModelGroups(
 
 /** Models visible in cross-provider search, in the same order as browsing. */
 export function matchingModels(
-  groups: readonly { provider: ProviderKind; models: readonly ModelInfo[] }[],
+  groups: readonly Pick<CatalogGroup, "label" | "models">[],
   query: string,
 ): ModelInfo[] {
   const needle = query.trim().toLocaleLowerCase();
   if (!needle) return [];
   return groups.flatMap((group) =>
     group.models.filter((model) => {
-      const vendor = model.vendor ? providerLabel(model.vendor) : "";
+      const derivedVendor = model.vendor ?? vendorForModelId(model.id);
+      const vendor = derivedVendor ? providerLabel(derivedVendor) : "";
+      const family = familyForModelId(model.id);
       return [
         model.display_name,
         model.id,
         providerLabel(model.provider),
         vendor,
+        // A gateway catalog is split by vendor and family tabs. Search has to
+        // hit those labels too: `glm-5.2` does not contain "Z.ai", and a row
+        // with no curated `vendor` still lives under its family tab.
+        group.label,
+        family?.label ?? "",
+        family?.match ?? "",
       ].some((value) => value.toLocaleLowerCase().includes(needle));
     }),
   );

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -1338,6 +1338,45 @@ describe("HarnessModelMenu", () => {
       renderToStaticMarkup(<OpenAIIcon className="size-4 shrink-0" />),
     );
   });
+
+  it("searches a gateway catalog by vendor and family tab labels", async () => {
+    const gatewayOptions = [
+      {
+        id: "claude-sonnet-4",
+        label: "Claude Sonnet 4",
+        source: "opencode · model-gateway",
+        vendor: "anthropic" as const,
+      },
+      {
+        id: "glm-5.2",
+        label: "GLM 5.2",
+        source: "opencode · model-gateway",
+        vendor: null,
+      },
+    ];
+    renderComposer(
+      <HarnessModelMenu
+        harness="opencode"
+        options={gatewayOptions}
+        value={gatewayOptions[0].id}
+        onChange={() => {}}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Model: Claude Sonnet 4" }),
+    );
+    await user.keyboard("z.ai");
+
+    expect(screen.getByRole("searchbox", { name: "Search models" })).toHaveValue(
+      "z.ai",
+    );
+    expect(screen.getByRole("menuitem", { name: /GLM 5.2/ })).toBeTruthy();
+    expect(
+      screen.queryByRole("menuitem", { name: /Claude Sonnet 4/ }),
+    ).toBeNull();
+  });
 });
 
 function pasteOn(target: Element, files: File[]) {

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -1369,9 +1369,9 @@ describe("HarnessModelMenu", () => {
     );
     await user.keyboard("z.ai");
 
-    expect(screen.getByRole("searchbox", { name: "Search models" })).toHaveValue(
-      "z.ai",
-    );
+    expect(
+      screen.getByRole("searchbox", { name: "Search models" }),
+    ).toHaveValue("z.ai");
     expect(screen.getByRole("menuitem", { name: /GLM 5.2/ })).toBeTruthy();
     expect(
       screen.queryByRole("menuitem", { name: /Claude Sonnet 4/ }),

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -38,6 +38,7 @@ import {
 } from "../PastedText";
 import { reasoningEffortOptions } from "../ModelMenu";
 import { familyForModelId } from "../modelFamilies";
+import { providerLabel } from "../ModelSelection";
 import { PermissionModeMenu } from "../PermissionModeMenu";
 import {
   ClaudeIcon,
@@ -269,14 +270,21 @@ export function HarnessModelMenu({
   const matches = useMemo(() => {
     const needle = query.trim().toLowerCase();
     if (!needle) return [];
-    return groups
-      .flatMap((group) => group.options)
-      .filter(
-        (option) =>
-          option.label.toLowerCase().includes(needle) ||
-          option.id.toLowerCase().includes(needle) ||
-          option.source.toLowerCase().includes(needle),
-      );
+    return groups.flatMap((group) =>
+      group.options.filter((option) => {
+        const family = familyForModelId(option.id);
+        const vendor = codeModelVendor(option);
+        return [
+          option.label,
+          option.id,
+          option.source,
+          group.label,
+          vendor ? providerLabel(vendor) : "",
+          family?.label ?? "",
+          family?.match ?? "",
+        ].some((value) => value.toLowerCase().includes(needle));
+      }),
+    );
   }, [groups, query]);
   const visible = searching
     ? matches

--- a/crates/tidebreak-desktop/ui/src/stories/ChatView.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ChatView.stories.tsx
@@ -144,6 +144,38 @@ const imageAttachment: ImageAttachment = {
   error: null,
 };
 
+/** Just-pasted bytes: local preview in hand, host publish not started yet. */
+const queuedImageAttachment: ImageAttachment = {
+  id: "image-queued",
+  name: "pasted-chart.png",
+  byteLen: 96_000,
+  uploadedBytes: 0,
+  status: "queued",
+  previewUrl:
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  attachmentId: null,
+  mediaType: "image/png",
+  width: null,
+  height: null,
+  error: null,
+};
+
+/** Host publish in flight with partial progress. */
+const uploadingImageAttachment: ImageAttachment = {
+  id: "image-uploading",
+  name: "screenshot.png",
+  byteLen: 320_000,
+  uploadedBytes: 128_000,
+  status: "uploading",
+  previewUrl:
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  attachmentId: null,
+  mediaType: "image/png",
+  width: null,
+  height: null,
+  error: null,
+};
+
 const baseMessages: ChatMessage[] = [
   {
     id: "message-user",
@@ -921,6 +953,24 @@ export const AttachmentsAndDraft: Story = {
         ],
         skills: ["browser"],
         folders: ["folder-research"],
+      },
+    },
+  },
+};
+
+/**
+ * Paste already put bytes in the composer. The chip must read Uploading, not
+ * Waiting to upload — queued and in-flight publish are the same reader-facing
+ * work.
+ */
+export const PastedImageUploading: Story = {
+  args: {
+    scenario: {
+      id: "pasted-image-uploading",
+      messages: baseMessages,
+      draft: "Describe the chart I just pasted.",
+      attachments: {
+        images: [queuedImageAttachment, uploadingImageAttachment],
       },
     },
   },

--- a/crates/tidebreak-desktop/ui/src/stories/HarnessModelMenu.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/HarnessModelMenu.stories.tsx
@@ -87,6 +87,39 @@ const OPENCODE: CodeModelOption[] = [
   },
 ];
 
+/**
+ * A Model Gateway catalog: first-party vendors plus open-model families whose
+ * tab labels (`Z.ai`, …) are not substrings of the model id. Search has to hit
+ * those rail labels, not only `display_name` / `id`.
+ */
+const GATEWAY_MIXED: CodeModelOption[] = [
+  {
+    id: "claude-sonnet-4",
+    label: "Claude Sonnet 4",
+    source: "opencode · model-gateway",
+    vendor: "anthropic",
+  },
+  {
+    id: "gpt-5",
+    label: "GPT 5",
+    source: "opencode · model-gateway",
+    vendor: null,
+    default: true,
+  },
+  {
+    id: "glm-5.2",
+    label: "GLM 5.2",
+    source: "opencode · model-gateway",
+    vendor: null,
+  },
+  {
+    id: "deepseek-v4-flash-0731",
+    label: "DeepSeek V4 Flash",
+    source: "opencode · model-gateway",
+    vendor: null,
+  },
+];
+
 /** One vendor: no All entry, because there is nothing to lift. */
 export const SingleVendor: Story = {
   args: {
@@ -103,6 +136,19 @@ export const MixedCatalog: Story = {
     harness: "opencode",
     options: OPENCODE,
     value: "openai/gpt-5.6-sol",
+    onChange: () => undefined,
+  },
+};
+
+/**
+ * Gateway rows split by vendor and family. Typing `z.ai` in search should
+ * keep GLM and drop the rest — the same contract as the chat ModelMenu.
+ */
+export const GatewayCatalogSearch: Story = {
+  args: {
+    harness: "opencode",
+    options: GATEWAY_MIXED,
+    value: "gpt-5",
     onChange: () => undefined,
   },
 };


### PR DESCRIPTION
## Summary
- Model Gateway catalogs in the chat and Code composers are searchable by the same vendor, family, and group labels shown in the tab rail (for example `z.ai` finds `GLM 5.2` even when the id has no vendor substring).
- Just-pasted image chips read **Uploading** instead of **Waiting to upload**, matching the in-flight work after paste already has bytes in hand.

## Why
Gateway rows often lack the rail label in `id`/`display_name`, and some have no curated `vendor`. Search only matched raw model fields, so vendor/family queries returned nothing. Queued paste is already local work; "Waiting to upload" looked like a stall rather than progress.

## Scope
- `ModelMenu.matchingModels` and Code `HarnessModelMenu` search
- `describeImageAttachment` queued copy
- Unit, jsdom, and Storybook coverage for the two behaviors

## Out of scope / other owners
Image session publication, Cmd+Enter steering, journal tool-card layout, synchronized loaders, workspace naming, Codex metadata and staging retention.

## Test plan
- [x] `ModelMenu` unit tests for family/vendor/group label matching
- [x] `ModelMenu` DOM search for a gateway catalog (`z.ai` → GLM)
- [x] Code `HarnessModelMenu` DOM search for the same contract
- [x] Image attachment + Composer chip copy for queued state
- [x] Storybook: `Composer/Model` GatewayCatalogSearch, `Conversation/ChatView` PastedImageUploading
- [x] `pnpm exec vitest` focused suite under Node 24 (123 passed)
- [x] `pnpm storybook:build` succeeded
- [ ] CI green on this PR

## Notes
Sandbox GitHub REST blocks `POST /issues` and assignee/label writes, so a separate tracking issue could not be opened or claimed from this environment. This PR is the review surface.