### PR TITLE
feat: preview workspace image files

### DIFF
--- a/crates/tidebreak-desktop/ui/src/api/client/code-files.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/code-files.ts
@@ -3,6 +3,7 @@ import type {
   CodeWorkspaceFiles,
   CodeWorkspaceSearch,
   CodeWorkspaceTree,
+  FileDownloadProgress,
 } from "../types";
 import {
   parseCodeWorkspaceBlob,
@@ -91,6 +92,20 @@ export function withCodeFilesApi<TBase extends Constructor<HttpCore>>(
           ),
         ),
         "code workspace blob",
+      );
+    }
+
+    async getCodeWorkspaceFile(
+      workspaceId: string,
+      path: string,
+      signal?: AbortSignal,
+      onProgress?: (progress: FileDownloadProgress) => void,
+    ): Promise<{ bytes: Uint8Array; contentType: string | null }> {
+      const params = new URLSearchParams({ path });
+      return this.streamBytes(
+        `/code/workspaces/${encodeURIComponent(workspaceId)}/file?${params}`,
+        signal,
+        onProgress,
       );
     }
   };

--- a/crates/tidebreak-desktop/ui/src/code/FileViewer.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FileViewer.dom.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clearFileDownloadCache } from "@/document/useFileDownload";
+import { FileViewer, imageMediaTypeForPath } from "./FileViewer";
+
+vi.mock("@monaco-editor/react", () => ({
+  default: () => <div>Text editor</div>,
+  loader: { config: vi.fn() },
+}));
+
+beforeEach(() => {
+  clearFileDownloadCache();
+  URL.createObjectURL = vi.fn(() => "blob:workspace-image");
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(cleanup);
+
+describe("FileViewer", () => {
+  it("opens a workspace image from its original bytes", async () => {
+    const client = {
+      getCodeWorkspaceBlob: vi.fn().mockResolvedValue({
+        path: "screenshots/review.webp",
+        content: "",
+        truncated: false,
+        binary: true,
+      }),
+      getCodeWorkspaceFile: vi.fn().mockResolvedValue({
+        bytes: new Uint8Array([1, 2, 3]),
+        contentType: "image/webp",
+      }),
+    };
+
+    render(
+      <FileViewer
+        client={client}
+        workspaceId="workspace-1"
+        path="screenshots/review.webp"
+      />,
+    );
+
+    expect(
+      await screen.findByRole("img", { name: "Document image" }),
+    ).toHaveAttribute("src", "blob:workspace-image");
+    expect(client.getCodeWorkspaceFile).toHaveBeenCalledWith(
+      "workspace-1",
+      "screenshots/review.webp",
+      expect.any(AbortSignal),
+      expect.any(Function),
+    );
+  });
+
+  it("reloads image bytes when the workspace content revision changes", async () => {
+    const client = {
+      getCodeWorkspaceBlob: vi.fn().mockResolvedValue({
+        path: "screenshots/review.webp",
+        content: "",
+        truncated: false,
+        binary: true,
+      }),
+      getCodeWorkspaceFile: vi.fn().mockResolvedValue({
+        bytes: new Uint8Array([1, 2, 3]),
+        contentType: "image/webp",
+      }),
+    };
+
+    const { rerender } = render(
+      <FileViewer
+        client={client}
+        workspaceId="workspace-1"
+        path="screenshots/review.webp"
+        contentRevision={1}
+      />,
+    );
+    await screen.findByRole("img", { name: "Document image" });
+
+    rerender(
+      <FileViewer
+        client={client}
+        workspaceId="workspace-1"
+        path="screenshots/review.webp"
+        contentRevision={2}
+      />,
+    );
+    await vi.waitFor(() => {
+      expect(client.getCodeWorkspaceFile).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("keeps an unsupported binary file on the fallback", async () => {
+    const client = {
+      getCodeWorkspaceBlob: vi.fn().mockResolvedValue({
+        path: "archive.zip",
+        content: "",
+        truncated: false,
+        binary: true,
+      }),
+      getCodeWorkspaceFile: vi.fn(),
+    };
+
+    render(
+      <FileViewer
+        client={client}
+        workspaceId="workspace-1"
+        path="archive.zip"
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        "This file is binary, so the editor does not open it.",
+      ),
+    ).toBeVisible();
+    expect(client.getCodeWorkspaceFile).not.toHaveBeenCalled();
+  });
+});
+
+it("recognizes browser image extensions without case sensitivity", () => {
+  expect(imageMediaTypeForPath("assets/PHOTO.JPEG")).toBe("image/jpeg");
+  expect(imageMediaTypeForPath("assets/diagram.svg")).toBe("image/svg+xml");
+  expect(imageMediaTypeForPath("assets/archive.zip")).toBeNull();
+});

--- a/crates/tidebreak-desktop/ui/src/code/FileViewer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/FileViewer.tsx
@@ -3,8 +3,10 @@ import Editor, { type OnMount } from "@monaco-editor/react";
 
 import type { ApiClient } from "../api/client";
 import type { CodeWorkspaceBlob } from "../api/types";
+import { ImageViewer } from "@/components/document/image-viewer";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import type { FileBytesSource } from "@/document/useFileDownload";
 import { useTheme } from "@/theme";
 import { configureMonaco, monacoLanguage, monacoTheme } from "./monacoEnv";
 import { MiddleTruncate } from "./MiddleTruncate";
@@ -23,7 +25,7 @@ export function FileViewer({
   revealRevision = 0,
   onOpenInEditor,
 }: {
-  client: Pick<ApiClient, "getCodeWorkspaceBlob">;
+  client: Pick<ApiClient, "getCodeWorkspaceBlob" | "getCodeWorkspaceFile">;
   workspaceId: string;
   path: string;
   contentRevision?: number;
@@ -87,6 +89,9 @@ export function FileViewer({
       )}
       {data && (
         <BlobBody
+          client={client}
+          workspaceId={workspaceId}
+          contentRevision={contentRevision}
           blob={data}
           theme={resolvedTheme}
           revealLine={revealLine}
@@ -98,11 +103,17 @@ export function FileViewer({
 }
 
 function BlobBody({
+  client,
+  workspaceId,
+  contentRevision,
   blob,
   theme,
   revealLine,
   revealRevision,
 }: {
+  client: Pick<ApiClient, "getCodeWorkspaceFile">;
+  workspaceId: string;
+  contentRevision: number;
   blob: CodeWorkspaceBlob;
   theme: "light" | "dark";
   revealLine?: number;
@@ -151,6 +162,20 @@ function BlobBody({
     reveal(revealLine);
   }, [reveal, revealLine, revealRevision]);
 
+  if (blob.binary && imageMediaTypeForPath(blob.path)) {
+    return (
+      <ImageViewer
+        source={workspaceFileSource(
+          client,
+          workspaceId,
+          blob.path,
+          contentRevision,
+        )}
+        className="bg-page-background min-h-0 flex-1"
+      />
+    );
+  }
+
   if (blob.binary) {
     return (
       <p className="text-muted-foreground px-3 py-6 text-sm">
@@ -194,4 +219,35 @@ function BlobBody({
       </div>
     </>
   );
+}
+
+const IMAGE_MEDIA_TYPES = new Map([
+  ["avif", "image/avif"],
+  ["bmp", "image/bmp"],
+  ["gif", "image/gif"],
+  ["ico", "image/x-icon"],
+  ["jpeg", "image/jpeg"],
+  ["jpg", "image/jpeg"],
+  ["png", "image/png"],
+  ["svg", "image/svg+xml"],
+  ["webp", "image/webp"],
+]);
+
+export function imageMediaTypeForPath(path: string): string | null {
+  const extension = path.toLowerCase().split(".").pop();
+  return extension ? (IMAGE_MEDIA_TYPES.get(extension) ?? null) : null;
+}
+
+function workspaceFileSource(
+  client: Pick<ApiClient, "getCodeWorkspaceFile">,
+  workspaceId: string,
+  path: string,
+  contentRevision: number,
+): FileBytesSource {
+  return {
+    id: `${workspaceId}/${path}`,
+    cacheKey: `workspace/${workspaceId}/${path}/${contentRevision}`,
+    fetch: (signal, onProgress) =>
+      client.getCodeWorkspaceFile(workspaceId, path, signal, onProgress),
+  };
 }

--- a/crates/tidebreak-desktop/ui/src/stories/FileViewer.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/FileViewer.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { ApiClient } from "@/api/client";
+import { FileViewer } from "@/code/FileViewer";
+
+type FileScenario = "image" | "image-failure" | "unsupported";
+
+const imageSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <rect width="1200" height="800" fill="#e8ecef"/>
+  <rect x="72" y="72" width="1056" height="656" rx="24" fill="#fbfcfd" stroke="#c7d0d8"/>
+  <text x="124" y="156" font-family="system-ui, sans-serif" font-size="30" font-weight="600" fill="#23313c">Workspace architecture</text>
+  <text x="124" y="196" font-family="system-ui, sans-serif" font-size="17" fill="#687985">Review capture · September 9, 2026</text>
+  <rect x="124" y="258" width="260" height="166" rx="14" fill="#dce8e7" stroke="#aac2c0"/>
+  <rect x="470" y="258" width="260" height="166" rx="14" fill="#e5e8f0" stroke="#b8bfd0"/>
+  <rect x="816" y="258" width="260" height="166" rx="14" fill="#e9e5ef" stroke="#c6bcd0"/>
+  <path d="M384 341h86M730 341h86" stroke="#7c8c97" stroke-width="4" stroke-linecap="round"/>
+  <text x="160" y="334" font-family="system-ui, sans-serif" font-size="22" font-weight="600" fill="#29413f">Conversation</text>
+  <text x="506" y="334" font-family="system-ui, sans-serif" font-size="22" font-weight="600" fill="#30394d">Workspace</text>
+  <text x="852" y="334" font-family="system-ui, sans-serif" font-size="22" font-weight="600" fill="#42364e">Review</text>
+  <text x="160" y="374" font-family="system-ui, sans-serif" font-size="16" fill="#61706f">Intent and progress</text>
+  <text x="506" y="374" font-family="system-ui, sans-serif" font-size="16" fill="#697184">Files and terminal</text>
+  <text x="852" y="374" font-family="system-ui, sans-serif" font-size="16" fill="#766b7e">Checks and comments</text>
+  <rect x="124" y="500" width="952" height="142" rx="14" fill="#f2f4f5" stroke="#d4dadd"/>
+  <text x="160" y="555" font-family="ui-monospace, monospace" font-size="16" fill="#52616b">assets/workspace-architecture.svg</text>
+  <text x="160" y="598" font-family="system-ui, sans-serif" font-size="18" fill="#33424c">Image files open in the same center pane as source files.</text>
+</svg>`;
+
+function clientFor(scenario: FileScenario) {
+  const image = scenario !== "unsupported";
+  return {
+    getCodeWorkspaceBlob: async () => ({
+      path: image ? "assets/workspace-architecture.svg" : "build/archive.zip",
+      content: "",
+      truncated: false,
+      binary: true,
+    }),
+    getCodeWorkspaceFile: async () => {
+      if (scenario === "image-failure") {
+        throw new Error("The workspace file could not be read.");
+      }
+      return {
+        bytes: new TextEncoder().encode(imageSvg),
+        contentType: "image/svg+xml",
+      };
+    },
+  } as Pick<ApiClient, "getCodeWorkspaceBlob" | "getCodeWorkspaceFile">;
+}
+
+function FileViewerStory({ scenario }: { scenario: FileScenario }) {
+  const path =
+    scenario === "unsupported"
+      ? "build/archive.zip"
+      : "assets/workspace-architecture.svg";
+  return (
+    <div className="h-[680px] overflow-hidden rounded-lg border bg-page-background">
+      <FileViewer
+        client={clientFor(scenario)}
+        workspaceId="workspace-storybook"
+        path={path}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Code/File viewer",
+  component: FileViewerStory,
+  args: { scenario: "image" },
+  argTypes: {
+    scenario: {
+      control: "select",
+      options: ["image", "image-failure", "unsupported"],
+    },
+  },
+} satisfies Meta<typeof FileViewerStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ImageFile: Story = {};
+
+export const ImageLoadFailure: Story = {
+  args: { scenario: "image-failure" },
+};
+
+export const UnsupportedBinaryFile: Story = {
+  args: { scenario: "unsupported" },
+};
+
+export const CompactImageFile: Story = {
+  globals: { viewport: { value: "compact", isRotated: false } },
+};

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -1017,6 +1017,10 @@ pub fn app(state: AppState) -> Router {
             get(routes::code::get_workspace_blob),
         )
         .route(
+            "/code/workspaces/{id}/file",
+            get(routes::code::get_workspace_file),
+        )
+        .route(
             "/code/workspaces/{id}/diff",
             get(routes::code::get_workspace_diff),
         )

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -124,9 +124,10 @@ pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;
 pub(crate) use workspaces::{
     archive_workspace, create_remote_workspace, create_workspace, get_workspace,
-    get_workspace_blob, get_workspace_diff, get_worktree_root, list_workspace_files,
-    list_workspace_tree, list_workspaces, patch_workspace, propose_workspace_title,
-    restore_workspace, retry_workspace_setup, search_workspace, set_worktree_root,
+    get_workspace_blob, get_workspace_diff, get_workspace_file, get_worktree_root,
+    list_workspace_files, list_workspace_tree, list_workspaces, patch_workspace,
+    propose_workspace_title, restore_workspace, retry_workspace_setup, search_workspace,
+    set_worktree_root,
 };
 
 // App-token handlers do not reach `AppState.code` directly. They extract a

--- a/crates/tidebreak-server-api/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server-api/src/routes/code/workspaces.rs
@@ -1,12 +1,14 @@
 use std::time::Duration;
 
+use axum::body::Body;
 use axum::extract::State;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
 
 use crate::code::ScopedCode;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
+use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
 
 use super::types::{
@@ -271,6 +273,29 @@ pub async fn get_workspace_blob(
         truncated: blob.truncated,
         binary: blob.binary,
     }))
+}
+
+pub async fn get_workspace_file(
+    code: ScopedCode,
+    Path(id): Path<WorkspaceId>,
+    Query(query): Query<WorkspaceBlobQuery>,
+) -> Result<Response, ServerError> {
+    let file = code.workspace_file(id, &query.path).await?;
+    let content_length = u64::try_from(file.bytes.len())
+        .map_err(|_| ServerError::internal("workspace file length exceeds u64"))?;
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, file.media_type)
+        .header(header::CONTENT_LENGTH, content_length.to_string())
+        .header(header::CACHE_CONTROL, "no-store")
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .header(header::CONTENT_SECURITY_POLICY, SERVED_BYTES_CONTENT_POLICY)
+        .header(header::REFERRER_POLICY, "no-referrer")
+        .header(header::CONTENT_DISPOSITION, "inline")
+        .body(Body::from(file.bytes))
+        .map_err(|error| {
+            ServerError::internal(format!("failed to build workspace file response: {error}"))
+        })
 }
 
 pub async fn list_workspace_files(

--- a/crates/tidebreak-server-api/src/tests/code_workspace.rs
+++ b/crates/tidebreak-server-api/src/tests/code_workspace.rs
@@ -377,6 +377,59 @@ async fn workspace_tree_is_bounded_ignores_and_never_returns_contents() {
     assert_eq!(bounded_search["truncated"], true);
 }
 
+#[tokio::test]
+async fn workspace_file_serves_original_image_bytes_with_safe_headers() {
+    let (router, token, _runtime, dir) = code_app(plain_text_script()).await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let worktree = std::path::PathBuf::from(workspace["worktree_path"].as_str().unwrap());
+    let png = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR";
+    std::fs::write(worktree.join("preview.png"), png).unwrap();
+
+    let response = client
+        .get(format!(
+            "http://{addr}/code/workspaces/{}/file",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .query(&[("path", "preview.png")])
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        response.headers()[reqwest::header::CONTENT_TYPE],
+        "image/png"
+    );
+    assert_eq!(
+        response.headers()[reqwest::header::CACHE_CONTROL],
+        "no-store"
+    );
+    assert_eq!(
+        response.headers()[reqwest::header::X_CONTENT_TYPE_OPTIONS],
+        "nosniff"
+    );
+    assert_eq!(
+        response.headers()[reqwest::header::CONTENT_DISPOSITION],
+        "inline"
+    );
+    assert_eq!(
+        response.headers()[reqwest::header::REFERRER_POLICY],
+        "no-referrer"
+    );
+    assert!(response
+        .headers()
+        .contains_key(reqwest::header::CONTENT_SECURITY_POLICY));
+    assert_eq!(
+        response.headers()[reqwest::header::CONTENT_LENGTH],
+        png.len().to_string()
+    );
+    assert_eq!(response.bytes().await.unwrap().as_ref(), png);
+}
+
 /// Archive keeps the branch; restore puts a checkout back under the same
 /// workspace row. Committed work returns, force-discarded work stays gone,
 /// and restoring an already-active workspace is a no-op.

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -987,6 +987,18 @@ impl CodeRuntime {
             .map_err(map_worktree)
     }
 
+    pub(crate) async fn workspace_file(
+        &self,
+        owner: &OwnerId,
+        workspace_id: WorkspaceId,
+        path: &str,
+    ) -> Result<worktree::WorktreeFile, ServerError> {
+        let workspace = self.require_live_workspace(owner, workspace_id).await?;
+        worktree::read_worktree_file_bytes(std::path::Path::new(&workspace.worktree_path), path)
+            .await
+            .map_err(map_worktree)
+    }
+
     pub(crate) async fn workspace_diff(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -473,6 +473,14 @@ impl ScopedCode {
         self.runtime.workspace_blob(&self.owner, id, path).await
     }
 
+    pub async fn workspace_file(
+        &self,
+        id: WorkspaceId,
+        path: &str,
+    ) -> Result<worktree::WorktreeFile, ServerError> {
+        self.runtime.workspace_file(&self.owner, id, path).await
+    }
+
     pub async fn workspace_files(
         &self,
         id: WorkspaceId,

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -1942,6 +1942,7 @@ pub fn two_word_name(seed: u128) -> String {
 }
 
 const MAX_BLOB_BYTES: usize = 512 * 1_024;
+const MAX_VIEWABLE_FILE_BYTES: usize = 16 * 1_024 * 1_024;
 
 /// One worktree file's text, bounded so a huge blob cannot fill the viewer.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1952,31 +1953,20 @@ pub struct WorktreeBlob {
     pub binary: bool,
 }
 
+/// One worktree file's original bytes for an inline viewer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeFile {
+    pub path: String,
+    pub bytes: Vec<u8>,
+    pub media_type: String,
+}
+
 /// Read one relative worktree file as UTF-8 text.
 pub async fn read_worktree_file(
     worktree_path: &Path,
     relative: &str,
 ) -> Result<WorktreeBlob, WorktreeError> {
-    let rel = validate_relative_file(relative)?;
-    let abs = worktree_path.join(&rel);
-    let canonical_root = tokio::fs::canonicalize(worktree_path)
-        .await
-        .map_err(|err| WorktreeError::internal(format!("could not resolve the worktree: {err}")))?;
-    let canonical = tokio::fs::canonicalize(&abs)
-        .await
-        .map_err(|_| WorktreeError::user(format!("file not found: {}", rel.display())))?;
-    if !canonical.starts_with(&canonical_root) {
-        return Err(WorktreeError::user("path must stay inside the worktree"));
-    }
-    let metadata = tokio::fs::metadata(&canonical).await.map_err(|err| {
-        WorktreeError::internal(format!("could not read {}: {err}", rel.display()))
-    })?;
-    if !metadata.is_file() {
-        return Err(WorktreeError::user(format!(
-            "{} is not a file",
-            rel.display()
-        )));
-    }
+    let (rel, canonical) = resolve_worktree_file(worktree_path, relative).await?;
     let file = tokio::fs::File::open(&canonical).await.map_err(|err| {
         WorktreeError::internal(format!("could not read {}: {err}", rel.display()))
     })?;
@@ -2007,6 +1997,64 @@ pub async fn read_worktree_file(
         truncated,
         binary: false,
     })
+}
+
+/// Read one relative worktree file as original bytes for an inline viewer.
+pub async fn read_worktree_file_bytes(
+    worktree_path: &Path,
+    relative: &str,
+) -> Result<WorktreeFile, WorktreeError> {
+    let (rel, canonical) = resolve_worktree_file(worktree_path, relative).await?;
+    let file = tokio::fs::File::open(&canonical).await.map_err(|err| {
+        WorktreeError::internal(format!("could not read {}: {err}", rel.display()))
+    })?;
+    let mut bytes = Vec::new();
+    let read = file
+        .take((MAX_VIEWABLE_FILE_BYTES as u64) + 1)
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|err| {
+            WorktreeError::internal(format!("could not read {}: {err}", rel.display()))
+        })?;
+    if read > MAX_VIEWABLE_FILE_BYTES {
+        return Err(WorktreeError::user(
+            "file is too large to preview; open it in your editor",
+        ));
+    }
+    let path = rel.to_string_lossy().replace('\\', "/");
+    let media_type = crate::media_type::sniff_media_type(&bytes, Some(&path));
+    Ok(WorktreeFile {
+        path,
+        bytes,
+        media_type,
+    })
+}
+
+async fn resolve_worktree_file(
+    worktree_path: &Path,
+    relative: &str,
+) -> Result<(PathBuf, PathBuf), WorktreeError> {
+    let rel = validate_relative_file(relative)?;
+    let abs = worktree_path.join(&rel);
+    let canonical_root = tokio::fs::canonicalize(worktree_path)
+        .await
+        .map_err(|err| WorktreeError::internal(format!("could not resolve the worktree: {err}")))?;
+    let canonical = tokio::fs::canonicalize(&abs)
+        .await
+        .map_err(|_| WorktreeError::user(format!("file not found: {}", rel.display())))?;
+    if !canonical.starts_with(&canonical_root) {
+        return Err(WorktreeError::user("path must stay inside the worktree"));
+    }
+    let metadata = tokio::fs::metadata(&canonical).await.map_err(|err| {
+        WorktreeError::internal(format!("could not read {}: {err}", rel.display()))
+    })?;
+    if !metadata.is_file() {
+        return Err(WorktreeError::user(format!(
+            "{} is not a file",
+            rel.display()
+        )));
+    }
+    Ok((rel, canonical))
 }
 
 fn validate_relative_file(value: &str) -> Result<PathBuf, WorktreeError> {
@@ -3178,6 +3226,23 @@ mod tests {
         assert_eq!(blob.content.len(), MAX_BLOB_BYTES);
         assert!(blob.content.starts_with("hello "));
         assert_ne!(blob.content, huge);
+    }
+
+    #[tokio::test]
+    async fn workspace_file_returns_original_image_bytes_and_media_type() {
+        let (_dir, repo) = init_repo();
+        let data = TempDir::new().unwrap();
+        let path = scratch_worktree(data.path(), "image-file");
+        create_ready(&repo, &path, "tidebreak/image-file", "main").await;
+        let png = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR";
+        std::fs::write(path.join("preview.png"), png).unwrap();
+
+        let file = read_worktree_file_bytes(&path, "preview.png")
+            .await
+            .unwrap();
+        assert_eq!(file.path, "preview.png");
+        assert_eq!(file.bytes, png);
+        assert_eq!(file.media_type, "image/png");
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Workspace image files currently appear as opaque binary files in the Code file viewer. This change serves bounded original workspace-file bytes through an authenticated route and renders supported images in the existing center pane.

The viewer now supports AVIF, BMP, GIF, ICO, JPEG, PNG, SVG, and WebP, including loading and failure states. Image cache keys include the workspace content revision so edited files refresh. Other binary files retain the current fallback.

The server confines paths to the workspace worktree, rejects files over 16 MiB, sniffs the response media type, and applies no-store, nosniff, sandboxed content security policy, no-referrer, and inline response headers. Existing text-file behavior and API routes remain compatible.

Validation:
- `cargo test -p tidebreak-server-core workspace_file_returns_original_image_bytes_and_media_type`
- `cargo test -p tidebreak-server workspace_file_serves_original_image_bytes_with_safe_headers`
- `cargo check -p tidebreak-server`
- `pnpm --dir crates/tidebreak-desktop/ui exec vitest run src/code/FileViewer.dom.test.tsx`
- `pnpm --dir crates/tidebreak-desktop/ui exec tsc --noEmit`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome format ...`
- `pnpm --dir crates/tidebreak-desktop/ui exec biome lint ...`
- `pnpm --dir crates/tidebreak-desktop/ui storybook:build`
- Visual review of desktop, compact, failure, and unsupported-binary stories
