### PR TITLE
feat(ui): Cmd/Ctrl+Enter steers during an active turn

### DIFF
--- a/crates/tidebreak-desktop/ui/src/Composer.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.test.tsx
@@ -7,6 +7,7 @@ import {
   imageSendBlocker,
   MAX_COMPOSER_LINES,
   shouldRestoreComposerFocus,
+  shouldSteerComposerKey,
   shouldSubmitComposerKey,
   type ComposerFolders,
   type ComposerImages,
@@ -112,6 +113,35 @@ describe("Composer", () => {
         }),
       ).toBe(false);
     }
+  });
+
+  it("steers on Cmd or Ctrl+Enter outside IME composition", () => {
+    const unmodified = {
+      key: "Enter",
+      shiftKey: false,
+      ctrlKey: false,
+      altKey: false,
+      metaKey: false,
+      isComposing: false,
+      keyCode: 13,
+    };
+    expect(shouldSteerComposerKey({ ...unmodified, metaKey: true })).toBe(true);
+    expect(shouldSteerComposerKey({ ...unmodified, ctrlKey: true })).toBe(true);
+    expect(shouldSteerComposerKey(unmodified)).toBe(false);
+    expect(
+      shouldSteerComposerKey({ ...unmodified, metaKey: true, shiftKey: true }),
+    ).toBe(false);
+    expect(
+      shouldSteerComposerKey({ ...unmodified, metaKey: true, altKey: true }),
+    ).toBe(false);
+    expect(
+      shouldSteerComposerKey({
+        ...unmodified,
+        metaKey: true,
+        isComposing: true,
+        keyCode: 229,
+      }),
+    ).toBe(false);
   });
 
   it("caps auto-grow at six lines while retaining a one-line minimum", () => {

--- a/crates/tidebreak-desktop/ui/src/Composer.tsx
+++ b/crates/tidebreak-desktop/ui/src/Composer.tsx
@@ -89,6 +89,7 @@ import { DocumentIcon } from "@/components/document-table/DocumentIcon";
 import type { ImportedDocument } from "@/documents";
 import type { PluginInfo } from "./api";
 import { folderAccessLabel, folderReach } from "./FolderAccess";
+import { usesCommandModifier } from "./ShellShortcuts";
 import { useUiStore } from "./UiStore";
 import type { ConnectedFolder } from "./host";
 import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
@@ -118,16 +119,26 @@ type ComposerKeyEvent = Pick<
   | "shiftKey"
 >;
 
-export function shouldSubmitComposerKey(event: ComposerKeyEvent): boolean {
+function isComposerEnter(event: ComposerKeyEvent): boolean {
   return (
     event.key === "Enter" &&
     !event.shiftKey &&
-    !event.ctrlKey &&
     !event.altKey &&
-    !event.metaKey &&
     !event.isComposing &&
     event.keyCode !== 229
   );
+}
+
+export function shouldSubmitComposerKey(event: ComposerKeyEvent): boolean {
+  return isComposerEnter(event) && !event.ctrlKey && !event.metaKey;
+}
+
+/**
+ * Cmd/Ctrl+Enter steers an active turn immediately, even when Enter queues.
+ * Either modifier is accepted on every platform so the chord cannot miss.
+ */
+export function shouldSteerComposerKey(event: ComposerKeyEvent): boolean {
+  return isComposerEnter(event) && (event.metaKey || event.ctrlKey);
 }
 
 export function shouldRestoreComposerFocus(
@@ -382,7 +393,8 @@ export type ComposerProps = {
   /**
    * Queue the draft to run as its own turn after the active one finishes.
    * Absent when the surface has no queue (e.g. a chat that does not exist
-   * yet); then a mid-turn Enter steers as before.
+   * yet); then a mid-turn Enter steers as before. Cmd/Ctrl+Enter always
+   * steers when a turn is active, even when this is present.
    */
   onQueue?: () => Promise<void>;
   onStop: () => Promise<void>;
@@ -476,6 +488,11 @@ export function Composer({
   const active = busy && activeTurnId !== null;
   const sendMode = useUiStore((state) => state.activeTurnSendMode);
   const queueAvailable = onQueue !== undefined;
+  const willQueue = queueAvailable && sendMode === "queue";
+  const command = usesCommandModifier(
+    typeof navigator === "undefined" ? "" : navigator.userAgent,
+  );
+  const modEnter = command ? "⌘Enter" : "Ctrl+Enter";
   const submissionText = messageWithPastedText(draft, pastedTexts?.items ?? []);
   const hasDraft = Boolean(submissionText.trim());
   const steerHasUnsupportedCharacter = active && submissionText.includes("\0");
@@ -672,7 +689,13 @@ export function Composer({
       setMentionHighlight(moved);
       return true;
     }
-    if (event.key === "Enter" || event.key === "Tab") {
+    if (
+      event.key === "Tab" ||
+      (event.key === "Enter" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey)
+    ) {
       const row = mentionMatches[mentionIndex];
       if (row && mentionToken) {
         setMentionToken(null);
@@ -811,7 +834,13 @@ export function Composer({
       setSlashHighlight(moved);
       return true;
     }
-    if (event.key === "Enter" || event.key === "Tab") {
+    if (
+      event.key === "Tab" ||
+      (event.key === "Enter" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey)
+    ) {
       const option = slashMatches[slashIndex];
       // A row that cannot be picked keeps the list up instead of closing on a
       // key that did nothing, so the reason stays in front of the reader.
@@ -824,23 +853,22 @@ export function Composer({
     return false;
   }
 
-  async function submit(): Promise<void> {
+  async function submit(
+    intent: "default" | "steer" = "default",
+  ): Promise<void> {
     if (!canSubmit) return;
     // A line that names a command is not a message: it runs here, and the draft
     // it came from goes away like a sent one would. Checked before the send so
     // a command is never posted to the model as prose.
-    const command = slash?.onCommand ? parseSlashCommand(draft) : null;
-    if (command) {
+    const parsedCommand = slash?.onCommand ? parseSlashCommand(draft) : null;
+    if (parsedCommand) {
       onDraftChange("");
-      slash?.onCommand?.(command.command.name, command.argument);
+      slash?.onCommand?.(parsedCommand.command.name, parsedCommand.argument);
       return;
     }
     const submissionKey = resetKey;
-    await (active
-      ? queueAvailable && sendMode === "queue"
-        ? onQueue()
-        : onSteer()
-      : onSend());
+    const queueing = willQueue && intent !== "steer";
+    await (active ? (queueing ? onQueue() : onSteer()) : onSend());
     historyIndexRef.current = null;
 
     // Restore focus after accepted guidance or a failed request. A new chat or
@@ -1254,6 +1282,15 @@ export function Composer({
             event.preventDefault();
             return;
           }
+          // Cmd/Ctrl+Enter steers only while a turn is active. When idle the
+          // chord is left alone so ordinary Enter remains the sole send key.
+          if (shouldSteerComposerKey(event.nativeEvent)) {
+            if (active) {
+              event.preventDefault();
+              void submit("steer");
+            }
+            return;
+          }
           if (!shouldSubmitComposerKey(event.nativeEvent)) return;
           event.preventDefault();
           void submit();
@@ -1344,24 +1381,35 @@ export function Composer({
           {active ? (
             <>
               {(hasDraft || steerPending) && (
-                <Button
-                  type="submit"
-                  variant="default"
-                  size="xs"
-                  className="h-8 min-w-[5rem] px-3 text-sm"
-                  aria-label={
-                    queueAvailable && sendMode === "queue"
-                      ? "Queue message for after this response"
-                      : "Steer active response"
+                <WithTooltip
+                  label={
+                    willQueue ? (
+                      <>
+                        Queue · Enter
+                        <span className="mt-1 block font-normal text-primary-foreground/80">
+                          Steer · {modEnter}
+                        </span>
+                      </>
+                    ) : (
+                      "Steer · Enter"
+                    )
                   }
-                  disabled={!canSubmit}
                 >
-                  {steerPending
-                    ? "Sending…"
-                    : queueAvailable && sendMode === "queue"
-                      ? "Queue"
-                      : "Steer"}
-                </Button>
+                  <Button
+                    type="submit"
+                    variant="default"
+                    size="xs"
+                    className="h-8 min-w-[5rem] px-3 text-sm"
+                    aria-label={
+                      willQueue
+                        ? "Queue message for after this response"
+                        : "Steer active response"
+                    }
+                    disabled={!canSubmit}
+                  >
+                    {steerPending ? "Sending…" : willQueue ? "Queue" : "Steer"}
+                  </Button>
+                </WithTooltip>
               )}
               <WithTooltip label={cancelPending ? "Stopping…" : "Stop"}>
                 <Button

--- a/crates/tidebreak-desktop/ui/src/ComposerSteer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerSteer.dom.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { Composer } from "./Composer";
+import { useUiStore } from "./UiStore";
+
+afterEach(() => {
+  cleanup();
+  useUiStore.setState({ activeTurnSendMode: "queue" });
+});
+
+beforeEach(() => {
+  useUiStore.setState({ activeTurnSendMode: "queue" });
+});
+
+function ActiveComposer({
+  onSend,
+  onSteer,
+  onQueue,
+  active = true,
+}: {
+  onSend: () => Promise<void>;
+  onSteer: () => Promise<void>;
+  onQueue?: () => Promise<void>;
+  active?: boolean;
+}) {
+  const [draft, setDraft] = useState("redirect the turn");
+  return (
+    <Composer
+      activeTurnId={active ? "turn-1" : null}
+      busy={active}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft={draft}
+      onDraftChange={setDraft}
+      onSend={onSend}
+      onSteer={onSteer}
+      onQueue={onQueue}
+      onStop={async () => undefined}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />
+  );
+}
+
+describe("Composer Cmd/Ctrl+Enter steer", () => {
+  it("queues on Enter and steers on Cmd+Enter while queue is the default", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onQueue = vi.fn().mockResolvedValue(undefined);
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ActiveComposer onSend={onSend} onSteer={onSteer} onQueue={onQueue} />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.keyDown(box, { key: "Enter" });
+    await waitFor(() => expect(onQueue).toHaveBeenCalledTimes(1));
+    expect(onSteer).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(box, { key: "Enter", metaKey: true });
+    await waitFor(() => expect(onSteer).toHaveBeenCalledTimes(1));
+    expect(onQueue).toHaveBeenCalledTimes(1);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("steers on Ctrl+Enter as well as Cmd+Enter", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onQueue = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ActiveComposer onSend={vi.fn()} onSteer={onSteer} onQueue={onQueue} />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Message" }), {
+      key: "Enter",
+      ctrlKey: true,
+    });
+    await waitFor(() => expect(onSteer).toHaveBeenCalledTimes(1));
+    expect(onQueue).not.toHaveBeenCalled();
+  });
+
+  it("does not send or steer on Cmd+Enter when no turn is running", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<ActiveComposer active={false} onSend={onSend} onSteer={onSteer} />);
+
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Message" }), {
+      key: "Enter",
+      metaKey: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(onSteer).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("ignores Cmd+Enter during IME composition and with Shift", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ActiveComposer onSend={vi.fn()} onSteer={onSteer} onQueue={vi.fn()} />,
+    );
+    const box = screen.getByRole("textbox", { name: "Message" });
+
+    fireEvent.keyDown(box, {
+      key: "Enter",
+      metaKey: true,
+      isComposing: true,
+      keyCode: 229,
+    });
+    fireEvent.keyDown(box, { key: "Enter", metaKey: true, shiftKey: true });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(onSteer).not.toHaveBeenCalled();
+  });
+
+  it("documents the steer chord on the queue action tooltip", () => {
+    render(
+      <ActiveComposer onSend={vi.fn()} onSteer={vi.fn()} onQueue={vi.fn()} />,
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Queue message for after this response",
+      }),
+    ).toBeVisible();
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/UiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/UiStore.ts
@@ -118,7 +118,7 @@ export type UiStore = {
    */
   modelMenuNotConnectedCollapsed: boolean;
   toggleModelMenuNotConnected: () => void;
-  /** What Enter and the single composer action do while a response is running. */
+  /** What Enter and the single composer action do while a response is running. Cmd/Ctrl+Enter always steers. */
   activeTurnSendMode: ActiveTurnSendMode;
   setActiveTurnSendMode: (mode: ActiveTurnSendMode) => void;
   /**

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.dom.test.tsx
@@ -449,6 +449,74 @@ describe("CodeComposer", () => {
     expect(box).toHaveValue("");
   });
 
+  it("steers immediately on Cmd+Enter while queueing is the default", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onSend = vi.fn();
+    renderComposer(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        onSend={onSend}
+        onSteer={onSteer}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "try the other file" } });
+    fireEvent.keyDown(box, { key: "Enter", metaKey: true });
+
+    await waitFor(() =>
+      expect(onSteer).toHaveBeenCalledWith("try the other file"),
+    );
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("steers immediately on Ctrl+Enter while queueing is the default", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onSend = vi.fn();
+    renderComposer(
+      <CodeComposer
+        running
+        permissionMode="ask"
+        onSend={onSend}
+        onSteer={onSteer}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "narrow the scope" } });
+    fireEvent.keyDown(box, { key: "Enter", ctrlKey: true });
+
+    await waitFor(() =>
+      expect(onSteer).toHaveBeenCalledWith("narrow the scope"),
+    );
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("leaves Cmd+Enter alone when the session is not running", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onSend = vi.fn();
+    renderComposer(
+      <CodeComposer
+        running={false}
+        permissionMode="ask"
+        onSend={onSend}
+        onSteer={onSteer}
+        onInterrupt={vi.fn()}
+      />,
+    );
+
+    const box = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(box, { target: { value: "start when ready" } });
+    fireEvent.keyDown(box, { key: "Enter", metaKey: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(onSteer).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   it("accepts guidance once a pending submit becomes an active turn", async () => {
     let resolveSend!: () => void;
     const onSend = vi.fn(

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -66,6 +66,7 @@ describe("AgentsPanel", () => {
 
     render(<AgentsPanel client={client} />);
     await screen.findByText("Active background agents per work");
+    expect(screen.getByText(/always steers immediately/)).toBeVisible();
     expect(screen.getByRole("radio", { name: "Queue" })).toBeChecked();
     fireEvent.click(screen.getByRole("radio", { name: "Steer" }));
     expect(useUiStore.getState().activeTurnSendMode).toBe("steer");

--- a/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/AgentsPanel.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Switch } from "@/components/ui/switch";
+import { usesCommandModifier } from "../ShellShortcuts";
 import { useUiStore, type ActiveTurnSendMode } from "../UiStore";
 import {
   SettingsError,
@@ -26,6 +27,11 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
   const setActiveTurnSendMode = useUiStore(
     (state) => state.setActiveTurnSendMode,
   );
+  const modEnter = usesCommandModifier(
+    typeof navigator === "undefined" ? "" : navigator.userAgent,
+  )
+    ? "⌘Enter"
+    : "Ctrl+Enter";
   const [limit, setLimit] = useState("");
   const [checkinSteps, setCheckinSteps] = useState("");
   const [errorCheckin, setErrorCheckin] = useState("");
@@ -136,7 +142,7 @@ export function AgentsPanel({ client }: { client: ApiClient }) {
     >
       <SettingsSection
         title="While an agent is responding"
-        description="Choose what the single composer action does when you type during a running response."
+        description={`Choose what Enter and the composer action do during a running response. ${modEnter} always steers immediately.`}
       >
         <RadioGroup
           aria-label="Default action while an agent is responding"


### PR DESCRIPTION
## Summary

Cmd/Ctrl+Enter steers the active turn immediately in Work and Code composers, even when Enter is configured to queue. Plain Enter and the single composer action still follow `activeTurnSendMode`. The chord does nothing when idle, during IME composition, or with Shift/Alt.

## Changes

- Shared `Composer` key handling: `shouldSteerComposerKey` + submit intent `steer`
- Queue-mode tooltip documents Enter vs Cmd/Ctrl+Enter; Agents settings copy notes the chord
- Focused unit + DOM tests for Work and Code (queue Enter, steer chord, idle, IME/Shift)

## Test plan

- [x] `vitest` Composer unit helpers, `ComposerSteer.dom`, `CodeComposer.dom`, `AgentsPanel.dom`
- [x] `tsc --noEmit`, biome format on touched files
- [x] Storybook build (`ActiveStreamingQueueAndStop` covers queue-mode composer)
- [ ] Manual: mid-turn queue mode — Enter queues, Cmd/Ctrl+Enter steers; idle Cmd+Enter does not send

## Overlap

Agent track for keen-field owns model-picker search/upload copy and may touch `Composer.test.tsx`. This PR only adds the isolated `shouldSteerComposerKey` unit cases there; behavioral coverage lives in `ComposerSteer.dom.test.tsx`.

## Tracking

Sandbox REST policy blocked `POST/PATCH /issues` (create/claim/assignee/labels). Work is tracked by this PR; assignee is the PR author (`naingthet`).
