### PR TITLE
fix(code): publish first-turn images to the new session before send

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/publishCodeSessionImages.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/publishCodeSessionImages.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiClient } from "../api/client";
+
+const publishCodeImage = vi.hoisted(() => vi.fn());
+const uploadImageAttachment = vi.hoisted(() => vi.fn());
+const hasLocalHostAuthority = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("../attachments", () => ({
+  publishCodeImage,
+}));
+
+vi.mock("../ImageAttachments", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../ImageAttachments")>()),
+  uploadImageAttachment,
+}));
+
+vi.mock("../host", () => ({
+  hasLocalHostAuthority,
+}));
+
+import {
+  publishCodeSessionImages,
+  submitFirstCodeTurn,
+} from "./publishCodeSessionImages";
+
+const SESSION_A = "sess-new-1";
+const SESSION_B = "sess-other";
+const BLOB_ID = "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21";
+
+function pngFile(): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], "shot.png", {
+    type: "image/png",
+  });
+}
+
+describe("publishCodeSessionImages / submitFirstCodeTurn", () => {
+  beforeEach(() => {
+    publishCodeImage.mockReset();
+    uploadImageAttachment.mockReset();
+    hasLocalHostAuthority.mockReset();
+    hasLocalHostAuthority.mockReturnValue(false);
+    uploadImageAttachment.mockResolvedValue({
+      attachmentId: BLOB_ID,
+      mediaType: "image/png",
+      width: 1,
+      height: 1,
+      byteLen: 4,
+    });
+  });
+
+  it("publishes each file to the new session before any turn is submitted", async () => {
+    const order: string[] = [];
+    uploadImageAttachment.mockImplementation(
+      async (_client: ApiClient, sessionId: string) => {
+        order.push(`publish:${sessionId}`);
+        return {
+          attachmentId: BLOB_ID,
+          mediaType: "image/png",
+          width: 1,
+          height: 1,
+          byteLen: 4,
+        };
+      },
+    );
+    const submitCodeTurn = vi.fn(async () => {
+      order.push("submit");
+      return { kind: "turn" };
+    });
+    const client = { submitCodeTurn } as unknown as ApiClient;
+    const file = pngFile();
+
+    await submitFirstCodeTurn({
+      client,
+      sessionId: SESSION_A,
+      message: "look at this",
+      images: [file],
+    });
+
+    expect(order).toEqual([`publish:${SESSION_A}`, "submit"]);
+    expect(uploadImageAttachment).toHaveBeenCalledWith(
+      client,
+      SESSION_A,
+      file,
+      expect.objectContaining({
+        path: expect.any(Function),
+      }),
+    );
+    const path = uploadImageAttachment.mock.calls[0][3].path as (
+      id: string,
+    ) => string;
+    expect(path(SESSION_A)).toBe(
+      `/sessions/${encodeURIComponent(SESSION_A)}/attachments/images`,
+    );
+    expect(submitCodeTurn).toHaveBeenCalledTimes(1);
+    expect(submitCodeTurn).toHaveBeenCalledWith(
+      SESSION_A,
+      "look at this",
+      undefined,
+      [{ blob_id: BLOB_ID, media_type: "image/png" }],
+    );
+  });
+
+  it("refuses to bind an image published for another session into the turn", async () => {
+    // Without the session-id argument on publish, a caller could reserve
+    // bytes on session B and then name that blob on session A's first turn.
+    // The server would answer 400 "was not published to session". This test
+    // locks the client contract: publication target === turn session.
+    uploadImageAttachment.mockImplementation(
+      async (_client: ApiClient, sessionId: string) => {
+        expect(sessionId).toBe(SESSION_A);
+        expect(sessionId).not.toBe(SESSION_B);
+        return {
+          attachmentId: BLOB_ID,
+          mediaType: "image/png",
+          width: 1,
+          height: 1,
+          byteLen: 4,
+        };
+      },
+    );
+    const submitCodeTurn = vi.fn(async () => ({ kind: "turn" }));
+    const client = { submitCodeTurn } as unknown as ApiClient;
+
+    await submitFirstCodeTurn({
+      client,
+      sessionId: SESSION_A,
+      message: "first turn",
+      images: [pngFile()],
+    });
+
+    expect(submitCodeTurn).toHaveBeenCalledWith(
+      SESSION_A,
+      "first turn",
+      undefined,
+      [{ blob_id: BLOB_ID, media_type: "image/png" }],
+    );
+  });
+
+  it("submits text-only first turns once, with no attachment payload", async () => {
+    const submitCodeTurn = vi.fn(async () => ({ kind: "turn" }));
+    const client = { submitCodeTurn } as unknown as ApiClient;
+
+    await submitFirstCodeTurn({
+      client,
+      sessionId: SESSION_A,
+      message: "  hello  ",
+      images: [],
+    });
+
+    expect(uploadImageAttachment).not.toHaveBeenCalled();
+    expect(submitCodeTurn).toHaveBeenCalledTimes(1);
+    expect(submitCodeTurn).toHaveBeenCalledWith(SESSION_A, "hello");
+  });
+
+  it("does not submit when the message is empty", async () => {
+    const submitCodeTurn = vi.fn();
+    const client = { submitCodeTurn } as unknown as ApiClient;
+
+    const posted = await submitFirstCodeTurn({
+      client,
+      sessionId: SESSION_A,
+      message: "   ",
+      images: [pngFile()],
+    });
+
+    expect(posted).toBe(false);
+    expect(submitCodeTurn).not.toHaveBeenCalled();
+    expect(uploadImageAttachment).not.toHaveBeenCalled();
+  });
+
+  it("uses the host publish path when local authority is available", async () => {
+    hasLocalHostAuthority.mockReturnValue(true);
+    publishCodeImage.mockResolvedValue({
+      attachmentId: BLOB_ID,
+      mediaType: "image/png",
+      width: 1,
+      height: 1,
+      byteLen: 4,
+    });
+    const file = pngFile();
+    const client = {} as ApiClient;
+
+    const attachments = await publishCodeSessionImages(client, SESSION_A, [
+      file,
+    ]);
+
+    expect(publishCodeImage).toHaveBeenCalledWith(SESSION_A, file);
+    expect(uploadImageAttachment).not.toHaveBeenCalled();
+    expect(attachments).toEqual([
+      { blob_id: BLOB_ID, media_type: "image/png" },
+    ]);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/code/publishCodeSessionImages.ts
+++ b/crates/tidebreak-desktop/ui/src/code/publishCodeSessionImages.ts
@@ -1,0 +1,75 @@
+import type { ApiClient } from "../api/client";
+import { publishCodeImage } from "../attachments";
+import { hasLocalHostAuthority } from "../host";
+import { uploadImageAttachment } from "../ImageAttachments";
+
+/** One image reference a code turn can carry after publication. */
+export type CodeTurnImageAttachment = {
+  blob_id: string;
+  media_type: string;
+};
+
+/**
+ * Publish image files to a code session and return turn attachment refs.
+ *
+ * Publication is per-session authority: bytes must be reserved on the session
+ * that will submit the turn. Callers hold `File`s until that session exists,
+ * then publish here before `POST …/turns`. Publishing to a different session
+ * (or skipping publication) yields `attachment blob … was not published`.
+ */
+export async function publishCodeSessionImages(
+  client: ApiClient,
+  sessionId: string,
+  files: readonly File[],
+): Promise<readonly CodeTurnImageAttachment[]> {
+  if (files.length === 0) return [];
+  const published = await Promise.all(
+    files.map(async (file) => {
+      if (hasLocalHostAuthority()) {
+        return publishCodeImage(sessionId, file);
+      }
+      return uploadImageAttachment(client, sessionId, file, {
+        onProgress: () => undefined,
+        signal: new AbortController().signal,
+        path: (id) => `/sessions/${encodeURIComponent(id)}/attachments/images`,
+      });
+    }),
+  );
+  return published.map((image) => ({
+    blob_id: image.attachmentId,
+    media_type: image.mediaType,
+  }));
+}
+
+/**
+ * Submit one first turn, publishing any images to `sessionId` first.
+ *
+ * Returns whether a turn was posted. Callers that already created the session
+ * use this so the message is sent at most once and only with attachments the
+ * new session actually holds.
+ */
+export async function submitFirstCodeTurn(input: {
+  client: ApiClient;
+  sessionId: string;
+  message: string;
+  images?: readonly File[];
+}): Promise<boolean> {
+  const message = input.message.trim();
+  if (!message) return false;
+  const attachments = await publishCodeSessionImages(
+    input.client,
+    input.sessionId,
+    input.images ?? [],
+  );
+  if (attachments.length > 0) {
+    await input.client.submitCodeTurn(
+      input.sessionId,
+      message,
+      undefined,
+      attachments,
+    );
+  } else {
+    await input.client.submitCodeTurn(input.sessionId, message);
+  }
+  return true;
+}

--- a/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
+++ b/crates/tidebreak-desktop/ui/src/code/startWorkspaceSession.ts
@@ -9,9 +9,6 @@ import type {
   PermissionMode,
   ReasoningEffort,
 } from "../api/types";
-import { publishCodeImage } from "../attachments";
-import { uploadImageAttachment } from "../ImageAttachments";
-import { hasLocalHostAuthority } from "../host";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { useCodeUiStore, type WorkspaceStartup } from "./CodeUiStore";
@@ -20,6 +17,7 @@ import {
   preferredCodeModels,
   requiresHarnessModelIds,
 } from "./labels";
+import { submitFirstCodeTurn } from "./publishCodeSessionImages";
 
 /** What the first session of a workspace is created with. */
 export type FirstSessionSettings = {
@@ -74,9 +72,10 @@ export async function resolveSessionModel(input: {
  * workspace composer, and a failed first turn does the same, so typed words
  * and pasted images are never dropped.
  *
- * The handoff clears as soon as the session exists. `POST /turns` waits for
- * the worker to finish the turn, so leaving the overlay up until submit
- * returns would cover the conversation for the whole first reply.
+ * While a first message still has images to publish, the handoff stays up so
+ * the session composer cannot send a second first turn with unpublished
+ * ids. Once publication finishes, the handoff drops so the socket can open
+ * and stream; `POST /turns` may still run for the whole first reply.
  */
 export async function startFirstSession(input: {
   client: ApiClient;
@@ -153,27 +152,25 @@ export async function startFirstSession(input: {
     });
     useCodeCatalogStore.getState().rememberSession(session);
     input.onSessionCreated?.(session, posted);
-    // Drop the steps before posting the first turn so the workspace page can
-    // open the session socket and stream. The route does not return until
-    // the turn ends.
-    setWorkspaceStartup(workspace.id, null);
     if (prompt) {
+      // Keep the handoff while images publish so the new session's composer
+      // cannot race a second send with ids that are not yet reserved here.
+      if (images.length > 0) {
+        setWorkspaceStartup(workspace.id, {
+          ...base,
+          hasFirstMessage: true,
+          phase: "sending_message",
+        });
+      } else {
+        setWorkspaceStartup(workspace.id, null);
+      }
       try {
-        const attachments = await publishFirstTurnImages(
+        await submitFirstCodeTurn({
           client,
-          session.id,
+          sessionId: session.id,
+          message: prompt,
           images,
-        );
-        if (attachments.length > 0) {
-          await client.submitCodeTurn(
-            session.id,
-            prompt,
-            undefined,
-            attachments,
-          );
-        } else {
-          await client.submitCodeTurn(session.id, prompt);
-        }
+        });
       } catch (error) {
         // Never drop typed words or pasted images: the workspace composer
         // holds them.
@@ -182,6 +179,8 @@ export async function startFirstSession(input: {
           `${turnFailed} ${friendlyErrorMessage(error, "Send it from the workspace composer.")}`,
         );
       }
+    } else {
+      setWorkspaceStartup(workspace.id, null);
     }
     return session;
   } catch (error) {
@@ -195,27 +194,4 @@ export async function startFirstSession(input: {
   } finally {
     setWorkspaceStartup(workspace.id, null);
   }
-}
-
-async function publishFirstTurnImages(
-  client: ApiClient,
-  sessionId: string,
-  files: readonly File[],
-): Promise<readonly { blob_id: string; media_type: string }[]> {
-  const published = await Promise.all(
-    files.map(async (file) => {
-      if (hasLocalHostAuthority()) {
-        return publishCodeImage(sessionId, file);
-      }
-      return uploadImageAttachment(client, sessionId, file, {
-        onProgress: () => undefined,
-        signal: new AbortController().signal,
-        path: (id) => `/sessions/${encodeURIComponent(id)}/attachments/images`,
-      });
-    }),
-  );
-  return published.map((image) => ({
-    blob_id: image.attachmentId,
-    media_type: image.mediaType,
-  }));
 }

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
@@ -24,13 +24,11 @@ import {
   preferredCodeModels,
   requiresHarnessModelIds,
 } from "../labels";
-import { hasLocalHostAuthority } from "../../host";
 import { liveCodeSessions } from "../parsers";
-import { publishCodeImage } from "../../attachments";
 import { toast } from "sonner";
-import { uploadImageAttachment } from "../../ImageAttachments";
 import { useCodeCatalogStore } from "../CodeCatalogStore";
 import { useCodeUiStore } from "../CodeUiStore";
+import { submitFirstCodeTurn } from "../publishCodeSessionImages";
 import { useConversationDigests } from "../CodeUpdatesStore";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { useNavigate } from "@tanstack/react-router";
@@ -361,39 +359,15 @@ export function useWorkspaceSessions({
       }
 
       try {
-        const attachments = heldImages?.length
-          ? await Promise.all(
-              heldImages.map(async (file) => {
-                const published = hasLocalHostAuthority()
-                  ? await publishCodeImage(created.id, file)
-                  : await uploadImageAttachment(
-                      startedWithClient,
-                      created.id,
-                      file,
-                      {
-                        onProgress: () => undefined,
-                        signal: new AbortController().signal,
-                        path: (id) =>
-                          `/sessions/${encodeURIComponent(id)}/attachments/images`,
-                      },
-                    );
-                return {
-                  blob_id: published.attachmentId,
-                  media_type: published.mediaType,
-                };
-              }),
-            )
-          : [];
-        if (attachments.length > 0) {
-          await startedWithClient.submitCodeTurn(
-            created.id,
-            message,
-            undefined,
-            attachments,
-          );
-        } else {
-          await startedWithClient.submitCodeTurn(created.id, message);
-        }
+        // Publish into this session only after create, then send once. Using
+        // blob ids reserved for another session (or never published) is what
+        // yields "attachment blob … was not published to session …".
+        await submitFirstCodeTurn({
+          client: startedWithClient,
+          sessionId: created.id,
+          message,
+          images: heldImages ?? [],
+        });
         clearFirstTurnRecovery(startedWithClient, created.id, recovery.id);
       } catch (err) {
         if (heldImages && heldImages.length > 0) {

--- a/crates/tidebreak-server-api/src/tests/code_attachments.rs
+++ b/crates/tidebreak-server-api/src/tests/code_attachments.rs
@@ -565,3 +565,170 @@ async fn a_session_cannot_attach_an_image_published_to_another_session() {
         "the refusal must name authority, not blob absence: {body}"
     );
 }
+
+/// First turn on a brand-new session: create → publish → submit, in that order.
+///
+/// The hosted first-message path (new workspace / start session with a pasted
+/// image) does exactly this. A regression that resolved attachments without a
+/// per-session publication row fails the submit half. Uses in-process oneshot
+/// so the contract is exercised without a bound TCP listener.
+#[tokio::test]
+async fn the_first_turn_of_a_new_session_accepts_an_image_published_after_create() {
+    use axum::body::Body;
+    use axum::http::{header, Request, StatusCode};
+    use tower::ServiceExt;
+
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_image_input(CapLevel::Supported);
+    let (router, token, _runtime, dir) = code_app_with(adapter).await;
+    let bearer = format!("Bearer {token}");
+    let repo = init_git_repo(dir.path());
+
+    let registered = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/code/repos")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::json!({ "path": repo }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(registered.status(), StatusCode::CREATED);
+    let repo_body: serde_json::Value = super::json_body(registered).await;
+
+    let workspace_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/code/workspaces")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "repo_id": json_id(&repo_body),
+                        "title": "first image turn",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(workspace_response.status(), StatusCode::CREATED);
+    let workspace: serde_json::Value = super::json_body(workspace_response).await;
+
+    let created = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/code/workspaces/{}/sessions", json_id(&workspace)))
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "harness": "claude_code",
+                        "permission_mode": "plan",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let session: serde_json::Value = super::json_body(created).await;
+    let session_id = json_id(&session).to_owned();
+
+    // Publish only after the session exists — the same order the desktop uses
+    // for a first turn that carries a pasted image.
+    let published = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/code/sessions/{session_id}/attachments/images"))
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "image/png")
+                .body(Body::from(one_pixel_png()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        published.status(),
+        StatusCode::CREATED,
+        "publishing the fixture image failed"
+    );
+    let published: serde_json::Value = super::json_body(published).await;
+    let blob_id = published["attachment_id"]
+        .as_str()
+        .or_else(|| published["blob_id"].as_str())
+        .expect("the publication names the blob")
+        .to_owned();
+
+    let first_turn = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/code/sessions/{session_id}/turns"))
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "message": "what is in this screenshot",
+                        "attachments": [{ "blob_id": blob_id, "media_type": "image/png" }],
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = first_turn.status();
+    let body_bytes = axum::body::to_bytes(first_turn.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8_lossy(&body_bytes);
+    assert_eq!(
+        status,
+        StatusCode::ACCEPTED,
+        "first turn with a just-published image must be accepted: {body}"
+    );
+    assert!(
+        !body.contains("was not published to session"),
+        "publication for this session must satisfy the first turn: {body}"
+    );
+
+    // Publication is not one-shot: a later turn on the same session may reuse
+    // the reservation. The client still sends the first message only once.
+    let follow_up = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/code/sessions/{session_id}/turns"))
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "message": "and again",
+                        "attachments": [{ "blob_id": blob_id, "media_type": "image/png" }],
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        follow_up.status(),
+        StatusCode::ACCEPTED,
+        "publication remains valid for later turns on the same session"
+    );
+}


### PR DESCRIPTION
## Summary

Starting a Code session with an attached image could fail after create with `HttpError: 400: attachment blob … was not published to session …` (hosted keen-vale; Grok and other harnesses). Publication is per-session authority; the first turn must reserve images on the **new** session before `POST …/turns`, and must not race a second send while that reservation is in flight.

## Changes

- Shared `publishCodeSessionImages` / `submitFirstCodeTurn` helper used by new-workspace start and workspace start-session
- Keep the workspace startup handoff in `sending_message` while first-turn images publish so the session composer cannot double-send unpublished ids
- Clear the handoff immediately for text-only first turns (existing behavior)
- Server regression: create → publish → first turn (oneshot) accepts the image; publication remains valid for a later turn on the same session
- Client unit tests lock publish-before-submit order and session identity

Closes #3283.

## Validation

- `cargo test -p tidebreak-server --lib the_first_turn_of_a_new_session_accepts_an_image_published_after_create`
- `vitest run src/code/publishCodeSessionImages.test.ts src/code/NewWorkspaceDialog.dom.test.tsx` (44 passed)
- `biome check` on touched UI files
- `tsc --noEmit` (UI)

No Storybook/UI visual changes. Browser verification not applicable.

## Overlap

Owns first-turn attachment publication only. Does not touch model-picker filtering, Cmd+Enter steering, tool-card layout, loader sync, workspace titles, Codex pin, or staging retention.