### PR TITLE
feat(release): prune old hosted staging desktop builds

### DIFF
--- a/.github/workflows/staging-prune.yml
+++ b/.github/workflows/staging-prune.yml
@@ -1,0 +1,72 @@
+name: Prune staging desktop releases
+
+# Staging publishes an immutable prefix per build. The updater only needs
+# latest.json and the artifacts it names, so older prefixes are unused storage.
+# Publish already prunes after a successful upload; this workflow is the
+# backstop (weekly) and the way to inspect a dry-run before the first cleanup.
+
+on:
+  schedule:
+    - cron: "47 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: List prefixes that would be deleted without deleting them
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  # Separate from tidebreak-desktop-staging-build so a prune cannot cancel a
+  # pending notarization. The planner refuses to delete the live feed version.
+  group: tidebreak-desktop-staging-prune
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: prune staging releases
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: desktop-staging
+      url: https://downloads.brightwave.io/tidebreak/staging/manifest.json
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: ${{ vars.DOWNLOADS_AWS_REGION || 'us-east-1' }}
+      AWS_RELEASE_ROLE_ARN: ${{ vars.AWS_RELEASE_ROLE_ARN }}
+      DOWNLOADS_S3_BUCKET: ${{ vars.DOWNLOADS_S3_BUCKET }}
+      STAGING_PRUNE_DRY_RUN: ${{ github.event.inputs.dry_run || false }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Validate staging hosting configuration
+        run: |
+          missing=()
+          for name in \
+            AWS_REGION \
+            AWS_RELEASE_ROLE_ARN \
+            DOWNLOADS_S3_BUCKET; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing desktop-staging hosting configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6
+        with:
+          role-to-assume: ${{ env.AWS_RELEASE_ROLE_ARN }}
+          role-session-name: tidebreak-staging-prune-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Prune old staging releases
+        run: scripts/prune-staging-releases.sh

--- a/.github/workflows/staging-publish.yml
+++ b/.github/workflows/staging-publish.yml
@@ -582,7 +582,7 @@ jobs:
           name: tidebreak-staging-macos-universal-${{ needs.validate_staging.outputs.version }}
           path: dist/macos/universal/
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1
 
       - name: Remove temporary signing material
         if: ${{ always() }}
@@ -803,3 +803,6 @@ jobs:
             }
             curl --fail --silent --show-error --head "$url" >/dev/null
           done
+
+      - name: Prune old staging releases
+        run: scripts/prune-staging-releases.sh

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -463,6 +463,19 @@ under `https://downloads.brightwave.io/tidebreak/staging/`; the publish step
 refuses any other prefix and will not advance `latest.json` if `main` has
 already moved on.
 
