### PR TITLE
build: bump Codex pin to 0.153.4 for gpt-6-astra metadata

### DIFF
--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -1170,6 +1170,7 @@ requires_openai_auth = true
         assert_eq!(caps_for(Some("codex-cli 0.147.0")), CapLevel::Supported);
         assert_eq!(caps_for(Some("0.147.9")), CapLevel::Supported);
         assert_eq!(caps_for(Some("codex-cli 0.153.0")), CapLevel::Supported);
+        assert_eq!(caps_for(Some("codex-cli 0.153.4")), CapLevel::Supported);
         assert_eq!(caps_for(Some("codex-cli 0.146.3")), CapLevel::Unknown);
         assert_eq!(
             caps_for(Some("codex-cli 0.147.0-alpha.1")),

--- a/crates/tidebreak-harness/src/pin.rs
+++ b/crates/tidebreak-harness/src/pin.rs
@@ -55,7 +55,7 @@ pub const PINS: &[HarnessPin] = &[
     },
     HarnessPin {
         kind: HarnessKind::Codex,
-        version: "0.153.0",
+        version: "0.153.4",
         package: "@openai/codex",
         bin: "codex",
     },
@@ -440,6 +440,15 @@ mod tests {
         ] {
             assert!(pin_for(kind).is_some(), "{kind}");
         }
+    }
+
+    /// Codex 0.153.0 lacks gpt-6-astra model metadata and falls back through
+    /// Model Gateway. 0.153.4 embeds Astra while keeping the same route id.
+    #[test]
+    fn codex_pin_supplies_astra_metadata_line() {
+        let pin = pin_for(HarnessKind::Codex).expect("codex pin");
+        assert_eq!(pin.package, "@openai/codex");
+        assert_eq!(pin.version, "0.153.4");
     }
 
     #[test]


### PR DESCRIPTION
Closes #3281.

## Summary

Hosted Codex sessions through Model Gateway warn that model metadata for `gpt-6-astra` is missing when the harness pin is `@openai/codex@0.153.0`. Bump the pin to `0.153.4`, which embeds Astra metadata in the published binary while keeping the same gateway route and model id.

## Verification

- Compared published linux-x64 vendor binaries: `gpt-6-astra` is absent from `0.153.0` and present in `0.153.4`.
- `cargo test -p tidebreak-harness --lib -- pin::tests`
- `cargo test -p tidebreak-harness --lib -- steering_capability`
- `node --test scripts/self-host-image-pins.test.mjs scripts/supervised-agent-image.test.mjs`

## Out of scope

Hosted gateway session auth and forge credential failures are handled separately.

## Test plan

- [x] Focused harness pin contracts and Codex steering capability gate
- [x] Self-host / supervised-agent image pin integrity scripts
- [ ] CI green on this PR