### PR TITLE
ci: authorize the mobile deploy workflow to read the Expo token

### DIFF
--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -874,6 +874,7 @@ test("production secrets remain isolated to the release workflow", () => {
     .filter(([, source]) => source.includes("secrets."))
     .map(([name]) => name);
   const allowedSecretConsumers = new Set([
+    "build-mobile.yml",
     "publish-e2b-template.yml",
     "publish-whisper-helper.yml",
     "release-draft.yml",
@@ -1038,6 +1039,40 @@ test("production secrets remain isolated to the release workflow", () => {
     /\.github\/e2b-cli\/node_modules\/\.bin\/e2b --version/,
   );
   assert.doesNotMatch(publishJob, /npm install|@latest/);
+
+  // The mobile deploy is the one secret consumer reachable from a pull
+  // request, and deliberately so: the routing dry-run that comments on a
+  // mobile PR must ask EAS for the last finished build's runtimeVersion,
+  // which needs auth. Three properties keep that narrow, and each is
+  // asserted here rather than left to review. The trigger is `pull_request`,
+  // never `pull_request_target`, so a fork's run is handed an empty token
+  // instead of the real one. The credential is scoped to Expo alone — it
+  // must not reach the signing secrets. And every step that actually ships
+  // (OTA publish, binary build + store submission) is guarded off for
+  // pull_request events, so a PR run can only ever read.
+  const mobile = workflows["build-mobile.yml"];
+  if (mobile) {
+    assert.doesNotMatch(mobile, /^\s*pull_request_target:/m);
+    assert.deepEqual(
+      [...new Set(mobile.match(/secrets\.[A-Z0-9_]+/g))],
+      ["secrets.EXPO_TOKEN"],
+    );
+    assert.match(
+      mobile,
+      /^permissions:\n  contents: read\n  pull-requests: write$/m,
+    );
+    for (const name of ["Publish OTA", "Build binary and auto-submit"]) {
+      const step = mobile.match(
+        new RegExp(`- name: ${name}\\n[\\s\\S]*?(?=\\n\\s+- name:|$)`),
+      )?.[0];
+      assert.ok(step, `missing deploy step: ${name}`);
+      assert.match(
+        step,
+        /github\.event_name != 'pull_request'/,
+        `${name} must never run from a pull request`,
+      );
+    }
+  }
 });
 
 test("desktop voice delegates whisper.cpp to the verified helper", () => {


### PR DESCRIPTION
Prep PR for #3296 (fingerprint-routed mobile deploys), split out because the release-policy gate runs **main's** copy of `workflow-security.test.mjs` against a PR's files — by design, a PR cannot introduce a secret-reading workflow and authorize it in the same change. This PR is that authorization, reviewed on its own.

It takes the security-test file from #3296 verbatim:
- `build-mobile.yml` added to the allowed secret consumers (subset check, so the entry is inert until the workflow exists).
- Guarded content assertions that activate the moment `build-mobile.yml` lands: trigger is `pull_request` never `pull_request_target` (fork runs get an empty token), `secrets.EXPO_TOKEN` is the only secret it may read, `permissions` fixed at `contents: read` + `pull-requests: write`, and both shipping steps (OTA publish, binary build/submit) must be guarded off for `pull_request` events so PR runs can only read.

After this merges, #3296 re-runs against the updated base and its `release policy` lane goes green; its own diff on this file becomes a no-op.

`node --test scripts/*.test.mjs`: 257 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)