### PR TITLE
fix(mobile): make the release build usable on device

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -36,9 +36,12 @@ export default function RootLayout() {
             headerShadowVisible: false,
             headerStyle: { backgroundColor: "#f4f5f7" },
             contentStyle: { backgroundColor: "#f4f5f7" },
+            // Chevron-only back button; the default inherits the previous
+            // route's title and falls back to its file name ("index").
+            headerBackButtonDisplayMode: "minimal",
           }}
         >
-          <Stack.Screen name="index" options={{ headerShown: false }} />
+          <Stack.Screen name="index" options={{ headerShown: false, title: "Tidebreak" }} />
           <Stack.Screen name="pair" options={{ title: "Gateway" }} />
           <Stack.Screen name="attach" options={{ title: "Machine" }} />
           <Stack.Screen name="home" options={{ title: "Attached" }} />

--- a/mobile/eslint.config.mjs
+++ b/mobile/eslint.config.mjs
@@ -19,21 +19,23 @@ export default tseslint.config(
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      // Hermes release builds have no web crypto/base64 globals; dev tooling
-      // polyfills them, so only CI can catch a stray reference before device.
+      // Dev tooling polyfills web globals that a Hermes release build may not
+      // have (global crypto crashed on-device pairing; #3292). Only CI can
+      // catch a stray reference before the device does.
       "no-restricted-globals": [
         "error",
         {
           name: "crypto",
-          message: "No global crypto in Hermes release builds - use expo-crypto.",
+          message: "Hermes has no global crypto - use expo-crypto.",
         },
         {
           name: "btoa",
-          message: "No btoa in Hermes release builds - encode base64 in JS.",
+          message:
+            "Engine coverage varies - use the base64url helpers in src/lib/crypto.ts.",
         },
         {
           name: "atob",
-          message: "No atob in Hermes release builds - decode base64 in JS.",
+          message: "Engine coverage varies - decode base64 in pure JS.",
         },
       ],
     },

--- a/mobile/eslint.config.mjs
+++ b/mobile/eslint.config.mjs
@@ -19,6 +19,23 @@ export default tseslint.config(
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
+      // Hermes release builds have no web crypto/base64 globals; dev tooling
+      // polyfills them, so only CI can catch a stray reference before device.
+      "no-restricted-globals": [
+        "error",
+        {
+          name: "crypto",
+          message: "No global crypto in Hermes release builds - use expo-crypto.",
+        },
+        {
+          name: "btoa",
+          message: "No btoa in Hermes release builds - encode base64 in JS.",
+        },
+        {
+          name: "atob",
+          message: "No atob in Hermes release builds - decode base64 in JS.",
+        },
+      ],
     },
   },
 );

--- a/mobile/expo-env.d.ts
+++ b/mobile/expo-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="expo/types" />

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -6,8 +6,8 @@
   "packageManager": "pnpm@10.18.3",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",

--- a/mobile/src/lib/crypto.ts
+++ b/mobile/src/lib/crypto.ts
@@ -1,24 +1,36 @@
+import { getRandomBytes } from "expo-crypto";
 import { sha256 } from "js-sha256";
+
+// Hermes provides no `crypto` or `btoa` globals in a release build (dev
+// tooling polyfills them, so the gap only surfaces on device). Randomness
+// comes from expo-crypto and base64url is encoded by hand.
+const BASE64URL_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+function base64UrlEncode(bytes: ArrayLike<number>): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i] ?? 0;
+    const b1 = i + 1 < bytes.length ? bytes[i + 1] : undefined;
+    const b2 = i + 2 < bytes.length ? bytes[i + 2] : undefined;
+    out += BASE64URL_ALPHABET[b0 >> 2];
+    out += BASE64URL_ALPHABET[((b0 & 0x03) << 4) | ((b1 ?? 0) >> 4)];
+    if (b1 === undefined) break;
+    out += BASE64URL_ALPHABET[((b1 & 0x0f) << 2) | ((b2 ?? 0) >> 6)];
+    if (b2 === undefined) break;
+    out += BASE64URL_ALPHABET[b2 & 0x3f];
+  }
+  return out;
+}
 
 export function sha256Hex(input: string): string {
   return sha256(input);
 }
 
 export function sha256Base64Url(input: string): string {
-  const bytes = sha256.array(input);
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return base64UrlEncode(sha256.array(input));
 }
 
 export function randomUrlSafe(byteLength = 32): string {
-  const bytes = new Uint8Array(byteLength);
-  crypto.getRandomValues(bytes);
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return base64UrlEncode(getRandomBytes(byteLength));
 }

