### PR TITLE
improve(harness): preserve hosted relay credentials for forge tools

### DIFF
--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -181,11 +181,10 @@ impl GrokSession {
     /// key, or `None` on a machine whose spawn wiring carried no key.
     ///
     /// The wiring hands the key over under the environment name
-    /// [`crate::SessionSpec::relay_key_env`]; the adapter consumes it here
-    /// and [`compose_print_plan`] keeps that variable out of the child's
-    /// environment. The Grok CLI reads credentials only from an auth file,
-    /// so the key travels the last hop inside a session-scoped 0600 file
-    /// pointed at by `GROK_AUTH_PATH`.
+    /// [`crate::SessionSpec::relay_key_env`]. The Grok CLI reads inference
+    /// credentials from a session-scoped 0600 file at `GROK_AUTH_PATH`.
+    /// [`compose_print_plan`] also retains the wired variable so shell
+    /// tools can borrow forge credentials through the host.
     ///
     /// Grok 1.0.4 refuses to start a headless child without a credential in
     /// its auth file and presents that credential as the bearer on every
@@ -333,9 +332,8 @@ pub(crate) struct PrintLaunch<'a> {
     /// machine whose spawn wiring carried no key.
     pub relay_auth: Option<&'a Path>,
     /// Environment variable name the spawn wiring used to carry the relay
-    /// key ([`crate::SessionSpec::relay_key_env`]). The adapter consumed
-    /// the key into `relay_auth`, so the variable is stripped from the
-    /// child's environment here.
+    /// key ([`crate::SessionSpec::relay_key_env`]). The child also retains
+    /// this key so its git helper can borrow the session's forge credential.
     pub relay_key_env: Option<&'a str>,
     /// An existing engine session to `--resume`.
     pub resume_ref: Option<&'a str>,
@@ -422,13 +420,10 @@ pub(crate) fn compose_print_plan(launch: PrintLaunch<'_>) -> Result<LaunchPlan, 
     argv.extend(launch.extra_argv.iter().cloned());
     let mut env = launch.extra_env.to_vec();
     env.retain(|(key, _)| {
-        !BrowserChannelSpec::is_reserved_env_key(key)
-            && launch.relay_key_env != Some(key.as_str())
-            && key != "PWD"
+        !BrowserChannelSpec::is_reserved_env_key_except(key, launch.relay_key_env) && key != "PWD"
     });
-    // The relay key itself was consumed into `relay_auth` and the retain
-    // above stripped its variable; the child learns only where the file is
-    // and which issuer scope it names.
+    // Grok reads inference credentials from its auth file. Shell tools also
+    // need the wired relay key to borrow forge credentials through the host.
     if let Some(auth) = launch.relay_auth {
         env.push(("GROK_AUTH_PATH".into(), auth.to_string_lossy().into_owned()));
         env.push(("GROK_OAUTH2_ISSUER".into(), RELAY_ISSUER.into()));
@@ -887,8 +882,8 @@ mod tests {
         assert!(!plan.argv.iter().any(|arg| arg == "xhigh"));
     }
 
-    #[test]
-    fn relay_wiring_moves_the_key_into_an_auth_file_and_points_the_env_at_it() {
+    #[tokio::test]
+    async fn relay_wiring_keeps_the_key_for_forge_tools_and_configures_the_auth_file() {
         let dir = tempfile::tempdir().unwrap();
         let auth_path = dir.path().join("auth.json");
         let plan = compose_print_plan(PrintLaunch {
@@ -897,6 +892,11 @@ mod tests {
             cwd: dir.path(),
             extra_env: &[
                 ("TIDEBREAK_LLM_KEY".to_owned(), "tbreak_hl_k".to_owned()),
+                ("tidebreak_llm_key".to_owned(), "untrusted".to_owned()),
+                (
+                    "TIDEBREAK_BROWSER_CAPFILE".to_owned(),
+                    "untrusted".to_owned(),
+                ),
                 (
                     "GROK_MODELS_BASE_URL".to_owned(),
                     "http://127.0.0.1:1/code/llm/openai/v1".to_owned(),
@@ -913,6 +913,24 @@ mod tests {
             effort_ladder: crate::grok::EFFORT_LADDER_1_0_4,
         })
         .unwrap();
+
+        #[cfg(unix)]
+        {
+            let mut shell = tokio::process::Command::new("/bin/sh");
+            shell.args(["-c", r#"test "$TIDEBREAK_LLM_KEY" = tbreak_hl_k"#]);
+            apply_child_env_tokio(
+                &mut shell,
+                HarnessKind::Grok,
+                Vec::new(),
+                &plan.env,
+                None,
+                None,
+            );
+            assert!(
+                shell.status().await.unwrap().success(),
+                "shell tools need the relay key"
+            );
+        }
 
         let env: std::collections::HashMap<_, _> = plan.env.into_iter().collect();
         assert_eq!(
@@ -933,11 +951,13 @@ mod tests {
             env.get("GROK_MODELS_BASE_URL").map(String::as_str),
             Some("http://127.0.0.1:1/code/llm/openai/v1")
         );
-        assert!(
-            !env.contains_key("TIDEBREAK_LLM_KEY"),
-            "the relay key never reaches the child's environment: {:?}",
-            env
+        assert_eq!(
+            env.get("TIDEBREAK_LLM_KEY").map(String::as_str),
+            Some("tbreak_hl_k"),
+            "git and gh borrow forge credentials under the wired session key"
         );
+        assert!(!env.contains_key("tidebreak_llm_key"));
+        assert!(!env.contains_key("TIDEBREAK_BROWSER_CAPFILE"));
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -798,10 +798,10 @@ pub struct SessionSpec {
     /// Environment variable name in `extra_env` that carries the session
     /// inference relay key, when the caller wired one ([`crate::wiring`],
     /// decision 71). Adapters let exactly this key survive the
-    /// reserved-namespace strip — or, for an engine that reads credentials
-    /// from a file, consume the value under this name instead of passing it
-    /// through. `None` means no relay is wired and the whole reserved
-    /// namespace is stripped.
+    /// reserved-namespace strip so shell tools can also borrow forge
+    /// credentials. Engines that read inference credentials from a file
+    /// additionally copy the value there. `None` means no relay is wired
+    /// and the whole reserved namespace is stripped.
     pub relay_key_env: Option<String>,
     /// Shell-resolved environment captured by the probe. Children run under
     /// the [`filter_child_env`] allowlist subset of this snapshot, not the

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -436,16 +436,17 @@ mod tests {
 
     #[test]
     fn launch_plan_never_includes_bypass_or_auto() {
-        let plan = compose_serve_plan(
-            Path::new("/usr/bin/opencode"),
-            &[],
-            Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            None,
-            None,
-        )
+        let plan = compose_serve_plan(crate::opencode::session::ServeLaunch {
+            binary: Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: None,
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         assert!(!plan
             .argv

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -282,18 +282,33 @@ fn effective_existing_config_str<'a>(
     Ok(Some(value))
 }
 
+/// Inputs for the long-lived Opencode serve child.
+pub(crate) struct ServeLaunch<'a> {
+    pub binary: &'a std::path::Path,
+    pub extra_argv: &'a [String],
+    pub cwd: &'a std::path::Path,
+    pub snapshot_env: &'a [(std::ffi::OsString, std::ffi::OsString)],
+    pub extra_env: &'a [(String, String)],
+    pub port: u16,
+    pub browser: Option<&'a BrowserChannelSpec>,
+    pub native: Option<&'a crate::NativeChannelSpec>,
+    /// The exact host-wired key used by shell tools to borrow forge credentials.
+    pub relay_key_env: Option<&'a str>,
+}
+
 /// Argv for the long-lived serve child. Prompt never appears here.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn compose_serve_plan(
-    binary: &std::path::Path,
-    extra_argv: &[String],
-    cwd: &std::path::Path,
-    snapshot_env: &[(std::ffi::OsString, std::ffi::OsString)],
-    extra_env: &[(String, String)],
-    port: u16,
-    browser: Option<&BrowserChannelSpec>,
-    native: Option<&crate::NativeChannelSpec>,
-) -> Result<LaunchPlan, HarnessError> {
+pub(crate) fn compose_serve_plan(launch: ServeLaunch<'_>) -> Result<LaunchPlan, HarnessError> {
+    let ServeLaunch {
+        binary,
+        extra_argv,
+        cwd,
+        snapshot_env,
+        extra_env,
+        port,
+        browser,
+        native,
+        relay_key_env,
+    } = launch;
     let mut argv = vec![
         binary.to_string_lossy().into_owned(),
         "serve".into(),
@@ -313,7 +328,7 @@ pub(crate) fn compose_serve_plan(
     }
     let mut env = extra_env.to_vec();
     env.retain(|(key, _)| {
-        !BrowserChannelSpec::is_reserved_env_key(key)
+        !BrowserChannelSpec::is_reserved_env_key_except(key, relay_key_env)
             && key != "PWD"
             && !env_key_eq(key, OPENCODE_CONFIG_CONTENT)
     });
@@ -527,16 +542,17 @@ impl OpencodeSession {
             self.child_pid.store(0, Ordering::SeqCst);
         }
         let port = pick_loopback_port()?;
-        let plan = compose_serve_plan(
-            self.spec.binary.as_deref().ok_or(HarnessError::NotFound)?,
-            &self.spec.extra_argv,
-            &self.spec.worktree,
-            &self.spec.env,
-            &self.spec.extra_env,
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: self.spec.binary.as_deref().ok_or(HarnessError::NotFound)?,
+            extra_argv: &self.spec.extra_argv,
+            cwd: &self.spec.worktree,
+            snapshot_env: &self.spec.env,
+            extra_env: &self.spec.extra_env,
             port,
-            self.spec.browser.as_ref(),
-            self.spec.native.as_ref(),
-        )?;
+            browser: self.spec.browser.as_ref(),
+            native: self.spec.native.as_ref(),
+            relay_key_env: self.spec.relay_key_env.as_deref(),
+        })?;
         let mut command = Command::new(&plan.argv[0]);
         command
             .args(&plan.argv[1..])
@@ -1263,18 +1279,71 @@ mod tests {
         assert!(session.child.lock().await.is_none());
     }
 
+    #[tokio::test]
+    async fn relay_wiring_preserves_only_the_host_key_for_forge_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let extra_env = vec![
+            ("TIDEBREAK_LLM_KEY".into(), "test-session-key".into()),
+            ("tidebreak_llm_key".into(), "untrusted".into()),
+            ("TIDEBREAK_BROWSER_CAPFILE".into(), "untrusted".into()),
+        ];
+        for relay_key_env in [Some("TIDEBREAK_LLM_KEY"), None] {
+            let plan = compose_serve_plan(ServeLaunch {
+                binary: std::path::Path::new("/usr/bin/opencode"),
+                extra_argv: &[],
+                cwd: dir.path(),
+                snapshot_env: &[],
+                extra_env: &extra_env,
+                port: 1234,
+                browser: None,
+                native: None,
+                relay_key_env,
+            })
+            .unwrap();
+            let value = plan
+                .env
+                .iter()
+                .find(|(name, _)| name == "TIDEBREAK_LLM_KEY");
+            assert_eq!(
+                value.map(|(_, value)| value.as_str()),
+                relay_key_env.map(|_| "test-session-key")
+            );
+            assert!(plan.env.iter().all(
+                |(name, _)| name != "tidebreak_llm_key" && name != "TIDEBREAK_BROWSER_CAPFILE"
+            ));
+            #[cfg(unix)]
+            if relay_key_env.is_some() {
+                let mut shell = tokio::process::Command::new("/bin/sh");
+                shell.args(["-c", r#"test "$TIDEBREAK_LLM_KEY" = test-session-key"#]);
+                apply_child_env_tokio(
+                    &mut shell,
+                    tidebreak_core::HarnessKind::Opencode,
+                    Vec::new(),
+                    &plan.env,
+                    None,
+                    None,
+                );
+                assert!(
+                    shell.status().await.unwrap().success(),
+                    "shell tools need the relay key"
+                );
+            }
+        }
+    }
+
     #[test]
     fn serve_plan_is_clean() {
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            None,
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: None,
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         assert_eq!(
             plan.argv,
@@ -1293,32 +1362,34 @@ mod tests {
 
     #[test]
     fn extra_auto_flag_is_rejected() {
-        let err = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &["--auto".into()],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            None,
-            None,
-        )
+        let err = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &["--auto".into()],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: None,
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap_err();
         assert!(matches!(err, HarnessError::LaunchRejected(_)));
     }
 
     #[test]
     fn extra_bypass_flag_is_rejected() {
-        let err = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &["--dangerously-skip-permissions".into()],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            None,
-            None,
-        )
+        let err = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &["--dangerously-skip-permissions".into()],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: None,
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap_err();
         assert!(matches!(err, HarnessError::LaunchRejected(_)));
     }
@@ -1422,16 +1493,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/browser-cap.json"),
             std::path::PathBuf::from("/usr/local/bin/tidebreak"),
         );
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            Some(&spec),
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: Some(&spec),
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1448,16 +1520,17 @@ mod tests {
 
     #[test]
     fn browser_absent_does_not_add_opencode_config() {
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            None,
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: None,
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         assert!(
             !plan
@@ -1529,16 +1602,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/native-cap.json"),
             std::path::PathBuf::from("/usr/local/bin/tidebreak"),
         );
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            None,
-            Some(&native),
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: None,
+            native: Some(&native),
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1568,16 +1642,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/native-cap.json"),
             std::path::PathBuf::from("/usr/local/bin/tidebreak"),
         );
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            Some(&browser),
-            Some(&native),
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: Some(&browser),
+            native: Some(&native),
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1596,16 +1671,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/browser-cap.json"),
             std::path::PathBuf::from("/Applications/Tidebreak.app/Contents/bin/tidebreak"),
         );
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            Some(&spec),
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: Some(&spec),
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1627,16 +1703,17 @@ mod tests {
             capfile.clone(),
             std::path::PathBuf::from("/usr/local/bin/tidebreak"),
         );
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            Some(&spec),
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: Some(&spec),
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1711,16 +1788,17 @@ mod tests {
             "mcp": { "other-server": { "type": "local", "command": ["foo"] } }
         })
         .to_string();
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[("OPENCODE_CONFIG_CONTENT".to_owned(), existing.clone())],
-            4096,
-            None,
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[("OPENCODE_CONFIG_CONTENT".to_owned(), existing.clone())],
+            port: 4096,
+            browser: None,
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1767,16 +1845,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/browser-cap.json"),
             std::path::PathBuf::from("/usr/local/bin/tidebreak"),
         );
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &snapshot,
-            &[],
-            4096,
-            Some(&spec),
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &snapshot,
+            extra_env: &[],
+            port: 4096,
+            browser: Some(&spec),
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1813,16 +1892,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/browser-cap.json"),
             std::path::PathBuf::from("/usr/local/bin/tidebreak"),
         );
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &snapshot,
-            &extra_env,
-            4096,
-            Some(&spec),
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &snapshot,
+            extra_env: &extra_env,
+            port: 4096,
+            browser: Some(&spec),
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1853,16 +1933,17 @@ mod tests {
             std::ffi::OsString::from(OPENCODE_CONFIG_CONTENT),
             std::ffi::OsString::from(existing),
         )];
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &snapshot,
-            &[],
-            4096,
-            None,
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &snapshot,
+            extra_env: &[],
+            port: 4096,
+            browser: None,
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         assert!(
             !plan
@@ -1883,16 +1964,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/browser-cap.json"),
             std::path::PathBuf::from("/usr/local/bin/tidebreak"),
         );
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &snapshot,
-            &[],
-            4096,
-            Some(&spec),
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &snapshot,
+            extra_env: &[],
+            port: 4096,
+            browser: Some(&spec),
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         let config_str = plan
             .env
@@ -1927,16 +2009,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/browser-cap.json"),
             std::path::PathBuf::from("/usr/local/bin/tidebreak"),
         );
-        let err = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &snapshot,
-            &[],
-            4096,
-            Some(&spec),
-            None,
-        )
+        let err = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &snapshot,
+            extra_env: &[],
+            port: 4096,
+            browser: Some(&spec),
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap_err();
         let message = err.to_string();
         assert!(
@@ -1952,16 +2035,17 @@ mod tests {
         })
         .to_string();
         let entry = ("opencode_config_content".to_owned(), overlay);
-        let plan = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            std::slice::from_ref(&entry),
-            4096,
-            None,
-            None,
-        )
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: std::slice::from_ref(&entry),
+            port: 4096,
+            browser: None,
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap();
         let preserved = plan
             .env
@@ -1985,16 +2069,17 @@ mod tests {
             std::path::PathBuf::from("/tmp/browser-cap.json"),
             std::path::PathBuf::from(bridge),
         );
-        let err = compose_serve_plan(
-            std::path::Path::new("/usr/bin/opencode"),
-            &[],
-            std::path::Path::new("/workspace"),
-            &[],
-            &[],
-            4096,
-            Some(&spec),
-            None,
-        )
+        let err = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: Some(&spec),
+            native: None,
+            relay_key_env: None,
+        })
         .unwrap_err();
         let message = err.to_string();
         assert!(

--- a/crates/tidebreak-harness/src/wiring.rs
+++ b/crates/tidebreak-harness/src/wiring.rs
@@ -43,8 +43,8 @@ pub struct InferenceWiring<'a> {
 /// those providers rides the caller's grant. Grok takes a custom models
 /// endpoint plus the relay key itself; its CLI reads credentials only from
 /// an auth file, so the grok adapter materializes the key as a
-/// session-scoped `GROK_AUTH_PATH` file and strips the variable from the
-/// child's environment.
+/// session-scoped `GROK_AUTH_PATH` file. The wired key variable also stays
+/// available to shell tools that borrow credentials through the host.
 #[must_use]
 pub fn spawn_wiring(
     kind: HarnessKind,


### PR DESCRIPTION
Hosted Grok sessions can run inference but cannot push branches or open PRs. The adapter removes `TIDEBREAK_LLM_KEY` after writing its inference auth file, while the generated Git credential helper and private `gh` wrapper need that variable to authenticate to Tidebreak. Git therefore receives a 401. Opencode also drops the reserved variable.

Preserve exactly the relay variable named by the host in both adapters, matching Claude and Codex. Keep Grok's inference auth file. Continue filtering other reserved variables and case variants. Opencode now takes named launch inputs to keep relay, browser, and native channel wiring explicit.

Regression tests launch a real shell with the composed child environment and verify that it receives the key. They also check that reserved lookalikes and browser overrides stay excluded. No API, database, or configuration migration is required. This extends the session key to the two adapters' shell children so the existing scoped forge relay works. It does not change relay authorization or persist forge tokens.

Validation:
- `cargo fmt --all` and `git diff --check`: pass.
- `cargo check --locked -p tidebreak-harness`: pass.
- `cargo test --locked -p tidebreak-harness relay_wiring`: 2 pass.
- After rebasing onto `main`, Grok and Opencode suites, serial: 73 and 59 pass.
- `cargo clippy --locked -p tidebreak-harness --all-targets --no-deps`: pass; existing core warnings remain.
- All 19 applicable CI checks pass on `16e4a8d452b84e4f35fabc2e46833e3192f886d9`, including all three server test partitions, desktop tests, and Windows native tests. The automatic review approves this commit with no findings.

The separate loss of a live Model Gateway login after a hosted server restart is outside this fix. No deployment is included.