### PR TITLE
fix(ui): keep comet loaders on one shared rotation phase

### DIFF
--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -246,10 +246,11 @@ markers, not as decorative advertising.
   surfaces. `EmptyMedia variant="icon"` draws no container at all, and it is
   the only icon treatment allowed on an empty surface.
 - Live agent, workspace, tool, and plan status uses the `Loader` comet variant
-  in the `live` tone. Indeterminate action progress uses `Spinner`; a busy
-  refresh control swaps to that glyph. Do not put `animate-spin` on `RefreshCw`
-  or `RotateCw`: Lucide's ink box is not the viewBox center, so the glyph
-  orbits.
+  in the `live` tone. Every comet shares one rotation phase, so a tool that
+  starts later stays in step with the workspace mark already spinning.
+  Indeterminate action progress uses `Spinner`; a busy refresh control swaps
+  to that glyph. Do not put `animate-spin` on `RefreshCw` or `RotateCw`:
+  Lucide's ink box is not the viewBox center, so the glyph orbits.
 
 ### Destructive actions
 

--- a/crates/tidebreak-desktop/ui/src/components/motion/loader.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/motion/loader.dom.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const reducedMotion = vi.hoisted(() => ({ current: false as boolean | null }));
+
+vi.mock("motion/react", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("motion/react")>();
+  return {
+    ...mod,
+    useReducedMotion: () => reducedMotion.current,
+  };
+});
+
+import { Loader, resetCometSharedClockForTests } from "./loader";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  reducedMotion.current = false;
+  resetCometSharedClockForTests();
+  setVisibility("visible");
+});
+
+beforeEach(() => {
+  reducedMotion.current = false;
+  resetCometSharedClockForTests();
+  setVisibility("visible");
+});
+
+function spinNode(container: HTMLElement) {
+  return container.querySelector("[data-comet-spin]");
+}
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => state === "hidden",
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("Loader comet", () => {
+  it("phases rotation onto a shared clock so late mounts stay in sync", () => {
+    vi.spyOn(performance, "now").mockReturnValue(250);
+    const first = render(<Loader variant="comet" speed={1} decorative />);
+    expect(spinNode(first.container)).toHaveStyle({ animationDelay: "-250ms" });
+
+    vi.spyOn(performance, "now").mockReturnValue(1250);
+    const second = render(<Loader variant="comet" speed={1} decorative />);
+    expect(spinNode(second.container)).toHaveStyle({
+      animationDelay: "-250ms",
+    });
+
+    vi.spyOn(performance, "now").mockReturnValue(600);
+    const third = render(<Loader variant="comet" speed={1} decorative />);
+    expect(spinNode(third.container)).toHaveStyle({ animationDelay: "-600ms" });
+  });
+
+  it("does not restart the cycle when a parent re-renders", () => {
+    vi.spyOn(performance, "now").mockReturnValue(250);
+    const view = render(<Loader variant="comet" speed={1} decorative />);
+    expect(spinNode(view.container)).toHaveStyle({ animationDelay: "-250ms" });
+
+    vi.spyOn(performance, "now").mockReturnValue(800);
+    view.rerender(<Loader variant="comet" speed={1} decorative />);
+    expect(spinNode(view.container)).toHaveStyle({ animationDelay: "-250ms" });
+  });
+
+  it("freezes the shared clock while the document is hidden", () => {
+    vi.spyOn(performance, "now").mockReturnValue(400);
+    const first = render(<Loader variant="comet" speed={1} decorative />);
+    expect(spinNode(first.container)).toHaveStyle({ animationDelay: "-400ms" });
+
+    setVisibility("hidden");
+    // Wall clock advances while hidden; phase must not.
+    vi.spyOn(performance, "now").mockReturnValue(9400);
+    const whileHidden = render(<Loader variant="comet" speed={1} decorative />);
+    expect(spinNode(whileHidden.container)).toHaveStyle({
+      animationDelay: "-400ms",
+    });
+
+    setVisibility("visible");
+    vi.spyOn(performance, "now").mockReturnValue(9600);
+    const afterResume = render(<Loader variant="comet" speed={1} decorative />);
+    // 400ms frozen + 200ms after resume.
+    expect(spinNode(afterResume.container)).toHaveStyle({
+      animationDelay: "-600ms",
+    });
+  });
+
+  it("omits the CSS spin node when motion is reduced", () => {
+    reducedMotion.current = true;
+    const view = render(<Loader variant="comet" speed={1} decorative />);
+    expect(spinNode(view.container)).toBeNull();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/components/motion/loader.tsx
+++ b/crates/tidebreak-desktop/ui/src/components/motion/loader.tsx
@@ -2,7 +2,13 @@
 // beui.dev/components/motion/loader
 
 import { motion, useReducedMotion } from "motion/react";
-import { useEffect, useId, useState, type HTMLAttributes } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type HTMLAttributes,
+} from "react";
 import { EASE_IN_OUT } from "@/lib/ease";
 import { cn } from "@/lib/utils";
 
@@ -308,39 +314,115 @@ function Morph({ size, speed, reduce }: PartProps) {
 
 const COMET_TRAIL = [0, 1, 2, 3, 4, 5];
 
+// Shared visible-time clock for every comet. CSS `animate-spin` freezes while
+// the document is hidden; this clock freezes on the same boundary so a comet
+// mounted after the tab returns still matches ones that were paused. One
+// document listener for the process — no per-spinner timers or rAF loops.
+let cometFrozenVisibleMs = 0;
+let cometVisibleOriginMs = 0;
+let cometDocumentHidden = false;
+let cometVisibilityBound = false;
+
+function onCometVisibilityChange(): void {
+  if (typeof document === "undefined") return;
+  const hidden = document.visibilityState === "hidden";
+  // Ignore no-op dispatches (tests reset visibility without a real transition).
+  if (hidden === cometDocumentHidden) return;
+  cometDocumentHidden = hidden;
+  if (hidden) {
+    cometFrozenVisibleMs += performance.now() - cometVisibleOriginMs;
+  } else {
+    cometVisibleOriginMs = performance.now();
+  }
+}
+
+function bindCometVisibilityClock(): void {
+  if (cometVisibilityBound || typeof document === "undefined") return;
+  cometVisibilityBound = true;
+  cometDocumentHidden = document.visibilityState === "hidden";
+  if (cometDocumentHidden) {
+    // Never ran a visible segment: pin phase to "now" so it stops advancing.
+    cometFrozenVisibleMs = performance.now();
+  } else {
+    // Origin 0 keeps shared time === performance.now() until the first hide.
+    cometVisibleOriginMs = 0;
+  }
+  document.addEventListener("visibilitychange", onCometVisibilityChange);
+}
+
+/** Elapsed ms that advance only while the document is visible. */
+function cometSharedNowMs(): number {
+  if (typeof document === "undefined") {
+    return performance.now();
+  }
+  bindCometVisibilityClock();
+  if (cometDocumentHidden) {
+    return cometFrozenVisibleMs;
+  }
+  return cometFrozenVisibleMs + (performance.now() - cometVisibleOriginMs);
+}
+
+/** Negative CSS delay that places a comet on the shared rotation clock. */
+function cometSpinDelayMs(speed: number): number {
+  const durationMs = Math.max(speed, 0.001) * 1000;
+  return -(cometSharedNowMs() % durationMs);
+}
+
+/** Test-only: clear accumulated visible time between cases. */
+export function resetCometSharedClockForTests(): void {
+  cometFrozenVisibleMs = 0;
+  cometVisibleOriginMs = 0;
+  cometDocumentHidden =
+    typeof document !== "undefined" && document.visibilityState === "hidden";
+}
+
 function Comet({ size, speed, reduce }: PartProps) {
   const head = size * 0.2;
   const r = size / 2 - head / 2;
+  // Freeze the delay on mount (and if `speed` changes). Computing it during
+  // every render would restart the CSS animation on each parent update.
+  const delayMs = useMemo(() => cometSpinDelayMs(speed), [speed]);
+  const trail = COMET_TRAIL.map((i) => {
+    const scale = 1 - i * 0.13;
+    const sz = head * scale;
+    return (
+      <span
+        key={i}
+        className="absolute top-1/2 left-1/2 rounded-full bg-current"
+        style={{
+          width: sz,
+          height: sz,
+          marginLeft: -sz / 2,
+          marginTop: -sz / 2,
+          opacity: 1 - i * 0.16,
+          transform: `rotate(${-i * 15}deg) translateY(${-r}px)`,
+        }}
+      />
+    );
+  });
+
   return (
     <span className="relative" style={{ width: size, height: size }}>
-      <motion.span
-        className="absolute inset-0"
-        animate={reduce ? REDUCED.animate : { rotate: 360 }}
-        transition={
-          reduce
-            ? REDUCED.transition
-            : { duration: speed, ease: "linear", repeat: Infinity }
-        }
-      >
-        {COMET_TRAIL.map((i) => {
-          const scale = 1 - i * 0.13;
-          const sz = head * scale;
-          return (
-            <span
-              key={i}
-              className="absolute top-1/2 left-1/2 rounded-full bg-current"
-              style={{
-                width: sz,
-                height: sz,
-                marginLeft: -sz / 2,
-                marginTop: -sz / 2,
-                opacity: 1 - i * 0.16,
-                transform: `rotate(${-i * 15}deg) translateY(${-r}px)`,
-              }}
-            />
-          );
-        })}
-      </motion.span>
+      {reduce ? (
+        <motion.span
+          className="absolute inset-0"
+          animate={REDUCED.animate}
+          transition={REDUCED.transition}
+        >
+          {trail}
+        </motion.span>
+      ) : (
+        <span
+          className="absolute inset-0 animate-spin"
+          data-comet-spin=""
+          style={{
+            animationDuration: `${speed}s`,
+            animationDelay: `${delayMs}ms`,
+          }}
+        >
+          {trail}
+        </span>
+      )}
     </span>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/stories/Loader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Loader.stories.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Loader } from "@/components/motion/loader";
@@ -42,6 +42,28 @@ export const CometSizes: Story = {
       ))}
     </div>
   ),
+};
+
+/** Late mounts join the same rotation, they do not start from 12 o'clock. */
+export const SyncedAcrossMounts: Story = {
+  render: function Render() {
+    const [joined, setJoined] = useState(false);
+    useEffect(() => {
+      const id = window.setTimeout(() => setJoined(true), 450);
+      return () => window.clearTimeout(id);
+    }, []);
+    return (
+      <div className="flex items-center gap-6 text-live">
+        <Loader variant="comet" size={24} label="Already spinning" />
+        <Loader variant="comet" size={16} label="Same cycle, smaller" />
+        {joined ? (
+          <Loader variant="comet" size={24} label="Joined later" />
+        ) : (
+          <span className="text-xs text-muted-foreground">joining…</span>
+        )}
+      </div>
+    );
+  },
 };
 
 export const StatusContexts: Story = {


### PR DESCRIPTION
Closes #3278

## Summary

Every `Loader` comet derives its CSS `animation-delay` from one module-level visible-time clock so late mounts join the same rotation instead of restarting at 12 o'clock. There are no per-spinner timers or rAF loops: one `visibilitychange` listener freezes the clock while the document is hidden (aligned with CSS spin pause), reduced motion still drops the spin node, and parent re-renders keep the mount-time delay.

## Scope

- `components/motion/loader.tsx` shared clock + comet delay
- DOM regression tests (late mount phase, re-render stability, hidden freeze, reduced motion)
- `Foundations/Loader` stories including `SyncedAcrossMounts`
- DESIGN.md status vocabulary note

Journal cards / composer call sites are out of scope (other owners).

## Test plan

- [x] `pnpm exec vitest run src/components/motion/loader.dom.test.tsx`
- [x] `pnpm exec biome format` on touched UI files
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm storybook:build`
- [ ] Review `Foundations/Loader` → Comet, CometSizes, SyncedAcrossMounts, StatusContexts in Storybook (light/dark, narrow/wide) once visual tooling is available