+Staging installs follow `latest.json` only, so hosted history is unused once a
+newer build is current. After each successful publish, and on a weekly
+schedule, `scripts/prune-staging-releases.sh` deletes every recognized
+`tidebreak/staging/releases/v0.0.0-staging.N/` prefix except the live feed
+version and the two newest other builds (keep count 3). Unknown keys,
+`latest.json`, `manifest.json`, and production prefixes are never planned for
+deletion. Before each recursive delete the script re-reads
+`tidebreak/staging/latest.json` and refuses if the prefix is live, so a
+concurrent publish that advances the feed cannot lose the new current build.
+Manual **Prune staging desktop releases** defaults to dry-run; the schedule and
+post-publish paths delete for real. Signed staging GitHub Actions artifacts
+expire after one day.
+
 Create a GitHub environment named `desktop-staging`. Copy the Apple signing
 secrets from `desktop-production`. Do **not** copy
 `TAURI_SIGNING_PRIVATE_KEY` or `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: a
@@ -474,8 +487,25 @@ environment's `TAURI_SIGNING_PRIVATE_KEY` and
 password. Point `AWS_RELEASE_ROLE_ARN` at a
 role whose GitHub OIDC subject is
 `repo:brightwave-inc/tidebreak:environment:desktop-staging` and whose S3
-write access is only `tidebreak/staging/*`. A role that can also write
+access is only under `tidebreak/staging/`. A role that can also write
 `tidebreak/latest.json` would make a publish-guard bug a production incident.
+
+IAM for that role is configured outside this repository. Publish already needs
+object read/write under the staging prefix. Prune additionally needs:
+
+- `s3:ListBucket` on the downloads bucket, conditioned on
+  `tidebreak/staging/` (delimiter listing of release prefixes and object
+  listing under a prefix about to be removed)
+- `s3:GetObject` on `tidebreak/staging/*` (read `latest.json`; head/get
+  objects while deciding what to remove)
+- `s3:DeleteObject` on `tidebreak/staging/releases/*` only — not on
+  `tidebreak/staging/latest.json` or `tidebreak/staging/manifest.json`
+
+Do not grant `tidebreak/latest.json`, `tidebreak/manifest.json`, or
+`tidebreak/releases/*`. If the bucket has versioning enabled,
+`aws s3 rm --recursive` only removes the current version (or writes a delete
+marker). Prior versions remain and still cost storage until a bucket lifecycle
+rule expires them; that lifecycle is also out of repo.
 
 Before the first public release, protect the environment as appropriate, verify
 all configuration values, and exercise the workflow with the intended first

--- a/scripts/prune-staging-releases.mjs
+++ b/scripts/prune-staging-releases.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import { assertHostedUnderChannel } from "./desktop-channel.mjs";
+import {
+  compareStagingVersions,
+  parseStagingVersion,
+} from "./staging-version.mjs";
+
+export const STAGING_RELEASES_PREFIX = "tidebreak/staging/releases/";
+export const DEFAULT_STAGING_RELEASE_KEEP_COUNT = 3;
+export const STAGING_FEED_KEYS = Object.freeze([
+  "tidebreak/staging/latest.json",
+  "tidebreak/staging/manifest.json",
+]);
+
+const STAGING_RELEASE_PREFIX_PATTERN =
+  /^tidebreak\/staging\/releases\/v(0\.0\.0-staging\.[1-9]\d*)\/$/;
+const STAGING_RELEASE_OBJECT_PATTERN =
+  /^tidebreak\/staging\/releases\/v(0\.0\.0-staging\.[1-9]\d*)\/(.+)$/;
+
+export function stagingReleasePrefix(version) {
+  const parsed = parseStagingVersion(version);
+  if (!parsed) {
+    throw new Error(`invalid staging version: ${version}`);
+  }
+  return `${STAGING_RELEASES_PREFIX}v${parsed.version}/`;
+}
+
+export function parseStagingReleasePrefix(prefix) {
+  if (typeof prefix !== "string") return null;
+  const match = STAGING_RELEASE_PREFIX_PATTERN.exec(prefix);
+  if (!match) return null;
+  return parseStagingVersion(match[1]);
+}
+
+function assertSafeStagingKey(key) {
+  if (typeof key !== "string" || key.length === 0) {
+    throw new Error("staging delete key is missing");
+  }
+  if (key.includes("//") || key.split("/").includes("..")) {
+    throw new Error(`refusing to delete staging key with an unsafe path: ${key}`);
+  }
+  if (STAGING_FEED_KEYS.includes(key)) {
+    throw new Error(`refusing to delete staging feed object: ${key}`);
+  }
+  assertHostedUnderChannel(key, "staging");
+}
+
+export function assertDeletableStagingReleasePrefix(prefix, latestVersion) {
+  assertSafeStagingKey(prefix);
+  if (!parseStagingReleasePrefix(prefix)) {
+    throw new Error(`not a deletable staging release prefix: ${prefix}`);
+  }
+  const livePrefix = stagingReleasePrefix(latestVersion);
+  if (prefix === livePrefix) {
+    throw new Error(`refusing to delete the live staging prefix ${prefix}`);
+  }
+}
+
+export function assertDeletableStagingReleaseKey(key, latestVersion) {
+  assertSafeStagingKey(key);
+  const match = STAGING_RELEASE_OBJECT_PATTERN.exec(key);
+  if (!match) {
+    throw new Error(`not a deletable staging release object: ${key}`);
+  }
+  if (latestVersion !== undefined) {
+    const livePrefix = stagingReleasePrefix(latestVersion);
+    if (key.startsWith(livePrefix)) {
+      throw new Error(
+        `refusing to delete object from the live staging prefix: ${key}`,
+      );
+    }
+  }
+}
+
+function parseKeepCount(keep) {
+  const keepCount =
+    typeof keep === "number" ? keep : Number.parseInt(keep, 10);
+  if (!Number.isInteger(keepCount) || keepCount < 1) {
+    throw new Error(`invalid keep count: ${keep}`);
+  }
+  return keepCount;
+}
+
+export function planStagingReleasePrune({
+  latestVersion,
+  prefixes,
+  keep = DEFAULT_STAGING_RELEASE_KEEP_COUNT,
+}) {
+  const parsedLatest = parseStagingVersion(latestVersion);
+  if (!parsedLatest) {
+    throw new Error(`invalid staging version: ${latestVersion}`);
+  }
+  const keepCount = parseKeepCount(keep);
+  const livePrefix = stagingReleasePrefix(parsedLatest.version);
+
+  const unique = [
+    ...new Set(
+      (prefixes ?? [])
+        .filter((prefix) => typeof prefix === "string")
+        .map((prefix) => prefix.trim())
+        .filter(Boolean),
+    ),
+  ];
+
+  const skipped = [];
+  const known = [];
+  for (const prefix of unique) {
+    const parsed = parseStagingReleasePrefix(prefix);
+    if (!parsed) {
+      skipped.push(prefix);
+      continue;
+    }
+    known.push({ prefix, version: parsed.version });
+  }
+  known.sort((left, right) =>
+    compareStagingVersions(right.version, left.version),
+  );
+  skipped.sort();
+
+  const keepExisting = [];
+  const keepSet = new Set();
+  const liveEntry = known.find((entry) => entry.prefix === livePrefix);
+  if (liveEntry) {
+    keepExisting.push(liveEntry.prefix);
+    keepSet.add(liveEntry.prefix);
+  }
+  for (const entry of known) {
+    if (keepExisting.length >= keepCount) break;
+    if (keepSet.has(entry.prefix)) continue;
+    keepExisting.push(entry.prefix);
+    keepSet.add(entry.prefix);
+  }
+
+  return {
+    latestVersion: parsedLatest.version,
+    keepCount,
+    keep: keepExisting,
+    delete: known
+      .filter((entry) => !keepSet.has(entry.prefix))
+      .sort((left, right) =>
+        compareStagingVersions(left.version, right.version),
+      )
+      .map((entry) => entry.prefix),
+    skipped,
+  };
+}
+
+function requiredOption(args, name) {
+  const index = args.indexOf(`--${name}`);
+  if (index === -1 || args[index + 1] === undefined) {
+    throw new Error(`missing --${name}`);
+  }
+  return args[index + 1];
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+  if (command === "--plan") {
+    const rest = args.slice(1);
+    const keepIndex = rest.indexOf("--keep");
+    const keep =
+      keepIndex === -1
+        ? DEFAULT_STAGING_RELEASE_KEEP_COUNT
+        : rest[keepIndex + 1];
+    const prefixes = readFileSync(0, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const plan = planStagingReleasePrune({
+      latestVersion: requiredOption(rest, "latest-version"),
+      prefixes,
+      keep,
+    });
+    console.log(JSON.stringify(plan, null, 2));
+    return;
+  }
+  if (command === "--assert-delete-prefix") {
+    assertDeletableStagingReleasePrefix(
+      args[1],
+      requiredOption(args, "latest-version"),
+    );
+    return;
+  }
+  if (command === "--assert-delete-key") {
+    const latestIndex = args.indexOf("--latest-version");
+    const latestVersion =
+      latestIndex === -1 ? undefined : args[latestIndex + 1];
+    assertDeletableStagingReleaseKey(args[1], latestVersion);
+    return;
+  }
+  throw new Error(
+    "usage: prune-staging-releases.mjs --plan --latest-version <version> [--keep <n>] | --assert-delete-prefix <prefix> --latest-version <version> | --assert-delete-key <key> [--latest-version <version>]",
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/prune-staging-releases.sh
+++ b/scripts/prune-staging-releases.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Delete hosted staging desktop prefixes that are not the live feed version
+# and are not among the newest retained neighbors. Never touches production
+# keys. AWS credentials and DOWNLOADS_S3_BUCKET must already be configured.
+
+here="$(cd "$(dirname "$0")" && pwd)"
+planner="$here/prune-staging-releases.mjs"
+
+dry_run=false
+case "${STAGING_PRUNE_DRY_RUN:-false}" in
+  true|1|yes) dry_run=true ;;
+  false|0|no|"") dry_run=false ;;
+  *)
+    echo "invalid STAGING_PRUNE_DRY_RUN: ${STAGING_PRUNE_DRY_RUN}" >&2
+    exit 1
+    ;;
+esac
+
+keep="${STAGING_PRUNE_KEEP:-3}"
+bucket="${DOWNLOADS_S3_BUCKET:?DOWNLOADS_S3_BUCKET is required}"
+work="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/tidebreak-staging-prune.XXXXXX")"
+cleanup() { rm -rf -- "$work"; }
+trap cleanup EXIT
+
+head_error="$work/latest-head-error"
+if ! aws s3api head-object \
+  --bucket "$bucket" \
+  --key tidebreak/staging/latest.json >/dev/null 2>"$head_error"; then
+  error="$(<"$head_error")"
+  case "$error" in
+    *404*|*Not\ Found*)
+      echo "No hosted staging latest.json; refusing to prune."
+      exit 0
+      ;;
+    *)
+      printf '%s\n' "$error" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+aws s3 cp \
+  "s3://$bucket/tidebreak/staging/latest.json" \
+  "$work/latest.json" >/dev/null
+latest="$(jq -er .version "$work/latest.json")"
+node "$here/staging-version.mjs" "$latest" >/dev/null
+
+prefixes_file="$work/prefixes.txt"
+: > "$prefixes_file"
+continuation=""
+while true; do
+  args=(
+    s3api list-objects-v2
+    --bucket "$bucket"
+    --prefix tidebreak/staging/releases/
+    --delimiter /
+    --output json
+  )
+  if [[ -n "$continuation" ]]; then
+    args+=(--continuation-token "$continuation")
+  fi
+  response="$(aws "${args[@]}")"
+  jq -r '.CommonPrefixes[]?.Prefix // empty' <<<"$response" >> "$prefixes_file"
+  continuation="$(jq -r '.NextContinuationToken // empty' <<<"$response")"
+  [[ -n "$continuation" ]] || break
+done
+
+plan_file="$work/plan.json"
+node "$planner" --plan --latest-version "$latest" --keep "$keep" \
+  < "$prefixes_file" > "$plan_file"
+jq . "$plan_file"
+
+keep_count="$(jq -r '.keep | length' "$plan_file")"
+delete_count="$(jq -r '.delete | length' "$plan_file")"
+skipped_count="$(jq -r '.skipped | length' "$plan_file")"
+printf 'Staging prune plan: keep %s, delete %s, skipped %s (live %s).\n' \
+  "$keep_count" "$delete_count" "$skipped_count" "$latest"
+
+if [[ "$dry_run" = true ]]; then
+  echo "Dry run; not deleting."
+  exit 0
+fi
+
+if (( delete_count == 0 )); then
+  echo "Nothing to delete."
+  exit 0
+fi
+
+while IFS= read -r prefix; do
+  [[ -n "$prefix" ]] || continue
+  if ! aws s3 cp \
+    "s3://$bucket/tidebreak/staging/latest.json" \
+    "$work/latest.json" >/dev/null; then
+    echo "Failed to re-read staging latest.json before deleting $prefix." >&2
+    exit 1
+  fi
+  live="$(jq -er .version "$work/latest.json")"
+  node "$planner" --assert-delete-prefix "$prefix" --latest-version "$live"
+  echo "Deleting s3://$bucket/$prefix"
+  aws s3 rm "s3://$bucket/$prefix" --recursive
+done < <(jq -r '.delete[]' "$plan_file")

--- a/scripts/prune-staging-releases.test.mjs
+++ b/scripts/prune-staging-releases.test.mjs
@@ -1,0 +1,329 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  DEFAULT_STAGING_RELEASE_KEEP_COUNT,
+  assertDeletableStagingReleaseKey,
+  assertDeletableStagingReleasePrefix,
+  parseStagingReleasePrefix,
+  planStagingReleasePrune,
+  stagingReleasePrefix,
+} from "./prune-staging-releases.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, "prune-staging-releases.mjs");
+const shell = readFileSync(join(here, "prune-staging-releases.sh"), "utf8");
+
+function prefix(version) {
+  return stagingReleasePrefix(version);
+}
+
+test("staging release prefixes are versioned directories under the staging channel", () => {
+  assert.equal(
+    prefix("0.0.0-staging.12"),
+    "tidebreak/staging/releases/v0.0.0-staging.12/",
+  );
+  assert.deepEqual(parseStagingReleasePrefix(prefix("0.0.0-staging.12")), {
+    version: "0.0.0-staging.12",
+    build: "12",
+  });
+  assert.equal(
+    parseStagingReleasePrefix("tidebreak/staging/releases/v0.0.0-staging.12"),
+    null,
+  );
+  assert.equal(
+    parseStagingReleasePrefix("tidebreak/staging/releases/v0.0.0-staging.1"),
+    null,
+  );
+  assert.equal(
+    parseStagingReleasePrefix("tidebreak/releases/v0.4.2/"),
+    null,
+  );
+  assert.equal(
+    parseStagingReleasePrefix("tidebreak/staging/releases/v0.4.2/"),
+    null,
+  );
+  assert.equal(
+    parseStagingReleasePrefix("tidebreak/staging/releases/v0.0.0-staging.01/"),
+    null,
+  );
+  assert.equal(DEFAULT_STAGING_RELEASE_KEEP_COUNT, 3);
+});
+
+test("prune keeps the live staging build and the newest neighbors", () => {
+  assert.deepEqual(
+    planStagingReleasePrune({
+      latestVersion: "0.0.0-staging.100",
+      prefixes: [
+        prefix("0.0.0-staging.97"),
+        prefix("0.0.0-staging.98"),
+        prefix("0.0.0-staging.99"),
+        prefix("0.0.0-staging.100"),
+      ],
+    }),
+    {
+      latestVersion: "0.0.0-staging.100",
+      keepCount: 3,
+      keep: [
+        prefix("0.0.0-staging.100"),
+        prefix("0.0.0-staging.99"),
+        prefix("0.0.0-staging.98"),
+      ],
+      delete: [prefix("0.0.0-staging.97")],
+      skipped: [],
+    },
+  );
+
+  // Live is not the newest listing entry: still retain live + two newest others.
+  assert.deepEqual(
+    planStagingReleasePrune({
+      latestVersion: "0.0.0-staging.100",
+      prefixes: [
+        prefix("0.0.0-staging.100"),
+        prefix("0.0.0-staging.101"),
+        prefix("0.0.0-staging.102"),
+        prefix("0.0.0-staging.99"),
+        prefix("0.0.0-staging.98"),
+      ],
+    }),
+    {
+      latestVersion: "0.0.0-staging.100",
+      keepCount: 3,
+      keep: [
+        prefix("0.0.0-staging.100"),
+        prefix("0.0.0-staging.102"),
+        prefix("0.0.0-staging.101"),
+      ],
+      delete: [prefix("0.0.0-staging.98"), prefix("0.0.0-staging.99")],
+      skipped: [],
+    },
+  );
+
+  assert.deepEqual(
+    planStagingReleasePrune({
+      latestVersion: "0.0.0-staging.5",
+      keep: 1,
+      prefixes: [
+        prefix("0.0.0-staging.5"),
+        prefix("0.0.0-staging.4"),
+        prefix("0.0.0-staging.6"),
+      ],
+    }),
+    {
+      latestVersion: "0.0.0-staging.5",
+      keepCount: 1,
+      keep: [prefix("0.0.0-staging.5")],
+      delete: [prefix("0.0.0-staging.4"), prefix("0.0.0-staging.6")],
+      skipped: [],
+    },
+  );
+});
+
+test("prune never deletes the live prefix even when it is absent from the listing", () => {
+  const plan = planStagingReleasePrune({
+    latestVersion: "0.0.0-staging.100",
+    prefixes: [
+      prefix("0.0.0-staging.99"),
+      prefix("0.0.0-staging.98"),
+      prefix("0.0.0-staging.97"),
+      prefix("0.0.0-staging.96"),
+    ],
+  });
+  assert.deepEqual(plan.keep, [
+    prefix("0.0.0-staging.99"),
+    prefix("0.0.0-staging.98"),
+    prefix("0.0.0-staging.97"),
+  ]);
+  assert.deepEqual(plan.delete, [prefix("0.0.0-staging.96")]);
+  assert.ok(!plan.delete.includes(prefix("0.0.0-staging.100")));
+});
+
+test("prune skips unknown prefixes instead of deleting them", () => {
+  const plan = planStagingReleasePrune({
+    latestVersion: "0.0.0-staging.2",
+    prefixes: [
+      prefix("0.0.0-staging.2"),
+      prefix("0.0.0-staging.1"),
+      "tidebreak/staging/releases/v0.4.2/",
+      "tidebreak/staging/releases/v0.0.0-staging.3",
+      "tidebreak/staging/latest.json",
+      "",
+      prefix("0.0.0-staging.2"),
+    ],
+  });
+  assert.deepEqual(plan.keep, [
+    prefix("0.0.0-staging.2"),
+    prefix("0.0.0-staging.1"),
+  ]);
+  assert.deepEqual(plan.delete, []);
+  assert.deepEqual(plan.skipped, [
+    "tidebreak/staging/latest.json",
+    "tidebreak/staging/releases/v0.0.0-staging.3",
+    "tidebreak/staging/releases/v0.4.2/",
+  ]);
+});
+
+test("prune refuses an invalid live version or keep count", () => {
+  assert.throws(
+    () =>
+      planStagingReleasePrune({
+        latestVersion: "0.4.2",
+        prefixes: [],
+      }),
+    /invalid staging version/,
+  );
+  assert.throws(
+    () =>
+      planStagingReleasePrune({
+        latestVersion: "0.0.0-staging.1",
+        prefixes: [],
+        keep: 0,
+      }),
+    /keep count/,
+  );
+});
+
+test("delete assertions refuse production objects, the live prefix, and feed files", () => {
+  const live = "0.0.0-staging.12";
+  assert.doesNotThrow(() =>
+    assertDeletableStagingReleasePrefix(prefix("0.0.0-staging.11"), live),
+  );
+  assert.doesNotThrow(() =>
+    assertDeletableStagingReleaseKey(
+      `${prefix("0.0.0-staging.11")}macos/universal/Tidebreak_0.0.0-staging.11_universal.dmg`,
+      live,
+    ),
+  );
+
+  assert.throws(
+    () => assertDeletableStagingReleasePrefix(prefix(live), live),
+    /live staging prefix/,
+  );
+  assert.throws(
+    () =>
+      assertDeletableStagingReleasePrefix(
+        "tidebreak/staging/releases/v0.0.0-staging.11",
+        live,
+      ),
+    /not a deletable staging release prefix/,
+  );
+  assert.throws(
+    () =>
+      assertDeletableStagingReleasePrefix(
+        "tidebreak/staging/releases/v0.0.0-staging.1",
+        live,
+      ),
+    /not a deletable staging release prefix/,
+  );
+  assert.throws(
+    () => assertDeletableStagingReleasePrefix("tidebreak/releases/v0.4.2/", live),
+    /production release/,
+  );
+  assert.throws(
+    () => assertDeletableStagingReleasePrefix("tidebreak/latest.json", live),
+    /production feed/,
+  );
+  assert.throws(
+    () =>
+      assertDeletableStagingReleasePrefix("tidebreak/staging/latest.json", live),
+    /feed object|not a deletable/,
+  );
+  assert.throws(
+    () =>
+      assertDeletableStagingReleaseKey("tidebreak/staging/manifest.json", live),
+    /feed object/,
+  );
+  assert.throws(
+    () =>
+      assertDeletableStagingReleaseKey(
+        `${prefix(live)}manifest.json`,
+        live,
+      ),
+    /live staging prefix/,
+  );
+  assert.throws(
+    () =>
+      assertDeletableStagingReleaseKey(
+        "tidebreak/staging/releases/v0.0.0-staging.11/foo/../latest.json",
+        live,
+      ),
+    /unsafe path/,
+  );
+});
+
+test("the prune CLI emits a plan from stdin prefixes", () => {
+  const result = spawnSync(
+    process.execPath,
+    [script, "--plan", "--latest-version", "0.0.0-staging.3", "--keep", "2"],
+    {
+      encoding: "utf8",
+      input: [
+        prefix("0.0.0-staging.1"),
+        prefix("0.0.0-staging.2"),
+        prefix("0.0.0-staging.3"),
+        prefix("0.0.0-staging.4"),
+      ].join("\n"),
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    latestVersion: "0.0.0-staging.3",
+    keepCount: 2,
+    keep: [prefix("0.0.0-staging.3"), prefix("0.0.0-staging.4")],
+    delete: [prefix("0.0.0-staging.1"), prefix("0.0.0-staging.2")],
+    skipped: [],
+  });
+});
+
+test("the prune CLI rejects deleting the live prefix", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--assert-delete-prefix",
+      prefix("0.0.0-staging.3"),
+      "--latest-version",
+      "0.0.0-staging.3",
+    ],
+    { encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /live staging prefix/);
+});
+
+test("the prune shell asserts each prefix before recursive delete", () => {
+  assert.match(shell, /node "\$planner" --plan --latest-version/);
+  assert.match(shell, /--assert-delete-prefix "\$prefix" --latest-version/);
+  const assertAt = shell.indexOf("--assert-delete-prefix");
+  const rmAt = shell.indexOf("aws s3 rm");
+  assert.ok(assertAt !== -1 && rmAt !== -1 && assertAt < rmAt);
+  const dryRunAt = shell.indexOf('"$dry_run" = true');
+  assert.ok(dryRunAt !== -1 && dryRunAt < rmAt);
+  // Re-read live latest.json inside the delete loop so a concurrent publish
+  // that advances the feed cannot delete the new current prefix.
+  const deleteLoopAt = shell.indexOf("while IFS= read -r prefix");
+  assert.notEqual(deleteLoopAt, -1);
+  const rereadSlice = shell.slice(deleteLoopAt);
+  const rereadAt = rereadSlice.indexOf("tidebreak/staging/latest.json");
+  const loopAssertAt = rereadSlice.indexOf("--assert-delete-prefix");
+  const loopRmAt = rereadSlice.indexOf("aws s3 rm");
+  assert.ok(
+    rereadAt !== -1 &&
+      loopAssertAt !== -1 &&
+      loopRmAt !== -1 &&
+      rereadAt < loopAssertAt &&
+      loopAssertAt < loopRmAt,
+  );
+  assert.match(rereadSlice, /jq -r '\.delete\[]'/);
+  assert.match(shell, /s3:\/\/\$bucket\/\$prefix/);
+  assert.doesNotMatch(shell, /[ "'`]tidebreak\/latest\.json/);
+  assert.doesNotMatch(shell, /[ "'`]tidebreak\/releases\//);
+  assert.match(shell, /tidebreak\/staging\/latest\.json/);
+  assert.match(shell, /tidebreak\/staging\/releases\//);
+  assert.match(shell, /--delimiter \//);
+  assert.doesNotMatch(shell, /--include|--exclude|s3api delete-object/);
+});

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -2627,6 +2627,55 @@ test("staging desktop publishes only under the staging prefix", () => {
     /s3:\/\/\$DOWNLOADS_S3_BUCKET\/tidebreak\/latest\.json/,
   );
   assert.doesNotMatch(publishStaging, /tidebreak\/releases\/v\$TIDEBREAK_VERSION/);
+  assert.match(publishStaging, /scripts\/prune-staging-releases\.sh/);
+  assert.doesNotMatch(publishStaging, /STAGING_PRUNE_DRY_RUN/);
+  const stagingSignedUpload = workflowJob(
+    stagingPublish ?? release,
+    "build_macos_staging",
+  );
+  const signedUploadAt = stagingSignedUpload.indexOf(
+    "Upload verified macOS artifacts",
+  );
+  assert.notEqual(signedUploadAt, -1);
+  assert.match(
+    stagingSignedUpload.slice(signedUploadAt, signedUploadAt + 400),
+    /retention-days: 1/,
+  );
+
+  const stagingPrune = workflows["staging-prune.yml"];
+  assert.ok(stagingPrune);
+  assert.match(stagingPrune, /^on:\n  schedule:\n    - cron: "[^"]+"$/m);
+  assert.match(stagingPrune, /^  workflow_dispatch:$/m);
+  assert.match(
+    stagingPrune,
+    /dry_run:\n        description: [^\n]+\n        required: false\n        default: true\n        type: boolean/,
+  );
+  assert.doesNotMatch(stagingPrune, /^\s*pull_request(?:_target)?:/m);
+  assert.doesNotMatch(stagingPrune, /^\s*push:/m);
+  assert.match(stagingPrune, /^permissions:\n  contents: read$/m);
+  assert.match(stagingPrune, /^  group: tidebreak-desktop-staging-prune$/m);
+  assert.doesNotMatch(
+    stagingPrune,
+    /^  group: tidebreak-desktop-staging-build$/m,
+  );
+  assert.match(stagingPrune, /cancel-in-progress: false/);
+  assert.match(stagingPrune, /if: \$\{\{ github\.ref == 'refs\/heads\/main' \}\}/);
+  assert.match(stagingPrune, /environment:\n      name: desktop-staging/);
+  assert.match(stagingPrune, /id-token: write/);
+  assert.match(stagingPrune, /scripts\/prune-staging-releases\.sh/);
+  assert.match(
+    stagingPrune,
+    /uses: aws-actions\/configure-aws-credentials@[0-9a-f]{40}/,
+  );
+  assert.doesNotMatch(stagingPrune, /secrets\./);
+  assert.doesNotMatch(stagingPrune, /desktop-production/);
+  assert.doesNotMatch(stagingPrune, /tidebreak\/latest\.json/);
+  assert.doesNotMatch(stagingPrune, /tidebreak\/releases\//);
+  assert.match(stagingPrune, /github\.event\.inputs\.dry_run \|\| false/);
+  assert.match(
+    stagingPrune,
+    /role-session-name: tidebreak-staging-prune-\$\{\{ github\.run_id \}\}/,
+  );
 
   const stagingOverlay = JSON.parse(
     readFileSync(


### PR DESCRIPTION
## Summary

Hosted staging desktop builds accumulate one immutable S3 prefix per publish while clients only follow `latest.json`. This adds a fail-closed prune path so storage cost stays bounded.

- **Policy:** keep the version in `tidebreak/staging/latest.json` plus the two newest other recognized `v0.0.0-staging.N` prefixes (keep count 3). Never delete the live prefix, unknown keys, feed objects, or production prefixes.
- **When:** after each successful staging publish; weekly schedule; manual workflow (dry-run default).
- **Safety:** planner recognizes only strict staging release prefixes; shell re-reads `latest.json` and re-asserts before each recursive delete; prune concurrency is separate from staging publish so notarization is not cancelled.
- **Actions retention:** signed staging macOS artifacts drop from 7 days to 1 day.
- **Out of repo:** IAM must allow `ListBucket` (staging prefix), `GetObject` under `tidebreak/staging/*`, and `DeleteObject` under `tidebreak/staging/releases/*` only. Versioned-bucket delete markers / old versions need a lifecycle rule if versioning is on. This PR does not run prune against live storage or change live IAM.

Closes #3280

## Test plan

- [x] `node --test scripts/prune-staging-releases.test.mjs`
- [x] `node --test --test-name-pattern='staging desktop publishes' scripts/workflow-security.test.mjs`
- [ ] CI green on this PR
- [ ] After merge (operator): confirm staging OIDC role has DeleteObject/ListBucket as documented; optional manual dry-run of **Prune staging desktop releases**