### PR TITLE
fix(mobile): time out attach discovery for unreachable machines

### DIFF
--- a/mobile/app/attach.tsx
+++ b/mobile/app/attach.tsx
@@ -2,11 +2,20 @@ import { useRouter } from "expo-router";
 import { useMemo, useState } from "react";
 import { Pressable, Text, TextInput } from "react-native";
 import { Screen, Body, ErrorText } from "../src/components/Screen";
-import { AttachError, discoverMachine, probePolicy } from "../src/lib/attach";
+import {
+  AttachError,
+  REASON_UNREACHABLE,
+  discoverMachine,
+  probePolicy,
+} from "../src/lib/attach";
 import { tokenStore } from "../src/session/runtime";
 import { useSessionStore } from "../src/session/store";
 
 type Stage = "idle" | "discover" | "verify" | "probe";
+
+type Failure =
+  | { kind: "unreachable"; detail: string }
+  | { kind: "error"; message: string };
 
 export default function AttachScreen() {
   const router = useRouter();
@@ -14,7 +23,7 @@ export default function AttachScreen() {
   const setSession = useSessionStore((state) => state.setSession);
   const [url, setUrl] = useState(session?.machinePrefillUrl ?? "");
   const [stage, setStage] = useState<Stage>("idle");
-  const [error, setError] = useState<string | null>(null);
+  const [failure, setFailure] = useState<Failure | null>(null);
 
   const hint = useMemo(() => {
     switch (stage) {
@@ -34,7 +43,7 @@ export default function AttachScreen() {
       router.replace("/");
       return;
     }
-    setError(null);
+    setFailure(null);
     setStage("discover");
     try {
       const discovered = await discoverMachine(url, session.gatewayUrl);
@@ -51,10 +60,15 @@ export default function AttachScreen() {
       setSession(tokenStore.snapshot());
       router.replace("/home");
     } catch (err) {
-      if (err instanceof AttachError) {
-        setError(`${err.stage}: ${err.message}`);
+      if (err instanceof AttachError && err.reason === REASON_UNREACHABLE) {
+        setFailure({ kind: "unreachable", detail: err.message });
+      } else if (err instanceof AttachError) {
+        setFailure({ kind: "error", message: `${err.stage}: ${err.message}` });
       } else {
-        setError(err instanceof Error ? err.message : "Attach failed.");
+        setFailure({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Attach failed.",
+        });
       }
     } finally {
       setStage("idle");
@@ -80,7 +94,25 @@ export default function AttachScreen() {
         className="rounded-lg border border-border bg-background px-3 py-3 text-base text-foreground"
       />
       {hint ? <Text className="text-sm text-info-foreground">{hint}</Text> : null}
-      {error ? <ErrorText>{error}</ErrorText> : null}
+      {failure?.kind === "unreachable" ? (
+        <>
+          <ErrorText>
+            Couldn’t reach the machine. Hosted machines often sit on a private
+            network — check that this phone is connected to the VPN or network
+            the machine requires, then retry. ({failure.detail})
+          </ErrorText>
+          <Pressable
+            disabled={stage !== "idle"}
+            className="rounded-lg border border-border px-4 py-3"
+            onPress={() => void attach()}
+          >
+            <Text className="text-center text-base font-medium text-foreground">
+              Retry
+            </Text>
+          </Pressable>
+        </>
+      ) : null}
+      {failure?.kind === "error" ? <ErrorText>{failure.message}</ErrorText> : null}
       <Pressable
         disabled={stage !== "idle" || url.trim().length === 0}
         className="rounded-lg bg-primary px-4 py-3"

--- a/mobile/src/lib/attach.test.ts
+++ b/mobile/src/lib/attach.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { AttachError, discoverMachine } from "./attach";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AttachError,
+  DISCOVERY_TIMEOUT_MS,
+  REASON_UNREACHABLE,
+  discoverMachine,
+} from "./attach";
 import { tidebreakMachineResource } from "./resource";
 
 describe("discoverMachine", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("accepts a matching echo and rejects a foreign resource", async () => {
     const machine = "https://machine.example.com";
     const gateway = "https://gateway.example.test";
@@ -31,6 +40,51 @@ describe("discoverMachine", () => {
         ),
       ),
     ).rejects.toMatchObject({
+      reason: "resource_mismatch",
+      stage: "verify",
+    } satisfies Partial<AttachError>);
+  });
+
+  it("times out as unreachable when discovery never answers", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn(
+      (_url: string, _init: { signal?: AbortSignal }) =>
+        new Promise<Response>(() => {
+          // A host behind a VPN drops packets: the transport never settles.
+        }),
+    );
+    const pending = discoverMachine(
+      "https://machine.example.com",
+      "https://gateway.example.test",
+      fetchImpl,
+    );
+    const assertion = expect(pending).rejects.toMatchObject({
+      reason: REASON_UNREACHABLE,
+      stage: "discover",
+    } satisfies Partial<AttachError>);
+    await vi.advanceTimersByTimeAsync(DISCOVERY_TIMEOUT_MS);
+    await assertion;
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  it("keeps the validation error for a reachable machine with a bad echo", async () => {
+    vi.useFakeTimers();
+    const pending = discoverMachine(
+      "https://machine.example.com",
+      "https://gateway.example.test",
+      async () =>
+        new Response(
+          JSON.stringify({
+            mode: "gateway",
+            gateway_url: "https://gateway.example.test",
+            resource:
+              "tidebreak:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          }),
+          { status: 200 },
+        ),
+    );
+    await expect(pending).rejects.toMatchObject({
       reason: "resource_mismatch",
       stage: "verify",
     } satisfies Partial<AttachError>);

--- a/mobile/src/lib/attach.ts
+++ b/mobile/src/lib/attach.ts
@@ -6,6 +6,8 @@ import { fetchRefusingRedirects, type HttpFetch, type HttpResponse } from "./htt
 import { urlsMatch, validatedBaseUrl } from "./url";
 import type { AuthDiscovery } from "./types";
 
+export const DISCOVERY_TIMEOUT_MS = 10_000;
+
 export const REASON_UNREACHABLE = "unreachable";
 export const REASON_NOT_A_MACHINE = "not_a_machine";
 export const REASON_GATEWAY_MISMATCH = "gateway_mismatch";
@@ -52,18 +54,37 @@ export async function discoverMachine(
   }
   const derived = tidebreakMachineResource(baseUrl);
   let response: HttpResponse;
+  // A machine on a private network (VPN-only hosted deployments) often drops
+  // packets instead of refusing the connection, so the fetch would hang
+  // forever. Race it against a deadline; the abort signal is best-effort for
+  // transports that honor it.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DISCOVERY_TIMEOUT_MS);
   try {
-    response = await fetchRefusingRedirects(
-      `${baseUrl}/auth/discovery`,
-      undefined,
-      fetchImpl,
-    );
+    response = await Promise.race([
+      fetchRefusingRedirects(
+        `${baseUrl}/auth/discovery`,
+        { signal: controller.signal },
+        fetchImpl,
+      ),
+      new Promise<never>((_, reject) => {
+        controller.signal.addEventListener("abort", () => {
+          reject(
+            new Error(
+              `No response after ${DISCOVERY_TIMEOUT_MS / 1000} seconds.`,
+            ),
+          );
+        });
+      }),
+    ]);
   } catch (error) {
     throw new AttachError(
       "discover",
       REASON_UNREACHABLE,
       error instanceof Error ? error.message : "The machine did not respond.",
     );
+  } finally {
+    clearTimeout(timer);
   }
   if (!response.ok) {
     throw new AttachError(


### PR DESCRIPTION
## Problem

The Attach screen's `/auth/discovery` fetch had no deadline. A machine on a private network (e.g. a hosted machine behind a VPN the phone isn't on) drops packets rather than refusing the connection, so the screen showed "Reading /auth/discovery…" indefinitely — no error, no retry, no hint.

## Fix

- `discoverMachine` races the discovery fetch against a 10-second deadline (`DISCOVERY_TIMEOUT_MS`), aborting the transport via `AbortController` when it fires. The timeout surfaces as the existing `AttachError` with `stage: "discover"`, `reason: "unreachable"`, so the deadline holds even for transports that ignore the abort signal.
- The Attach screen now renders a distinct error state for the unreachable reason: the machine couldn't be reached, check that the phone is on the VPN/network the machine requires, plus a Retry button.
- Validation failures on a reachable machine (mismatched resource echo, wrong gateway) keep their existing `stage: message` rendering — the two cases stay distinct.

## Tests

- New vitest case: an injected transport that never settles rejects with `unreachable`/`discover` after advancing fake timers by `DISCOVERY_TIMEOUT_MS`, and the transport's abort signal is fired.
- New vitest case pinning that a reachable machine with a bad echo still fails as `resource_mismatch`/`verify`.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (96 passed) all green in `mobile/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)