### PR TITLE
improve: preserve native browser dialog semantics

### DIFF
--- a/crates/tidebreak-desktop/Cargo.toml
+++ b/crates/tidebreak-desktop/Cargo.toml
@@ -72,6 +72,9 @@ tar = "=0.4.46"
 zip.workspace = true
 
 
+[dev-dependencies]
+tauri = { version = "=2.11.5", features = ["test"] }
+
 [target.'cfg(any(target_os = "macos", target_os = "linux", windows))'.dependencies]
 tauri-plugin-single-instance = { version = "=2.4.4", features = ["deep-link"] }
 

--- a/crates/tidebreak-desktop/src/lib.rs
+++ b/crates/tidebreak-desktop/src/lib.rs
@@ -63,6 +63,7 @@ mod host_authority;
 mod image_attachments;
 mod menu;
 mod native_cursor_overlay;
+mod native_dialogs;
 mod native_runtime_adapter;
 mod node_install;
 mod office_install;
@@ -854,7 +855,7 @@ pub fn run() {
 
     let app = builder
         .plugin(tauri_plugin_deep_link::init())
-        .plugin(tauri_plugin_dialog::init())
+        .plugin(native_dialogs::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/crates/tidebreak-desktop/src/native_dialogs.rs
+++ b/crates/tidebreak-desktop/src/native_dialogs.rs
@@ -1,0 +1,73 @@
+//! Keep native dialog commands without replacing browser JavaScript globals.
+//!
+//! The upstream plugin injects `window.confirm = async ...` into every webview.
+//! A website can treat that Promise as consent, and its dialogs bypass WebKit's
+//! agent guard. Tidebreak uses explicit dialog commands, so it needs no overrides.
+
+use tauri::ipc::Invoke;
+use tauri::plugin::{Plugin, TauriPlugin};
+use tauri::webview::PageLoadPayload;
+use tauri::{AppHandle, RunEvent, Runtime, Webview, Window};
+
+pub(crate) fn init<R: Runtime>() -> impl Plugin<R> {
+    NativeDialogs(tauri_plugin_dialog::init())
+}
+
+struct NativeDialogs<R: Runtime>(TauriPlugin<R>);
+
+impl<R: Runtime> Plugin<R> for NativeDialogs<R> {
+    fn name(&self) -> &'static str {
+        self.0.name()
+    }
+
+    fn initialize(
+        &mut self,
+        app: &AppHandle<R>,
+        config: serde_json::Value,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.0.initialize(app, config)
+    }
+
+    // Leave both initialization-script methods at their default of None. The
+    // native browser keeps its synchronous alert, confirm, and prompt behavior.
+
+    fn window_created(&mut self, window: Window<R>) {
+        self.0.window_created(window);
+    }
+
+    fn webview_created(&mut self, webview: Webview<R>) {
+        self.0.webview_created(webview);
+    }
+
+    fn on_navigation(&mut self, webview: &Webview<R>, url: &url::Url) -> bool {
+        self.0.on_navigation(webview, url)
+    }
+
+    fn on_page_load(&mut self, webview: &Webview<R>, payload: &PageLoadPayload<'_>) {
+        self.0.on_page_load(webview, payload);
+    }
+
+    fn on_event(&mut self, app: &AppHandle<R>, event: &RunEvent) {
+        self.0.on_event(app, event);
+    }
+
+    fn extend_api(&mut self, invoke: Invoke<R>) -> bool {
+        self.0.extend_api(invoke)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dialog_plugin_preserves_browser_globals() {
+        let plugin = init::<tauri::Wry>();
+        assert_eq!(plugin.name(), "dialog");
+        assert!(
+            plugin.initialization_script().is_none()
+                && plugin.initialization_script_2().is_none(),
+            "Browser pages must keep native synchronous dialogs instead of the plugin's Promise-returning confirm override"
+        );
+    }
+}

--- a/crates/tidebreak-desktop/src/native_dialogs.rs
+++ b/crates/tidebreak-desktop/src/native_dialogs.rs
@@ -61,6 +61,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn registered_plugin_initializes_native_dialog_state() {
+        use tauri::test::{mock_builder, mock_context, noop_assets, MockRuntime};
+        use tauri::Manager;
+        use tauri_plugin_dialog::{Dialog, DialogExt};
+
+        let app = mock_builder()
+            .plugin(init())
+            .build(mock_context(noop_assets()))
+            .expect("dialog plugin registers and initializes");
+        let state = app
+            .try_state::<Dialog<MockRuntime>>()
+            .expect("native dialog setup registers its managed state");
+        assert!(std::ptr::eq(app.dialog(), state.inner()));
+        let _file_picker = app.dialog().file();
+        let _message = app
+            .dialog()
+            .message("Native dialog setup remains available");
+    }
+
+    #[test]
     fn dialog_plugin_preserves_browser_globals() {
         let plugin = init::<tauri::Wry>();
         assert_eq!(plugin.name(), "dialog");


### PR DESCRIPTION
## What changed

A website that calls `if (confirm(...))` receives a truthy Promise because the dialog plugin overwrites `window.confirm` in every webview. Live computer-use testing reproduced `Confirm: [object Promise]`. The override also routes page alerts around the independent browser's WebKit dialog guard.

Register the upstream plugin through a wrapper that omits its JavaScript overrides. Browser pages retain synchronous native dialogs, so the independent browser guard can cancel confirmation and text prompts. Forward native setup, commands, and lifecycle hooks unchanged. Tidebreak's own UI already uses explicit dialog commands rather than the replaced globals.

## Validation

- `cargo test -p tidebreak-desktop --lib native_dialogs -- --nocapture`: 2 passed, 0 failed.
- Formatting and diff checks pass.
- The signed macOS app passes live alert, confirmation, prompt, and file-picker tests. The page observes `Confirm: false` and `Prompt: null`. Every dialog cancellation is reported, and the pointer, foreground app, native responder, and selected editor remain unchanged.
- A Tauri mock-runtime regression test registers this wrapper through `Builder::plugin`, verifies managed `Dialog` state, and exercises `DialogExt` builder access without opening native UI.

## Compatibility and risk

No dependency, wire format, or permission changes. Explicit dialog commands and native permission prompts keep the upstream implementation. Ordinary websites regain standard browser dialog semantics; agent-owned WebKit views retain their existing native dialog guard. The wrapper forwards the upstream plugin's other hooks so this change is limited to its global JavaScript overrides.