--- a/mobile/src/lib/pkce.test.ts
+++ b/mobile/src/lib/pkce.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createPkcePair } from "./pkce";
-import { sha256Base64Url } from "./crypto";
+import { randomUrlSafe, sha256Base64Url } from "./crypto";
 
 describe("PKCE S256", () => {
   it("hashes the verifier with S256 / base64url", () => {
@@ -11,5 +11,19 @@ describe("PKCE S256", () => {
     expect(pair.challenge).toBe(sha256Base64Url(verifier));
     expect(pair.challenge).toMatch(/^[A-Za-z0-9_-]+$/);
     expect(pair.challenge.includes("=")).toBe(false);
+  });
+
+  it("matches the RFC 7636 appendix B vector", () => {
+    // Pins the hand-rolled base64url encoder (Hermes has no btoa) to the
+    // spec's known answer; a wrong encoding breaks every token exchange.
+    expect(sha256Base64Url("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")).toBe(
+      "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    );
+  });
+
+  it("generates url-safe verifiers of the expected length", () => {
+    const value = randomUrlSafe(32);
+    expect(value).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(randomUrlSafe(32)).not.toBe(value);
   });
 });

--- a/mobile/src/session/updatesStore.ts
+++ b/mobile/src/session/updatesStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 import type { SessionDigest as CodeSessionDigest } from "../generated/wire";
 import {
   EMPTY_UPDATES,
@@ -20,7 +21,11 @@ export const useUpdatesStore = create<UpdatesStore>((set) => ({
 }));
 
 export function useListedSessions(): CodeSessionDigest[] {
-  return useUpdatesStore((state) => listedSessions(state));
+  // listedSessions builds a fresh array, so the raw selector returns a new
+  // reference on every call — under useSyncExternalStore that re-renders
+  // forever ("Maximum update depth exceeded"). useShallow keeps the previous
+  // array while its elements are unchanged.
+  return useUpdatesStore(useShallow((state) => listedSessions(state)));
 }
 
 export function useHasSnapshot(): boolean {

--- a/mobile/src/test/expoCryptoStub.ts
+++ b/mobile/src/test/expoCryptoStub.ts
@@ -1,0 +1,9 @@
+// Vitest stand-in for expo-crypto (native module; not loadable under Node).
+// Wired up via the alias in vitest.config.ts.
+import { randomFillSync } from "node:crypto";
+
+export function getRandomBytes(byteCount: number): Uint8Array {
+  const bytes = new Uint8Array(byteCount);
+  randomFillSync(bytes);
+  return bytes;
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -4,8 +4,14 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts", "nativewind-env.d.ts"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "nativewind-env.d.ts"
+  ]
 }

--- a/mobile/vitest.config.ts
+++ b/mobile/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),
+      "expo-crypto": path.resolve(__dirname, "src/test/expoCryptoStub.ts"),
     },
   },
 });


### PR DESCRIPTION
Three release-blocking fixes found by running the real (Release/TestFlight) build — none reproducible under dev tooling:

**1. Pairing crash: `Property 'crypto' doesn't exist`.** `randomUrlSafe()` (PKCE verifier/state) called the web global `crypto.getRandomValues`, which Hermes does not provide — dev polyfills it. Now uses `expo-crypto.getRandomBytes` plus a dependency-free base64url encoder (no `btoa`), pinned to the RFC 7636 appendix B vector, with `expo-crypto` stubbed for vitest and eslint `no-restricted-globals` banning `crypto`/`btoa`/`atob`. **Verified end-to-end in a Release-configuration simulator: pairing + OAuth + machine attach all work.**

**2. Sessions screen fatal → crash loop.** `useListedSessions` derived a fresh array inside the raw zustand selector; under `useSyncExternalStore` that re-renders forever (`Maximum update depth exceeded`), and expo-updates error recovery re-threw it natively on every relaunch (`ErrorRecovery.crash()`), bricking the install. Fixed with `useShallow`; audited every other store selector — all return stable slices.

**3. "< index" back label.** The back button inherited the index route's file name. Chevron-only back buttons + a real title on index.

Green: `pnpm typecheck`, `pnpm lint`, `pnpm test` (94 passing).

JS-only → ships to installed TestFlight builds as an OTA after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)