### PR TITLE
fix(mobile): cold start on the hub, not the Sessions index

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -8,7 +8,10 @@ export default function WelcomeScreen() {
   const session = useSessionStore((state) => state.session);
 
   if (session?.machine) {
-    return <Redirect href="/sessions" />;
+    // Land on the hub so every surface is a push with a back affordance;
+    // redirecting into an index surface leaves it as the root of the stack
+    // with no way back out.
+    return <Redirect href="/home" />;
   }
   if (session) {
     return <Redirect href="/attach" />;


### PR DESCRIPTION
Cold-starting while attached redirected straight to `/sessions`, leaving the Sessions index as the root of the navigation stack with no way back to the hub ("Attached") screen. This predates today's fixes — the Sessions render-loop crash used to mask it.

One-line change in `app/index.tsx`: redirect to `/home` instead, so the hub is the root and every surface (Sessions, Approvals, Delivery, Chats, Settings) is a push with a working back chevron.

The deeper IA question (hub as an Orienting surface vs. bottom tabs; auto-attach; unreachable-machine timeout) is tracked separately — this just removes the dead end.

Green: `pnpm typecheck`, `pnpm lint`, `pnpm test` (94 passing). JS-only → OTA-deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)