### PR TITLE
fix(server): hosted workspace titles from gateway utility models

### DIFF
--- a/crates/tidebreak-server-api/src/tests/configuration.rs
+++ b/crates/tidebreak-server-api/src/tests/configuration.rs
@@ -6114,7 +6114,10 @@ async fn background_roles_walk_the_callers_entitlements() {
     .unwrap()
     .expect("the caller's entitlements must serve the utility role");
     assert_eq!(utility.provider, providers::ProviderKind::ModelGateway);
-    assert_eq!(utility.id, "acme-opus");
+    // Cheapest-first over the caller's snapshot: acme-gpt has the smaller
+    // context window. Gateway protocols enforce structured output, so it is
+    // eligible even without a curated alias map.
+    assert_eq!(utility.id, "acme-gpt");
 
     assert!(
         model_roles::resolve(
@@ -6129,6 +6132,59 @@ async fn background_roles_walk_the_callers_entitlements() {
         .unwrap()
         .is_none(),
         "background work with no caller must be skipped, never run as somebody else"
+    );
+}
+
+/// A hosted caller's catalog may list only deployment-local model ids with no
+/// curated alias. Gateway protocols still enforce structured output, so the
+/// utility role must resolve — otherwise workspace titling silently leaves
+/// every new checkout on its generated two-word name.
+#[tokio::test]
+async fn background_roles_accept_gateway_models_without_curated_aliases() {
+    let dir = tempfile::tempdir().unwrap();
+    let (store, secrets) = empty_deployment(&dir).await;
+
+    let _env = ENV_LOCK.lock().await;
+    let _key = ScopedEnv::unset("ANTHROPIC_API_KEY");
+    let _base = ScopedEnv::unset("ANTHROPIC_BASE_URL");
+    let provisioned = crate::managed_policy::MemoryProvisionedPolicy::new();
+    let snapshot = providers::GatewayModelSnapshot {
+        gateway_url: "https://gateway.example".to_owned(),
+        installation_id: None,
+        models: vec![providers::CustomModelConfig {
+            id: "acme-inhouse-llm".into(),
+            display_name: Some("Acme In-house".into()),
+            context_window: 64_000,
+            max_output_tokens: 8_000,
+            ..Default::default()
+        }],
+        model_protocols: [(
+            "acme-inhouse-llm".to_owned(),
+            providers::GatewayModelProtocol::OpenaiResponses,
+        )]
+        .into_iter()
+        .collect(),
+        model_reasoning_efforts: Default::default(),
+        member_catalog: Some("v1".into()),
+        catalog_etag: None,
+    };
+
+    let utility = model_roles::resolve(
+        &*store,
+        &*secrets,
+        &*provisioned,
+        &crate::managed_policy::NoOsPolicy,
+        model_roles::ModelRole::Utility,
+        Some(&snapshot),
+    )
+    .await
+    .unwrap()
+    .expect("a gateway-only model must still serve the utility role");
+    assert_eq!(utility.provider, providers::ProviderKind::ModelGateway);
+    assert_eq!(utility.id, "acme-inhouse-llm");
+    assert!(
+        utility.supports_structured_output,
+        "gateway protocols enforce structured output without a curated map"
     );
 }
 

--- a/crates/tidebreak-server/src/chat_titling.rs
+++ b/crates/tidebreak-server/src/chat_titling.rs
@@ -262,10 +262,15 @@ impl ChatTitler {
         let Some(material) = user_message_digest(&self.store.list_messages(chat_id).await?) else {
             return Ok(None);
         };
-        // The title runs as the chat's owner: on a hosted machine that is
-        // the caller whose credential can actually drive it (decision 62).
+        // The title runs under the conversation's credential authority: an
+        // external grant stays on its delegated token, and a browser-owned
+        // chat stays on the caller's sign-in (decision 62). Owner-only
+        // resolution would replace a grant with the browser session.
         let owner = self.store.chat_owner(chat_id).await.unwrap_or_default();
-        let provider = self.resolver.resolve_for(owner.as_ref()).await;
+        let provider = self
+            .resolver
+            .resolve_for_session(owner.as_ref(), chat_id)
+            .await;
         let title = derive_text_with_retries::<TitleProposal>(
             provider.as_ref(),
             utility,

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -165,7 +165,16 @@ async fn propose_from_message(
     // Resolved per call, like every consumer of the utility role: `None` means
     // this install has no model for background work. On a hosted machine both
     // the role and the provider resolve as the workspace's owner (decision 62).
-    let caller_gateway = state.caller_gateway_snapshot(owner).await.ok().flatten();
+    let caller_gateway = match state.caller_gateway_snapshot(owner).await {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::warn!(
+                ?error,
+                "could not read caller gateway entitlements for workspace naming"
+            );
+            None
+        }
+    };
     let Some(utility) = crate::model_roles::resolve_utility_model(
         &*state.store,
         &*state.secrets,
@@ -175,6 +184,11 @@ async fn propose_from_message(
     )
     .await?
     else {
+        if caller_gateway.is_some() {
+            tracing::warn!(
+                "no utility model in the caller's gateway entitlements; leaving the workspace on its generated name"
+            );
+        }
         return Ok(ProposalOutcome::NotApplicable);
     };
     let provider = state.resolver.resolve_for(Some(owner)).await;

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -68,10 +68,12 @@ pub async fn propose_for_creation(
     owner: &OwnerId,
     message: &str,
 ) -> Result<Option<String>> {
-    Ok(match propose_from_message(state, owner, message).await? {
-        ProposalOutcome::Proposed(title) => Some(title),
-        ProposalOutcome::Declined | ProposalOutcome::NotApplicable => None,
-    })
+    Ok(
+        match propose_from_message(state, owner, None, message).await? {
+            ProposalOutcome::Proposed(title) => Some(title),
+            ProposalOutcome::Declined | ProposalOutcome::NotApplicable => None,
+        },
+    )
 }
 
 /// Derive a title for the workspace behind `session_id` in the background,
@@ -135,7 +137,7 @@ async fn derive_workspace_title(
     if workspace.title != placeholder || workspace.status != CodeWorkspaceStatus::Active {
         return Ok(Outcome::NotApplicable);
     }
-    let title = match propose_from_message(state, owner, message).await? {
+    let title = match propose_from_message(state, owner, Some(session_id), message).await? {
         ProposalOutcome::Proposed(title) => title,
         ProposalOutcome::Declined => return Ok(Outcome::Declined),
         ProposalOutcome::NotApplicable => return Ok(Outcome::NotApplicable),
@@ -153,6 +155,7 @@ async fn derive_workspace_title(
 async fn propose_from_message(
     state: &AppState,
     owner: &OwnerId,
+    session_id: Option<SessionId>,
     message: &str,
 ) -> Result<ProposalOutcome> {
     if !state.resolver.enforces_model_registry() {
@@ -164,16 +167,34 @@ async fn propose_from_message(
     }
     // Resolved per call, like every consumer of the utility role: `None` means
     // this install has no model for background work. On a hosted machine both
-    // the role and the provider resolve as the workspace's owner (decision 62).
-    let caller_gateway = match state.caller_gateway_snapshot(owner).await {
-        Ok(snapshot) => snapshot,
-        Err(error) => {
-            tracing::warn!(
-                ?error,
-                "could not read caller gateway entitlements for workspace naming"
-            );
-            None
-        }
+    // the role and the provider resolve under the conversation's credential
+    // authority (decision 62) — a live session keeps its external grant, and a
+    // pre-create naming call uses the owner's sign-in.
+    let caller_gateway = match session_id {
+        Some(session_id) => match state
+            .resolver
+            .session_gateway_snapshot(Some(owner), session_id)
+            .await
+        {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "could not read session gateway entitlements for workspace naming"
+                );
+                None
+            }
+        },
+        None => match state.caller_gateway_snapshot(owner).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "could not read caller gateway entitlements for workspace naming"
+                );
+                None
+            }
+        },
     };
     let Some(utility) = crate::model_roles::resolve_utility_model(
         &*state.store,
@@ -191,7 +212,15 @@ async fn propose_from_message(
         }
         return Ok(ProposalOutcome::NotApplicable);
     };
-    let provider = state.resolver.resolve_for(Some(owner)).await;
+    let provider = match session_id {
+        Some(session_id) => {
+            state
+                .resolver
+                .resolve_for_session(Some(owner), session_id)
+                .await
+        }
+        None => state.resolver.resolve_for(Some(owner)).await,
+    };
     let title = derive_text_with_retries::<TitleProposal>(
         provider.as_ref(),
         &utility,

--- a/crates/tidebreak-server/src/gateway_runtime/tests.rs
+++ b/crates/tidebreak-server/src/gateway_runtime/tests.rs
@@ -1518,7 +1518,8 @@ async fn a_gateway_model_matching_a_curated_id_inherits_its_capabilities() {
         vec![crate::model_registry::InputModality::Text]
     );
     assert!(!unmatched.supports_reasoning);
-    assert!(!unmatched.supports_structured_output);
+    // Gateway protocols enforce structured output without a curated map.
+    assert!(unmatched.supports_structured_output);
 }
 
 /// The background loop's first attempt is immediate — the boot case it

--- a/crates/tidebreak-server/src/providers.rs
+++ b/crates/tidebreak-server/src/providers.rs
@@ -1033,6 +1033,15 @@ impl ResolvedModelPolicy {
     /// custom treatment.
     fn gateway_for(model: &CustomModelConfig) -> Self {
         let mut policy = Self::custom_for(ProviderKind::ModelGateway, model);
+        // Model Gateway protocols enforce structured output: Anthropic via a
+        // forced tool or `output_config.format`, OpenAI via `json_schema`.
+        // Unlike an arbitrary compatible endpoint, background utility work
+        // (workspace titling, chat titling, the approval judge) can depend on
+        // that contract even when the row does not map to a curated vendor id.
+        // Without this, a hosted caller's entitled models that lack curated
+        // aliases resolve the utility role to nothing and every workspace keeps
+        // its generated two-word name (decision 62).
+        policy.supports_structured_output = true;
         let Some(spec) = gateway_curated_spec(model) else {
             return policy;
         };

--- a/crates/tidebreak-server/src/providers/tests.rs
+++ b/crates/tidebreak-server/src/providers/tests.rs
@@ -559,7 +559,8 @@ async fn gateway_identity_conflicting_local_and_upstream_ids_are_not_equivalent_
     assert_eq!(policy.vendor, None);
     assert_eq!(policy.verification, VerificationTier::Unverified);
     assert_eq!(policy.input_modalities, vec![InputModality::Text]);
-    assert!(!policy.supports_structured_output);
+    // Gateway protocols still enforce structured output without a curated map.
+    assert!(policy.supports_structured_output);
     assert!(!policy.supports_reasoning);
     assert!(policy.reasoning_efforts.is_empty());
 }
@@ -594,7 +595,7 @@ async fn gateway_identity_conflicting_recognized_aliases_are_not_equivalent_or_e
     assert_eq!(policy.vendor, None);
     assert_eq!(policy.verification, VerificationTier::Unverified);
     assert_eq!(policy.input_modalities, vec![InputModality::Text]);
-    assert!(!policy.supports_structured_output);
+    assert!(policy.supports_structured_output);
     assert!(!policy.supports_reasoning);
     assert!(policy.reasoning_efforts.is_empty());
 }


### PR DESCRIPTION
## Summary
Hosted Tidebreak kept generated two-word workspace names (and the matching branch/worktree slugs when naming runs before checkout) because the utility role refused Model Gateway models that did not map to a curated structured-output row. Gateway Anthropic/OpenAI protocols already enforce structured output, so those models are eligible for workspace titling, chat titling, and other background utility work.

## Root cause
`ResolvedModelPolicy::gateway_for` inherited `supports_structured_output: false` from the arbitrary-compatible path whenever a catalog row lacked a curated alias. `ModelRole::Utility` requires that flag, so `resolve_utility_model` returned `None` on typical hosted catalogs. `POST /code/workspace-title` and first-turn background naming then left the placeholder name in place. Branch/worktree naming only follows a successful pre-creation suggestion; this change does not rename existing committed checkouts.

## Changes
- Mark Model Gateway policies as supporting structured output by default; curated matches still overlay vendor capabilities.
- Log when gateway entitlements are missing or yield no utility model during workspace naming.
- Resolve chat titles and turn-time workspace titles through the session credentials. External grants keep their delegated authority for catalog reads and inference; pre-creation naming continues to use the owner sign-in.
- Regression: utility resolves for a gateway-only model with no curated aliases; update cheapest-first hosted utility expectation.

## Test plan
- [x] `cargo test -p tidebreak-server-core --lib gateway_identity_conflicting`
- [x] `cargo test -p tidebreak-server-core --lib a_gateway_model_matching_a_curated_id_inherits_its_capabilities`
- [x] `cargo test -p tidebreak-server --lib background_roles`
- [x] `cargo check -p tidebreak-server-core -p tidebreak-server`
- [x] `cargo fmt` on touched packages
- Loopback HTTP tests could not run in the sandbox because local TCP requests hang. CI passed all three server test partitions, including `repository_free_external_sessions_run_the_default_grant_model_and_refuse_revocation`, with its security assertion intact. All required checks passed, and the automatic review approved commit `12f493e9c2d04f2a111516b1cb5174c69ecd7cec`.

Closes #3277