### PR TITLE
improve(ui): align journal tool rows to the reading column

### DIFF
--- a/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/MessageList.dom.test.tsx
@@ -742,7 +742,11 @@ describe("command output", () => {
     list({ ...ran, stdout: "two tests passed\n" });
 
     await user.click(screen.getByRole("button", { name: /cargo build/ }));
-    expect(screen.getByText(/two tests passed/)).toBeInTheDocument();
+    // The quiet fact may also sit under the title; the output pane is the
+    // expanded body the reader opened for.
+    expect(screen.getByLabelText("Output")).toHaveTextContent(
+      "two tests passed",
+    );
 
     await user.click(screen.getByRole("tab", { name: "command" }));
     expect(

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.dom.test.tsx
@@ -80,6 +80,8 @@ describe("ToolCommandCard expansion", () => {
 
     expect(screen.queryByText("Local")).toBeNull();
     expect(screen.queryByText("Done")).toBeNull();
+    // Quiet success still surfaces a one-line stdout fact on the row.
+    expect(screen.getByText("rendered")).toBeTruthy();
 
     await user.click(screen.getByRole("button", { name: /python3 render.py/ }));
 
@@ -88,7 +90,7 @@ describe("ToolCommandCard expansion", () => {
     expect(screen.getByLabelText("Output")).toHaveTextContent("rendered");
   });
 
-  it("keeps a failed command folded until the reader opens it", async () => {
+  it("opens a failed command with its error excerpt and exact exit on the badge", async () => {
     const user = userEvent.setup();
     const { rerender } = render(
       <ToolCommandCard
@@ -108,16 +110,17 @@ describe("ToolCommandCard expansion", () => {
     );
 
     const row = screen.getByRole("button", { name: /python3 render.py/ });
-    expect(row.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.queryByText("Exit 101")).toBeNull();
-    expect(screen.queryByText(/module not found/)).toBeNull();
-
-    await user.click(row);
-
     expect(row.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("Exit 101")).toBeTruthy();
+    expect(screen.getAllByText(/module not found/).length).toBeGreaterThan(0);
     expect(screen.getByLabelText("Output")).toHaveTextContent(
       "module not found",
+    );
+
+    // Exact command detail stays on the command tab.
+    await user.click(screen.getByRole("tab", { name: "command" }));
+    expect(screen.getByLabelText("Command")).toHaveTextContent(
+      "python3 render.py",
     );
 
     rerender(
@@ -136,6 +139,6 @@ describe("ToolCommandCard expansion", () => {
         }}
       />,
     );
-    expect(screen.getByText("Timed out")).toBeTruthy();
+    expect(screen.getAllByText("Timed out").length).toBeGreaterThan(0);
   });
 });

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.test.tsx
@@ -106,7 +106,7 @@ describe("toolCallPresentation", () => {
 });
 
 describe("ToolCommandCard", () => {
-  it("titles itself with the command instead of a generic phrase", () => {
+  it("titles itself with a grounded command target instead of a generic phrase", () => {
     const markup = renderToStaticMarkup(
       <ToolCommandCard
         name="exec"
@@ -116,7 +116,9 @@ describe("ToolCommandCard", () => {
       />,
     );
 
-    expect(visibleText(markup)).toContain("cargo test --workspace");
+    // Grounded title: command head + meaningful arg, not the full argv and not
+    // the generic allowlisted phrase.
+    expect(visibleText(markup)).toContain("cargo test");
     expect(visibleText(markup)).not.toContain("Ran a command");
     // The allowlisted phrase still names the card for assistive technology.
     expect(markup).toContain('aria-label="Run a command: Command complete"');
@@ -155,7 +157,7 @@ describe("ToolCommandCard", () => {
     );
   });
 
-  it("opens while the command is running and closes once it has settled", () => {
+  it("opens while running or failed, and stays quiet once a success settles", () => {
     const running = renderToStaticMarkup(
       <ToolCommandCard
         name="exec"
@@ -178,13 +180,21 @@ describe("ToolCommandCard", () => {
         name="exec"
         status="failed"
         preview={preview}
-        result={null}
+        result={{
+          tool: "exec",
+          exitCode: 1,
+          timedOut: false,
+          outputTruncated: false,
+          stdout: "",
+          stderr: "module not found\n",
+        }}
       />,
     );
 
     expect(running).toContain('aria-expanded="true"');
     expect(done).toContain('aria-expanded="false"');
-    expect(failed).toContain('aria-expanded="false"');
+    expect(failed).toContain('aria-expanded="true"');
+    expect(visibleText(failed)).toContain("module not found");
   });
 
   it("keeps settled metadata in the expanded detail", () => {
@@ -222,6 +232,8 @@ describe("ToolCommandCard", () => {
     expect(completed).not.toContain("Done");
     expect(waiting).not.toContain("Waiting for approval");
     expect(cancelled).not.toContain("Not run");
+
+    // A failed command starts open so the exit badge is already readable.
     expect(
       visibleText(
         renderToStaticMarkup(
@@ -229,11 +241,18 @@ describe("ToolCommandCard", () => {
             name="exec"
             status="failed"
             preview={preview}
-            result={null}
+            result={{
+              tool: "exec",
+              exitCode: 1,
+              timedOut: false,
+              outputTruncated: false,
+              stdout: "",
+              stderr: "boom\n",
+            }}
           />,
         ),
       ),
-    ).not.toContain("Failed");
+    ).toContain("Exit 1");
 
     // A live command starts open, so its status is already part of the
     // detail the reader needs now.

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
@@ -13,9 +13,17 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { ToolStatusIcon, type ToolTone } from "./ToolStatusIcon";
 import { ToolCardShell } from "./ToolCardShell";
-import { ToolOutputPreview } from "./ToolOutputPreview";
-import { toolPreviewHeadline, toolPreviewPresentation } from "./ToolPreview";
+import {
+  RUNNING_COLLAPSED_LINES,
+  ToolOutputPreview,
+} from "./ToolOutputPreview";
+import {
+  toolPreviewHeadline,
+  toolPreviewPresentation,
+  toolResultFact,
+} from "./ToolPreview";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { MiddleTruncate } from "./code/MiddleTruncate";
 
 /**
  * What a first-run sandbox image pull is doing, said where the person is
@@ -304,14 +312,16 @@ const FALLBACK_TOOL: ToolPresentation = {
 /**
  * The card for a command the agent ran.
  *
- * The title is the agent's own sentence about what it is doing, because "Ran a
- * command" is the same sentence whether it listed a directory or rebuilt the
- * workspace, and an argument vector is not a sentence at all to a reader who
- * does not read shell. A call that narrated nothing falls back to the command
- * itself, in monospace. Either way the literal command and its output are in
- * the body, one click away. It opens while the command is still running;
- * a settled card, including a failed one, collapses back to one line once
- * the badge carries the outcome.
+ * The collapsed title is a grounded action plus target: the model's display
+ * summary when it wrote one, otherwise a short command head that middle-
+ * truncates instead of widening the journal. A short factual result (exit
+ * line, first error) sits under the title when it helps; successful rows stay
+ * quiet. The literal command, cwd, and full streams stay one click away and
+ * are unchanged on approval cards.
+ *
+ * Running rows open with a height-bounded tail. Failed rows open so the error
+ * is one click from the badge and already excerpted on the row. Successful
+ * settled rows stay collapsed.
  *
  * Only tools that project a preview get a card. Everything else lives in the
  * activity rail, where a line of text is the whole story the renderer has.
@@ -326,6 +336,11 @@ export function ToolCommandCard({
   const command = toolPreviewPresentation(preview, result);
   const headline = toolPreviewHeadline(preview);
   const running = presentation.tone === "running";
+  const failed =
+    presentation.tone === "failed" ||
+    Boolean(result?.timedOut) ||
+    (typeof result?.exitCode === "number" && result.exitCode !== 0);
+  const fact = toolResultFact(result, { failed });
   // Live, unjournaled state: only a command that is still running can be the
   // one waiting on the image, and a settled card must never claim it is.
   const preparing =
@@ -334,14 +349,24 @@ export function ToolCommandCard({
   // A command that finished silently has nothing to tab between, and a
   // "Command / Output → no output" pair reads as confusing noise.
   const tabbed = running || output !== null;
+  // A failed row keeps its fact on the subtitle even while expanded, so the
+  // eye never loses the reason it opened. Successful facts only appear once.
+  const subtitle =
+    fact && (failed || presentation.tone === "completed") ? fact : null;
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-1.5">
       <ToolCardShell
         label={`${presentation.label}: ${presentation.statusLabel}`}
         icon={<Terminal className="size-3.5 shrink-0" aria-hidden="true" />}
-        title={headline.text}
-        titleClassName={headline.literal ? "font-mono" : undefined}
+        title={
+          headline.literal ? (
+            <MiddleTruncate text={headline.text} className="font-mono" />
+          ) : (
+            headline.text
+          )
+        }
+        subtitle={subtitle}
         badge={
           <>
             {result?.backend && (
@@ -363,11 +388,11 @@ export function ToolCommandCard({
         trailing={
           <ToolStatusIcon tone={presentation.tone} className="size-3.5" />
         }
-        defaultExpanded={running}
+        defaultExpanded={running || failed}
       >
         {tabbed ? (
           <Tabs defaultValue="output">
-            <TabsList className="flex w-full items-center justify-start gap-1 px-0">
+            <TabsList className="flex w-full min-w-0 items-center justify-start gap-1 px-0">
               <TabsTrigger value="command" className="py-1 text-xs capitalize">
                 command
               </TabsTrigger>
@@ -375,8 +400,8 @@ export function ToolCommandCard({
                 output
               </TabsTrigger>
             </TabsList>
-            <div className="pt-1">
-              <TabsContent value="command" className="mt-0">
+            <div className="min-w-0 pt-1">
+              <TabsContent value="command" className="mt-0 min-w-0">
                 <ToolOutputPreview
                   text={command.detail}
                   collapsedLines={12}
@@ -384,7 +409,7 @@ export function ToolCommandCard({
                   bare
                 />
               </TabsContent>
-              <TabsContent value="output" className="mt-0">
+              <TabsContent value="output" className="mt-0 min-w-0">
                 {output === null ? (
                   <p className="text-muted-foreground flex items-center gap-1.5 py-1 text-xs">
                     <Loader
@@ -397,7 +422,12 @@ export function ToolCommandCard({
                   </p>
                 ) : null}
                 {output !== null && (
-                  <ToolOutputPreview text={output} collapsedLines={12} bare />
+                  <ToolOutputPreview
+                    text={output}
+                    collapsedLines={running ? RUNNING_COLLAPSED_LINES : 12}
+                    followTail={running || failed}
+                    bare
+                  />
                 )}
               </TabsContent>
             </div>

--- a/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCallCard.tsx
@@ -336,7 +336,7 @@ export function ToolCommandCard({
   const tabbed = running || output !== null;
 
   return (
-    <div className="flex max-w-prose flex-col gap-1.5">
+    <div className="flex w-full min-w-0 flex-col gap-1.5">
       <ToolCardShell
         label={`${presentation.label}: ${presentation.statusLabel}`}
         icon={<Terminal className="size-3.5 shrink-0" aria-hidden="true" />}

--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -15,6 +15,11 @@ type ToolCardShellProps = {
   badge?: ReactNode;
   /** Compact metadata that belongs on the collapsed row. */
   trailing?: ReactNode;
+  /**
+   * Quiet secondary line under the title (error excerpt, short result fact).
+   * Stays visible whether or not the body is expanded.
+   */
+  subtitle?: ReactNode;
   /** Open on mount, which is worth doing only while work is still happening. */
   defaultExpanded?: boolean;
   /** Controlled expansion for hosts that already own reveal state. */
@@ -38,6 +43,11 @@ type ToolCardShellProps = {
  * panels. Provider and outcome metadata live with the expanded detail unless a
  * host supplies genuinely glanceable trailing metadata, such as code mode's
  * duration and status glyph.
+ *
+ * Width is owned by the parent reading column (`.messages-column`). This shell
+ * is always `w-full min-w-0` so a long command cannot stretch the transcript;
+ * inside a journal the icon sits in the column's leading gutter so the title
+ * lines up with prose.
  */
 export function ToolCardShell({
   icon,
@@ -45,6 +55,7 @@ export function ToolCardShell({
   titleClassName,
   badge,
   trailing,
+  subtitle,
   defaultExpanded = false,
   expanded: controlledExpanded,
   onExpandedChange,
@@ -66,7 +77,10 @@ export function ToolCardShell({
 
   return (
     <section
-      className={cn("tool-card-shell w-full min-w-0 [overflow-anchor:none]", className)}
+      className={cn(
+        "tool-card-shell w-full min-w-0 [overflow-anchor:none]",
+        className,
+      )}
       aria-label={label}
       role={announce ? "status" : undefined}
       aria-live={announce ? "polite" : undefined}
@@ -75,7 +89,7 @@ export function ToolCardShell({
       <button
         type="button"
         className={cn(
-          "relative flex w-full min-w-0 cursor-pointer items-start gap-2 rounded-md py-1 text-left text-sm hover:bg-muted/50",
+          "relative flex w-full min-w-0 cursor-pointer items-start gap-2 rounded-md py-1 text-left text-md hover:bg-muted/50",
           FOCUS_RING_TIGHT,
           HOVER_TINT,
         )}
@@ -83,22 +97,32 @@ export function ToolCardShell({
         aria-controls={bodyId}
         onClick={() => setExpanded(!expanded)}
       >
-        <span className="tool-card-icon text-muted-foreground mt-0.5 shrink-0 [&>svg]:size-3.5" aria-hidden="true">
+        <span
+          className="tool-card-icon text-muted-foreground mt-0.5 shrink-0 [&>svg]:size-3.5"
+          aria-hidden="true"
+        >
           {icon}
         </span>
-        <span className={cn("min-w-0 flex-1", titleClassName)}>
-          {typeof title === "string" ? (
-            <span className="block truncate" title={title}>
-              {title}
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className={cn("min-w-0", titleClassName)}>
+            {typeof title === "string" ? (
+              <span className="block truncate" title={title}>
+                {title}
+              </span>
+            ) : (
+              // Rendered directly so a `titleClassName` flex layout reaches the
+              // host's own title children; an inline wrapper here forces a
+              // block-level child (e.g. MiddleTruncate) onto its own line.
+              title
+            )}
+          </span>
+          {subtitle ? (
+            <span className="text-muted-foreground block min-w-0 truncate font-mono text-xs">
+              {subtitle}
             </span>
-          ) : (
-            // Rendered directly so a `titleClassName` flex layout reaches the
-            // host's own title children; an inline wrapper here forces a
-            // block-level child (e.g. MiddleTruncate) onto its own line.
-            title
-          )}
+          ) : null}
         </span>
-        <span className="text-muted-foreground ml-auto flex h-4 shrink-0 items-center gap-1.5 text-xs tabular-nums">
+        <span className="text-muted-foreground ml-auto flex h-5 shrink-0 items-center gap-1.5 text-xs tabular-nums">
           {trailing}
           <ChevronDown
             className={cn(
@@ -110,7 +134,10 @@ export function ToolCardShell({
         </span>
       </button>
       {expanded && (
-        <div id={bodyId} className={cn("mt-1.5 min-w-0", bodyClassName)}>
+        <div
+          id={bodyId}
+          className={cn("mt-1.5 min-w-0 overflow-hidden", bodyClassName)}
+        >
           {badge && (
             <div className="mb-1.5 flex flex-wrap items-center gap-1">
               {badge}

--- a/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolCardShell.tsx
@@ -66,7 +66,7 @@ export function ToolCardShell({
 
   return (
     <section
-      className={cn("max-w-prose [overflow-anchor:none]", className)}
+      className={cn("tool-card-shell w-full min-w-0 [overflow-anchor:none]", className)}
       aria-label={label}
       role={announce ? "status" : undefined}
       aria-live={announce ? "polite" : undefined}
@@ -75,7 +75,7 @@ export function ToolCardShell({
       <button
         type="button"
         className={cn(
-          "-mx-1.5 flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-0.5 text-left text-md hover:bg-muted/50",
+          "relative flex w-full min-w-0 cursor-pointer items-start gap-2 rounded-md py-1 text-left text-sm hover:bg-muted/50",
           FOCUS_RING_TIGHT,
           HOVER_TINT,
         )}
@@ -83,7 +83,7 @@ export function ToolCardShell({
         aria-controls={bodyId}
         onClick={() => setExpanded(!expanded)}
       >
-        <span className="text-muted-foreground shrink-0 [&>svg]:size-3.5">
+        <span className="tool-card-icon text-muted-foreground mt-0.5 shrink-0 [&>svg]:size-3.5" aria-hidden="true">
           {icon}
         </span>
         <span className={cn("min-w-0 flex-1", titleClassName)}>
@@ -98,7 +98,7 @@ export function ToolCardShell({
             title
           )}
         </span>
-        <span className="text-muted-foreground ml-auto flex shrink-0 items-center gap-1.5 text-xs tabular-nums">
+        <span className="text-muted-foreground ml-auto flex h-4 shrink-0 items-center gap-1.5 text-xs tabular-nums">
           {trailing}
           <ChevronDown
             className={cn(
@@ -110,7 +110,7 @@ export function ToolCardShell({
         </span>
       </button>
       {expanded && (
-        <div id={bodyId} className={cn("mt-1.5", bodyClassName)}>
+        <div id={bodyId} className={cn("mt-1.5 min-w-0", bodyClassName)}>
           {badge && (
             <div className="mb-1.5 flex flex-wrap items-center gap-1">
               {badge}

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.dom.test.tsx
@@ -35,4 +35,25 @@ describe("ToolOutputPreview", () => {
     expect(screen.queryByRole("button", { name: /more line/ })).toBeNull();
     expect(screen.getByRole("button", { name: "Copy output" })).toBeTruthy();
   });
+
+  it("follows the tail when asked, and still offers the full text", async () => {
+    render(
+      <ToolOutputPreview
+        text={twelveLines}
+        collapsedLines={4}
+        followTail
+        bare
+      />,
+    );
+
+    const body = screen.getByLabelText("Output");
+    expect(body.textContent).toContain("line 12");
+    expect(body.textContent).not.toMatch(/^line 1$/m);
+    expect(body.textContent).not.toContain("line 8");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show all 12 lines" }),
+    );
+    expect(screen.getByLabelText("Output").textContent).toMatch(/^line 1$/m);
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.dom.test.tsx
@@ -52,7 +52,7 @@ describe("ToolOutputPreview", () => {
     expect(body.textContent).not.toContain("line 8");
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Show all 12 lines" }),
+      screen.getByRole("button", { name: "· · · 8 more lines" }),
     );
     expect(screen.getByLabelText("Output").textContent).toMatch(/^line 1$/m);
   });

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -10,6 +10,8 @@ type ToolOutputPreviewProps = {
   text: string;
   /** Lines shown before the expander takes over. */
   collapsedLines?: number;
+  startLine?: number;
+  followTail?: boolean;
   /** What this block is, for the copy control and assistive technology. */
   label?: string;
   /**
@@ -37,6 +39,8 @@ type ToolOutputPreviewProps = {
 export function ToolOutputPreview({
   text,
   collapsedLines = DEFAULT_COLLAPSED_LINES,
+  startLine = 0,
+  followTail = false,
   label = "Output",
   bare = false,
   onToggle,
@@ -46,16 +50,19 @@ export function ToolOutputPreview({
   // A trailing newline is punctuation, not a line worth offering to expand.
   const lines = useMemo(() => text.replace(/\n+$/, "").split("\n"), [text]);
   const hiddenCount = Math.max(0, lines.length - collapsedLines);
+  const firstLine = followTail
+    ? Math.max(0, lines.length - collapsedLines)
+    : Math.max(0, Math.min(startLine, lines.length - collapsedLines));
   const body =
     hiddenCount > 0 && !expanded
-      ? lines.slice(0, collapsedLines).join("\n")
+      ? lines.slice(firstLine, firstLine + collapsedLines).join("\n")
       : lines.join("\n");
 
   if (text.trim().length === 0) return null;
 
   return (
-    <div className="flex flex-col items-start gap-1">
-      <div className="group relative w-full">
+    <div className="flex w-full min-w-0 flex-col items-start gap-1">
+      <div className="group relative w-full min-w-0">
         <pre
           id={bodyId}
           // A bare `aria-label` on a `pre` names nothing: the element is
@@ -65,7 +72,7 @@ export function ToolOutputPreview({
           aria-label={label}
           className={
             bare
-              ? "text-muted-foreground overflow-x-auto pr-7 font-mono text-md break-words whitespace-pre-wrap [overflow-anchor:none]"
+              ? `text-muted-foreground max-h-80 overflow-auto pr-7 font-mono text-sm whitespace-pre [overflow-anchor:none] ${followTail && !expanded ? "h-[6em]" : ""}`
               : "bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap"
           }
         >
@@ -97,7 +104,7 @@ export function ToolOutputPreview({
           {expanded
             ? "Show less"
             : bare
-              ? `· · · ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`
+              ? `Show all ${lines.length} lines`
               : `Show ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`}
         </button>
       )}

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -28,7 +28,7 @@ type ToolOutputPreviewProps = {
   label?: string;
   /**
    * Plain indented output: no surface, no padding box. The expander reads
-   * "Show all N lines" instead of "Show N more lines".
+   * "· · · N more lines" instead of "Show N more lines".
    */
   bare?: boolean;
   /**
@@ -123,7 +123,7 @@ export function ToolOutputPreview({
           {expanded
             ? "Show less"
             : bare
-              ? `Show all ${lines.length} lines`
+              ? `· · · ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`
               : `Show ${hiddenCount} more line${hiddenCount === 1 ? "" : "s"}`}
         </button>
       )}

--- a/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolOutputPreview.tsx
@@ -1,22 +1,34 @@
 import { useId, useMemo, useState } from "react";
 
 import { ClipboardCopyButton } from "./ClipboardCopyButton";
+import { cn } from "@/lib/utils";
 
 /** How much of a tool's output is worth showing before the reader asks. */
 export const DEFAULT_COLLAPSED_LINES = 8;
+
+/** Bounded running tail: enough to see progress without growing the row. */
+export const RUNNING_COLLAPSED_LINES = 6;
 
 type ToolOutputPreviewProps = {
   /** What the tool printed, verbatim. */
   text: string;
   /** Lines shown before the expander takes over. */
   collapsedLines?: number;
-  startLine?: number;
+  /**
+   * Prefer the end of the stream (live command tail). Ignored once the reader
+   * expands the block — expansion always shows the full text.
+   */
   followTail?: boolean;
+  /**
+   * When not following the tail, start the collapsed window at this line.
+   * Clamped so a short block still shows up to `collapsedLines` lines.
+   */
+  startLine?: number;
   /** What this block is, for the copy control and assistive technology. */
   label?: string;
   /**
    * Plain indented output: no surface, no padding box. The expander reads
-   * "· · · N more lines" instead of "Show N more lines".
+   * "Show all N lines" instead of "Show N more lines".
    */
   bare?: boolean;
   /**
@@ -27,7 +39,7 @@ type ToolOutputPreviewProps = {
 };
 
 /**
- * A tool's output, clamped to the first few lines with the rest one click away.
+ * A tool's output, clamped to a few lines with the rest one click away.
  *
  * Output is the part of a transcript most likely to be enormous and least
  * likely to be read in full, so the default is a glance: enough lines to see
@@ -35,12 +47,15 @@ type ToolOutputPreviewProps = {
  * clipboard whether or not it is expanded. Clamping by line rather than by
  * height keeps the count in the expander truthful — "show 40 more lines" that
  * turns out to be four is worse than no count at all.
+ *
+ * The block is width-bounded (`min-w-0`, horizontal scroll on long lines) so a
+ * single unwrapped command cannot stretch the parent reading column.
  */
 export function ToolOutputPreview({
   text,
   collapsedLines = DEFAULT_COLLAPSED_LINES,
-  startLine = 0,
   followTail = false,
+  startLine = 0,
   label = "Output",
   bare = false,
   onToggle,
@@ -50,9 +65,12 @@ export function ToolOutputPreview({
   // A trailing newline is punctuation, not a line worth offering to expand.
   const lines = useMemo(() => text.replace(/\n+$/, "").split("\n"), [text]);
   const hiddenCount = Math.max(0, lines.length - collapsedLines);
-  const firstLine = followTail
-    ? Math.max(0, lines.length - collapsedLines)
-    : Math.max(0, Math.min(startLine, lines.length - collapsedLines));
+  const firstLine = collapsedWindowStart(
+    lines.length,
+    collapsedLines,
+    followTail,
+    startLine,
+  );
   const body =
     hiddenCount > 0 && !expanded
       ? lines.slice(firstLine, firstLine + collapsedLines).join("\n")
@@ -70,11 +88,12 @@ export function ToolOutputPreview({
           // control beside it uses the same word.
           role="group"
           aria-label={label}
-          className={
+          className={cn(
             bare
-              ? `text-muted-foreground max-h-80 overflow-auto pr-7 font-mono text-sm whitespace-pre [overflow-anchor:none] ${followTail && !expanded ? "h-[6em]" : ""}`
-              : "bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap"
-          }
+              ? "text-muted-foreground max-h-80 overflow-auto pr-7 font-mono text-sm whitespace-pre [overflow-anchor:none]"
+              : "bg-muted text-muted-foreground overflow-x-auto rounded-md p-2 pr-9 font-mono text-xs break-words whitespace-pre-wrap",
+            bare && followTail && !expanded && "h-[6em]",
+          )}
         >
           {body}
         </pre>
@@ -110,4 +129,16 @@ export function ToolOutputPreview({
       )}
     </div>
   );
+}
+
+/** First line index for the collapsed window. Exported for unit tests. */
+export function collapsedWindowStart(
+  lineCount: number,
+  collapsedLines: number,
+  followTail: boolean,
+  startLine: number,
+): number {
+  if (lineCount <= collapsedLines) return 0;
+  if (followTail) return lineCount - collapsedLines;
+  return Math.max(0, Math.min(startLine, lineCount - collapsedLines));
 }

--- a/crates/tidebreak-desktop/ui/src/ToolPreview.test.ts
+++ b/crates/tidebreak-desktop/ui/src/ToolPreview.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ToolActionPreview } from "./api";
-import { toolPreviewHeadline, toolPreviewPresentation } from "./ToolPreview";
+import {
+  toolPreviewHeadline,
+  toolPreviewPresentation,
+  toolResultFact,
+} from "./ToolPreview";
 
 describe("toolPreviewPresentation", () => {
   it("reads a command back as the argument vector it will run", () => {
@@ -81,11 +85,13 @@ describe("how a call narrates itself", () => {
     expect(literal.detail).not.toContain("Clearing");
   });
 
-  it("leads a settled card with the sentence, and falls back to the command", () => {
+  it("leads a settled card with the sentence, and falls back to a grounded target", () => {
     expect(toolPreviewHeadline(narrated)).toEqual({
       text: "Clearing the stale build directory",
       literal: false,
     });
+    // No model sentence: command head plus the path-like argument, not the
+    // full argv — long flags must not become the collapsed title.
     expect(
       toolPreviewHeadline({
         tool: "exec",
@@ -94,7 +100,63 @@ describe("how a call narrates itself", () => {
         cwd: ".",
         files: [],
       }),
-    ).toEqual({ text: "rm -rf /tmp/build", literal: true });
+    ).toEqual({ text: "rm build", literal: true });
+  });
+});
+
+describe("grounded exec headlines and result facts", () => {
+  it("prefers a path-like argument as the meaningful target", () => {
+    expect(
+      toolPreviewHeadline({
+        tool: "exec",
+        command: "python3",
+        args: ["/workspace/very/long/path/to/scripts/render.py", "--verbose"],
+        cwd: ".",
+        files: [],
+      }),
+    ).toEqual({ text: "python3 render.py", literal: true });
+  });
+
+  it("surfaces a short stderr fact for a failed run without inventing copy", () => {
+    expect(
+      toolResultFact(
+        {
+          tool: "exec",
+          exitCode: 1,
+          timedOut: false,
+          outputTruncated: false,
+          stdout: "noise\n",
+          stderr: "Error: Cannot find module 'pptxgenjs'\n    at main\n",
+        },
+        { failed: true },
+      ),
+    ).toBe("Error: Cannot find module 'pptxgenjs'");
+  });
+
+  it("keeps a successful multi-line run quiet", () => {
+    expect(
+      toolResultFact({
+        tool: "exec",
+        exitCode: 0,
+        timedOut: false,
+        outputTruncated: false,
+        stdout: "line one\nline two\n",
+        stderr: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps a single short successful stdout line as a fact", () => {
+    expect(
+      toolResultFact({
+        tool: "exec",
+        exitCode: 0,
+        timedOut: false,
+        outputTruncated: false,
+        stdout: "Checked 12 files in 41ms. No fixes applied.\n",
+        stderr: "",
+      }),
+    ).toBe("Checked 12 files in 41ms. No fixes applied.");
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/ToolPreview.tsx
+++ b/crates/tidebreak-desktop/ui/src/ToolPreview.tsx
@@ -115,6 +115,10 @@ export function toolPreviewPresentation(
  * action is never lost: it is one click away in the card's own body, and it is
  * still the only thing an approval card shows.
  *
+ * When the model left no sentence, the headline is still grounded in the
+ * action: a short verb plus the most meaningful target (path, URL, query, or
+ * command head) so a long argv cannot become the whole transcript width.
+ *
  * `literal` is what tells a caller to set a monospace face: prose in monospace
  * reads as something a shell would run, which it is not.
  */
@@ -126,7 +130,108 @@ export function toolPreviewHeadline(preview: ToolActionPreview): {
   if (typeof summary === "string" && summary.length > 0) {
     return { text: summary, literal: false };
   }
+  if (preview.tool === "exec") {
+    return {
+      text: groundedExecHeadline(preview.command, preview.args),
+      literal: true,
+    };
+  }
   return { text: toolPreviewPresentation(preview).headline, literal: true };
+}
+
+/**
+ * A short factual line drawn from the command's own streams — never a second
+ * model call. Prefer stderr for failures, a single quiet stdout line for a
+ * clean finish, and nothing when the streams are noise.
+ */
+export function toolResultFact(
+  result: ExecResultPreview | null,
+  options: { failed?: boolean } = {},
+): string | null {
+  if (!result) return null;
+  if (result.timedOut) return "Timed out";
+  if (result.exitCode === null) return "Stopped by a signal";
+
+  const failed =
+    options.failed === true ||
+    (typeof result.exitCode === "number" && result.exitCode !== 0);
+
+  if (failed) {
+    const fromStderr = firstMeaningfulLine(result.stderr);
+    if (fromStderr) return clipFact(fromStderr);
+    const fromStdout = firstMeaningfulLine(result.stdout);
+    if (fromStdout) return clipFact(fromStdout);
+    if (typeof result.exitCode === "number") {
+      return `Exit ${result.exitCode}`;
+    }
+    return null;
+  }
+
+  // A successful run stays quiet unless stdout is already one short fact.
+  const line = firstMeaningfulLine(result.stdout);
+  if (!line) return null;
+  if (result.stdout.replace(/\n+$/, "").includes("\n")) return null;
+  if (line.length > FACT_MAX) return null;
+  return line;
+}
+
+/** Cap on a collapsed-row fact so it cannot become a second transcript. */
+const FACT_MAX = 120;
+
+/**
+ * Grounded exec title when the model left no summary: command name plus the
+ * most informative argument (usually a path or script), not the full argv.
+ */
+export function groundedExecHeadline(
+  command: string,
+  args: readonly string[],
+): string {
+  const base = commandBaseName(command);
+  const target = meaningfulExecTarget(args);
+  if (!target) return base;
+  return `${base} ${target}`;
+}
+
+function meaningfulExecTarget(args: readonly string[]): string | null {
+  // Walk from the end: the last path-like token is usually the file or package
+  // under review; flags and short options stay out of the collapsed title.
+  for (let index = args.length - 1; index >= 0; index -= 1) {
+    const arg = args[index];
+    if (!arg || arg.startsWith("-")) continue;
+    if (arg.includes("/") || arg.includes("\\") || /\.\w{1,8}$/.test(arg)) {
+      return commandBaseName(arg);
+    }
+  }
+  for (let index = args.length - 1; index >= 0; index -= 1) {
+    const arg = args[index];
+    if (!arg || arg.startsWith("-")) continue;
+    return arg.length > 48 ? `${arg.slice(0, 45)}…` : arg;
+  }
+  return null;
+}
+
+function commandBaseName(value: string): string {
+  const trimmed = value.replace(/[\\/]+$/, "");
+  const parts = trimmed.split(/[\\/]/);
+  return parts[parts.length - 1] || trimmed || value;
+}
+
+function firstMeaningfulLine(text: string): string | null {
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    // Stream section headers and shell prompts are structure, not a fact.
+    if (line === "$ stdout" || line === "$ stderr") continue;
+    if (line.startsWith("$ ")) continue;
+    if (line.startsWith("# ")) continue;
+    return line;
+  }
+  return null;
+}
+
+function clipFact(line: string): string {
+  if (line.length <= FACT_MAX) return line;
+  return `${line.slice(0, FACT_MAX - 1)}…`;
 }
 
 /**

--- a/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ConversationTranscript.stories.tsx
@@ -230,6 +230,111 @@ const toolHeavyMessages: ChatMessage[] = [
   },
 ];
 
+/**
+ * Prose, a quiet success, a live bounded run, and a failed excerpt in one
+ * column — the mixed journal the tool-row redesign is judged against.
+ */
+const mixedExecMessages: ChatMessage[] = [
+  {
+    id: "mixed-user",
+    role: "user",
+    text: "Run the formatter, start the unit suite, and fix the deck renderer if it fails.",
+    createdAt: "2026-09-09T15:00:00.000Z",
+  },
+  {
+    id: "mixed-assistant-1",
+    role: "assistant",
+    text: "I will keep routine commands quiet in the journal and only open failures so the error is one glance away.",
+    sources: [],
+    createdAt: "2026-09-09T15:00:04.000Z",
+  },
+  {
+    id: "mixed-exec-ok",
+    role: "tool",
+    callId: "mixed-ok",
+    name: "exec",
+    status: "completed",
+    preview: {
+      tool: "exec",
+      command: "pnpm",
+      args: ["exec", "biome", "check", "src/ToolCallCard.tsx"],
+      cwd: "crates/tidebreak-desktop/ui",
+      files: [],
+      summary: "Checking the tool card module",
+    },
+    result: {
+      tool: "exec",
+      exitCode: 0,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: "Checked 1 file in 18ms. No fixes applied.\n",
+      stderr: "",
+      backend: "local",
+    },
+  },
+  {
+    id: "mixed-exec-run",
+    role: "tool",
+    callId: "mixed-run",
+    name: "exec",
+    status: "running",
+    preview: {
+      tool: "exec",
+      command: "pnpm",
+      args: ["test", "src/ToolPreview.test.ts"],
+      cwd: "crates/tidebreak-desktop/ui",
+      files: [],
+      summary: "Running the preview unit tests",
+    },
+    result: {
+      tool: "exec",
+      exitCode: null,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: Array.from(
+        { length: 16 },
+        (_, index) => ` ✓ grounded headline case ${index + 1}`,
+      ).join("\n"),
+      stderr: "",
+      backend: "local",
+    },
+  },
+  {
+    id: "mixed-exec-fail",
+    role: "tool",
+    callId: "mixed-fail",
+    name: "exec",
+    status: "failed",
+    preview: {
+      tool: "exec",
+      command: "python3",
+      args: [
+        "/workspace/checkout/scripts/very/long/path/render_deck.py",
+        "reports/q3.pptx",
+      ],
+      cwd: "checkout",
+      files: ["reports/q3.pptx"],
+    },
+    result: {
+      tool: "exec",
+      exitCode: 1,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: "",
+      stderr:
+        "Error: Cannot find module 'pptxgenjs'\n    at Object.<anonymous> (scripts/render_deck.py:12)\n",
+      backend: "local",
+    },
+  },
+  {
+    id: "mixed-assistant-2",
+    role: "assistant",
+    text: "The deck renderer is missing `pptxgenjs`. I can install it next, or switch the script to the workspace package that already provides it.",
+    sources: [],
+    createdAt: "2026-09-09T15:00:40.000Z",
+  },
+];
+
 const failureMessages: ChatMessage[] = [
   {
     id: "failure-user",
@@ -417,6 +522,20 @@ export const CompactingConversation: Story = {
 };
 
 export const ToolHeavySession: Story = {};
+
+/**
+ * Mixed journal: prose, quiet success, bounded running output, and a failed
+ * command with an error excerpt — all in the shared reading column.
+ */
+export const MixedToolRows: Story = {
+  args: { messages: mixedExecMessages, busy: true, pinLastTurn: true },
+};
+
+/** Same mix at a narrow pane width so truncation cannot widen the column. */
+export const MixedToolRowsNarrow: Story = {
+  args: { messages: mixedExecMessages, busy: true, pinLastTurn: true },
+  globals: { viewport: { value: "compact", isRotated: false } },
+};
 
 export const RetryableFailure: Story = {
   args: { messages: failureMessages },

--- a/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Patterns.stories.tsx
@@ -138,12 +138,14 @@ $ pnpm test -- TaskPlanCard.dom.test.tsx`}
           </div>
           <div>
             <p className="text-xs font-medium text-muted-foreground">
-              Failed (collapsed)
+              Failed (open with error excerpt)
             </p>
             <ToolCardShell
               icon={<FileText className="size-3.5" aria-hidden="true" />}
               title="Checking the PowerPoint library"
+              subtitle="Error: Cannot find module 'pptxgenjs'"
               label="Run a command: Tool could not complete"
+              defaultExpanded
               badge={
                 <>
                   <Badge variant="outline">Local</Badge>
@@ -156,8 +158,8 @@ $ pnpm test -- TaskPlanCard.dom.test.tsx`}
                 <CircleAlert className="text-muted-foreground size-3.5" />
               }
             >
-              <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
-                <pre className="whitespace-pre-wrap">
+              <div className="text-muted-foreground font-mono text-xs">
+                <pre className="overflow-x-auto whitespace-pre">
                   {`Error: Cannot find module 'pptxgenjs'`}
                 </pre>
               </div>

--- a/crates/tidebreak-desktop/ui/src/stories/ToolCommandCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ToolCommandCard.stories.tsx
@@ -1,0 +1,191 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ToolCommandCard } from "@/ToolCallCard";
+
+/**
+ * Chat journal command rows: grounded title, quiet success, bounded running
+ * tail, and a failed row that surfaces the error excerpt while keeping the
+ * exact command on expansion. Framed in `.messages-column` so the icon gutter
+ * and reading width match the live transcript.
+ */
+const meta = {
+  title: "Conversation/Tool command",
+  component: ToolCommandCard,
+  args: {
+    name: "exec",
+    status: "completed" as const,
+    preview: {
+      tool: "exec" as const,
+      command: "pnpm",
+      args: ["exec", "biome", "check", "src/stories"],
+      cwd: "crates/tidebreak-desktop/ui",
+      files: [],
+    },
+    result: {
+      tool: "exec" as const,
+      exitCode: 0,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: "Checked 12 files in 41ms. No fixes applied.\n",
+      stderr: "",
+      backend: "local" as const,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="messages bg-background min-h-[28rem]">
+        <div className="messages-column">
+          <p className="text-md text-foreground leading-relaxed">
+            Assistant prose shares this reading column. Tool titles should start
+            on the same left edge; long commands must not widen it.
+          </p>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof ToolCommandCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Successful settled row: one quiet line plus an optional short fact. */
+export const Succeeded: Story = {};
+
+/**
+ * Model narration leads when present; the literal argv stays on the command
+ * tab and is what approvals still show.
+ */
+export const Narrated: Story = {
+  args: {
+    preview: {
+      tool: "exec",
+      command: "cargo",
+      args: ["test", "-p", "tidebreak-core", "--", "preview"],
+      cwd: ".",
+      files: [],
+      summary: "Running the core preview tests",
+    },
+    result: {
+      tool: "exec",
+      exitCode: 0,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: "test result: ok. 12 passed; 0 failed\n",
+      stderr: "",
+      backend: "local",
+    },
+  },
+};
+
+/** Live command: open with a height-bounded output tail. */
+export const Running: Story = {
+  args: {
+    status: "running",
+    preview: {
+      tool: "exec",
+      command: "cargo",
+      args: ["test", "--workspace"],
+      cwd: ".",
+      files: [],
+      summary: "Running the workspace tests",
+    },
+    result: {
+      tool: "exec",
+      exitCode: null,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: Array.from(
+        { length: 20 },
+        (_, index) => `Compiling crate_${index} v0.4.2`,
+      ).join("\n"),
+      stderr: "",
+      backend: "local",
+    },
+  },
+};
+
+/** Failure opens with the error excerpt on the row and full streams inside. */
+export const Failed: Story = {
+  args: {
+    status: "failed",
+    preview: {
+      tool: "exec",
+      command: "python3",
+      args: ["scripts/render_deck.py", "reports/q3.pptx"],
+      cwd: "checkout",
+      files: ["reports/q3.pptx"],
+    },
+    result: {
+      tool: "exec",
+      exitCode: 1,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: "",
+      stderr:
+        "Error: Cannot find module 'pptxgenjs'\n    at Object.<anonymous> (scripts/render_deck.py:12)\n",
+      backend: "local",
+    },
+  },
+};
+
+/**
+ * A command long enough to force middle truncation must not grow the column
+ * past the prose edge.
+ */
+export const LongCommand: Story = {
+  args: {
+    status: "completed",
+    preview: {
+      tool: "exec",
+      command: "pnpm",
+      args: [
+        "--dir",
+        "crates/tidebreak-desktop/ui",
+        "exec",
+        "vitest",
+        "run",
+        "src/ToolCallCard.dom.test.tsx",
+        "src/ToolOutputPreview.dom.test.tsx",
+        "src/ToolPreview.test.ts",
+        "--reporter=dot",
+      ],
+      cwd: ".",
+      files: [],
+    },
+    result: {
+      tool: "exec",
+      exitCode: 0,
+      timedOut: false,
+      outputTruncated: false,
+      stdout: "Tests  14 passed (14)\n",
+      stderr: "",
+      backend: "local",
+    },
+  },
+};
+
+/** Narrow journal width: truncation and gutter alignment under stress. */
+export const Narrow: Story = {
+  decorators: [
+    (Story) => (
+      <div
+        className="messages bg-background min-h-[24rem]"
+        style={{ width: 420 }}
+      >
+        <div className="messages-column">
+          <p className="text-md text-foreground leading-relaxed">
+            Narrow pane: titles still align with prose.
+          </p>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  args: {
+    ...LongCommand.args,
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -571,6 +571,12 @@ body {
     scrollbar-gutter: stable;
   }
 
+  /*
+   * One parent-owned reading column: prose, tool rows, outputs, and notices
+   * share this max width. The leading pad is the tool-icon gutter so a boxless
+   * tool title lines up with assistant prose; duration and disclosure stay on
+   * the row's right edge inside the same column.
+   */
   .messages-column {
     width: 100%;
     max-width: 48rem;
@@ -579,11 +585,17 @@ body {
     gap: 0.5rem;
     padding-block: 1.5rem;
     padding-inline-start: 1.5rem;
+    min-width: 0;
   }
 
   .messages-column .tool-card-icon {
     position: absolute;
     inset-inline-start: -1.5rem;
+  }
+
+  .messages-column .tool-card-shell {
+    width: 100%;
+    min-width: 0;
   }
 
   /* The column's base rhythm is the tight intra-exchange gap; a user message opens

--- a/crates/tidebreak-desktop/ui/src/styles.css
+++ b/crates/tidebreak-desktop/ui/src/styles.css
@@ -578,6 +578,12 @@ body {
     flex-direction: column;
     gap: 0.5rem;
     padding-block: 1.5rem;
+    padding-inline-start: 1.5rem;
+  }
+
+  .messages-column .tool-card-icon {
+    position: absolute;
+    inset-inline-start: -1.5rem;
   }
 
   /* The column's base rhythm is the tight intra-exchange gap; a user message opens
@@ -840,7 +846,8 @@ body {
   }
 
   .message-assistant {
-    align-self: flex-start;
+    width: 100%;
+    min-width: 0;
     padding: 0.1rem 0;
     background: transparent;
   }


### PR DESCRIPTION
Closes #3279

## Summary
- Parent-owned `.messages-column` is the shared reading width for prose, boxless tool rows, outputs, and notices; tool icons sit in a leading gutter so titles line up with assistant text while duration/disclosure stay on the right edge.
- Collapsed command previews show a grounded action + meaningful target (model summary when present, otherwise command head + path-like arg) and a short factual result from streams — no extra model call.
- Successful rows stay quiet; running rows open with a height-bounded tail; failed rows open with an error excerpt. Exact command, cwd, and full output remain on expansion. Approval cards still render literal `toolPreviewPresentation().detail` only.
- Storybook: `Conversation/Tool command` states (including narrow) and mixed-transcript stories; Patterns failed row updated.

## Validation
- Focused vitest: ToolPreview, ToolCallCard, ToolOutputPreview, stylesContract (42 passed)
- `biome format` on touched files
- `tsc --noEmit`
- `pnpm storybook:build`

## Screenshots
Captured and inspected the command states and mixed transcripts locally at desktop and narrow widths across all four Storybook themes. The 68 captures include a 420px transcript check with no page overflow. A separate keyboard check confirms that Enter collapses the failed command card and retains a visible focus ring.

## Risk
Presentation-only in the chat journal tool surface. Code-mode `CodeToolCard` still uses `ToolCardShell` and benefits from width/gutter CSS inside `.messages-column`.