### PR TITLE
improve(slack): approve channel repository scopes before tasks

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/confirm.rs
+++ b/crates/tidebreak-core/src/db/ops/code/confirm.rs
@@ -1,10 +1,13 @@
-//! Per-channel repository confirmation under a workspace grant.
+//! The repository scope an administrator approves for each channel.
 
+use sea_orm::sea_query::{Expr, ExprTrait, Func};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
 };
 
-use crate::code::{CodeChannelRepositoryConfirm, CodeChannelRepositoryState, CodeGrantId};
+use crate::code::{
+    CodeChannelRepositoryConfirm, CodeChannelRepositoryState, CodeGrantId, CodeGrantKind,
+};
 use crate::error::{AgentError, Result};
 use crate::OwnerId;
 
@@ -24,6 +27,27 @@ async fn grant_owned_by(
             .map_err(store_err)?
             .is_some(),
     )
+}
+
+/// Serialize scope changes with grant revocation on both SQLite and PostgreSQL.
+async fn lock_live_workspace_grant(
+    conn: &impl sea_orm::ConnectionTrait,
+    owner: &OwnerId,
+    grant_id: CodeGrantId,
+) -> Result<bool> {
+    let locked = entities::code_external_grant::Entity::update_many()
+        .col_expr(
+            entities::code_external_grant::Column::Id,
+            sea_orm::sea_query::Expr::col(entities::code_external_grant::Column::Id),
+        )
+        .filter(entities::code_external_grant::Column::Id.eq(grant_id.0))
+        .filter(entities::code_external_grant::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_grant::Column::Kind.eq(CodeGrantKind::Workspace.as_str()))
+        .filter(entities::code_external_grant::Column::RevokedAt.is_null())
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(locked.rows_affected == 1)
 }
 
 fn confirm_from_model(
@@ -81,7 +105,13 @@ pub async fn channel_repository_is_confirmed(
     Ok(entities::code_channel_repository_confirm::Entity::find()
         .filter(entities::code_channel_repository_confirm::Column::GrantId.eq(grant_id.0))
         .filter(entities::code_channel_repository_confirm::Column::ChannelId.eq(channel_id))
-        .filter(entities::code_channel_repository_confirm::Column::Repository.eq(repository))
+        // Older approvals can retain the forge's mixed-case spelling.
+        .filter(
+            Func::lower(Expr::col(
+                entities::code_channel_repository_confirm::Column::Repository,
+            ))
+            .eq(repository.to_ascii_lowercase()),
+        )
         .filter(
             entities::code_channel_repository_confirm::Column::State
                 .eq(CodeChannelRepositoryState::Confirmed.as_str()),
@@ -92,8 +122,8 @@ pub async fn channel_repository_is_confirmed(
         .is_some())
 }
 
-/// Record a pending confirmation. A different pending repository for the same
-/// channel is superseded. Returns the pending row.
+/// Record a repository request without replacing other requests in the channel.
+/// An approval that wins a concurrent request stays confirmed.
 pub async fn ensure_pending_channel_repository(
     store: &DbStore,
     owner: &OwnerId,
@@ -104,38 +134,48 @@ pub async fn ensure_pending_channel_repository(
     set_by_display: &str,
 ) -> Result<CodeChannelRepositoryConfirm> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    if !grant_owned_by(&transaction, owner, grant_id).await? {
+    if !lock_live_workspace_grant(&transaction, owner, grant_id).await? {
         transaction.commit().await.map_err(store_err)?;
-        return Err(AgentError::Store("grant not found".into()));
+        return Err(AgentError::Store("live workspace grant not found".into()));
     }
-    let now = database_now(&transaction).await?;
-    let pending = entities::code_channel_repository_confirm::Entity::find()
+    let existing = entities::code_channel_repository_confirm::Entity::find()
         .filter(entities::code_channel_repository_confirm::Column::GrantId.eq(grant_id.0))
         .filter(entities::code_channel_repository_confirm::Column::ChannelId.eq(channel_id))
         .filter(
-            entities::code_channel_repository_confirm::Column::State
-                .eq(CodeChannelRepositoryState::Pending.as_str()),
+            Func::lower(Expr::col(
+                entities::code_channel_repository_confirm::Column::Repository,
+            ))
+            .eq(repository.to_ascii_lowercase()),
         )
-        .all(&transaction)
+        .one(&transaction)
         .await
         .map_err(store_err)?;
-    for row in pending {
-        if row.repository == repository {
+    if let Some(row) = existing {
+        if row.state != CodeChannelRepositoryState::Superseded.as_str() {
             let confirm = confirm_from_model(row)?;
             transaction.commit().await.map_err(store_err)?;
             return Ok(confirm);
         }
-        entities::code_channel_repository_confirm::ActiveModel {
+        // Older releases superseded the first request when a second repository
+        // was selected. A retry must revive that request instead of colliding
+        // with its primary key.
+        let updated = entities::code_channel_repository_confirm::ActiveModel {
             grant_id: Set(row.grant_id),
-            channel_id: Set(row.channel_id.clone()),
-            repository: Set(row.repository.clone()),
-            state: Set(CodeChannelRepositoryState::Superseded.as_str().to_owned()),
+            channel_id: Set(row.channel_id),
+            repository: Set(row.repository),
+            state: Set(CodeChannelRepositoryState::Pending.as_str().to_owned()),
+            set_by_identity: Set(set_by_identity.to_owned()),
+            set_by_display: Set(set_by_display.to_owned()),
+            confirmed_by: Set(None),
             ..Default::default()
         }
         .update(&transaction)
         .await
         .map_err(store_err)?;
+        transaction.commit().await.map_err(store_err)?;
+        return confirm_from_model(updated);
     }
+    let now = database_now(&transaction).await?;
     let model = entities::code_channel_repository_confirm::ActiveModel {
         grant_id: Set(grant_id.0),
         channel_id: Set(channel_id.to_owned()),
@@ -151,6 +191,81 @@ pub async fn ensure_pending_channel_repository(
     confirm_from_model(inserted)
 }
 
+/// Approve an explicit repository scope before or after a channel requests it.
+/// The caller validates canonical repository names and administrator authority.
+/// Existing approvals remain valid; the whole batch commits together.
+pub async fn approve_channel_repositories(
+    store: &DbStore,
+    owner: &OwnerId,
+    grant_id: CodeGrantId,
+    channel_id: &str,
+    repositories: &[String],
+    admin: &OwnerId,
+) -> Result<bool> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !lock_live_workspace_grant(&transaction, owner, grant_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(false);
+    }
+    let now = database_now(&transaction).await?;
+    for repository in repositories {
+        use entities::code_channel_repository_confirm::{ActiveModel, Column, Entity};
+        let aliases = Entity::find()
+            .filter(Column::GrantId.eq(grant_id.0))
+            .filter(Column::ChannelId.eq(channel_id))
+            .filter(Func::lower(Expr::col(Column::Repository)).eq(repository))
+            .order_by_asc(Column::CreatedAt)
+            .order_by_asc(Column::Repository)
+            .all(&transaction)
+            .await
+            .map_err(store_err)?;
+        let previous = aliases
+            .iter()
+            .find(|row| row.repository == *repository)
+            .or_else(|| aliases.first());
+        Entity::insert(ActiveModel {
+            grant_id: Set(grant_id.0),
+            channel_id: Set(channel_id.to_owned()),
+            repository: Set(repository.clone()),
+            set_by_identity: Set(previous.map_or_else(
+                || admin.as_str().to_owned(),
+                |row| row.set_by_identity.clone(),
+            )),
+            set_by_display: Set(previous.map_or_else(
+                || "Administrator".to_owned(),
+                |row| row.set_by_display.clone(),
+            )),
+            state: Set(CodeChannelRepositoryState::Confirmed.as_str().to_owned()),
+            confirmed_by: Set(Some(admin.as_str().to_owned())),
+            created_at: Set(previous.map_or(now, |row| row.created_at)),
+        })
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::columns([
+                Column::GrantId,
+                Column::ChannelId,
+                Column::Repository,
+            ])
+            .update_columns([Column::State, Column::ConfirmedBy])
+            .to_owned(),
+        )
+        .exec_without_returning(&transaction)
+        .await
+        .map_err(store_err)?;
+        // Collapse historical casing aliases so a completed approval cannot
+        // leave the same repository displayed as pending.
+        Entity::delete_many()
+            .filter(Column::GrantId.eq(grant_id.0))
+            .filter(Column::ChannelId.eq(channel_id))
+            .filter(Func::lower(Expr::col(Column::Repository)).eq(repository))
+            .filter(Column::Repository.ne(repository))
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
+    }
+    transaction.commit().await.map_err(store_err)?;
+    Ok(true)
+}
+
 /// An admin confirms a pending `(grant, channel, repository)` pair.
 pub async fn confirm_channel_repository(
     store: &DbStore,
@@ -161,7 +276,7 @@ pub async fn confirm_channel_repository(
     admin: &OwnerId,
 ) -> Result<Option<CodeChannelRepositoryConfirm>> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    if !grant_owned_by(&transaction, owner, grant_id).await? {
+    if !lock_live_workspace_grant(&transaction, owner, grant_id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }

--- a/crates/tidebreak-core/src/db/tests.rs
+++ b/crates/tidebreak-core/src/db/tests.rs
@@ -16,6 +16,7 @@ mod blob_retirement;
 mod chat;
 mod client_wait;
 mod code;
+mod code_channel_scope;
 mod connected_app;
 mod context_checkpoint;
 mod delegated_file_read;

--- a/crates/tidebreak-core/src/db/tests/code_channel_scope.rs
+++ b/crates/tidebreak-core/src/db/tests/code_channel_scope.rs
@@ -1,0 +1,231 @@
+use super::temp_store;
+use crate::code::{CodeChannelRepositoryState, CodeGrantKind};
+use crate::db::code::*;
+use crate::db::{entities, DbStore};
+use crate::OwnerId;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+async fn grant(store: &DbStore, owner: &OwnerId, kind: CodeGrantKind) -> crate::CodeExternalGrant {
+    mint_external_grant(
+        store,
+        owner,
+        MintGrantSubject {
+            channel_kind: "slack",
+            external_identity: kind.as_str(),
+            workspace_identity: "T1",
+            kind,
+        },
+        &uuid::Uuid::new_v4().simple().to_string().repeat(2),
+        &uuid::Uuid::new_v4().simple().to_string().repeat(2),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn channel_scope_approves_several_repositories_before_a_task_and_keeps_requests() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::new("service").unwrap();
+    let admin = OwnerId::new("admin").unwrap();
+    let grant = grant(&store, &owner, CodeGrantKind::Workspace).await;
+    let repositories = vec!["acme/first".to_owned(), "acme/second".to_owned()];
+    for repo in &repositories {
+        ensure_pending_channel_repository(&store, &owner, grant.id, "C1", repo, "U1", "Casey")
+            .await
+            .unwrap();
+    }
+    let pending = list_channel_repository_confirms(&store, &owner, grant.id)
+        .await
+        .unwrap();
+    assert_eq!(pending.len(), 2);
+    assert!(pending
+        .iter()
+        .all(|r| r.state == CodeChannelRepositoryState::Pending));
+    assert!(
+        approve_channel_repositories(&store, &owner, grant.id, "C1", &repositories, &admin)
+            .await
+            .unwrap()
+    );
+    // A second channel can have its whole scope approved before its first request.
+    assert!(
+        approve_channel_repositories(&store, &owner, grant.id, "C2", &repositories, &admin)
+            .await
+            .unwrap()
+    );
+    assert!(approve_channel_repositories(
+        &store,
+        &owner,
+        grant.id,
+        "C1",
+        &["acme/third".to_owned()],
+        &admin
+    )
+    .await
+    .unwrap());
+    for channel in ["C1", "C2"] {
+        for repo in &repositories {
+            assert!(
+                channel_repository_is_confirmed(&store, &owner, grant.id, channel, repo)
+                    .await
+                    .unwrap()
+            );
+            let retried = ensure_pending_channel_repository(
+                &store, &owner, grant.id, channel, repo, "U1", "Casey",
+            )
+            .await
+            .unwrap();
+            assert_eq!(retried.state, CodeChannelRepositoryState::Confirmed);
+        }
+    }
+    assert!(
+        !channel_repository_is_confirmed(&store, &owner, grant.id, "C2", "acme/third")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !channel_repository_is_confirmed(&store, &admin, grant.id, "C1", "acme/first")
+            .await
+            .unwrap()
+    );
+    assert!(list_channel_repository_confirms(&store, &owner, grant.id)
+        .await
+        .unwrap()
+        .iter()
+        .all(|r| r.confirmed_by.as_ref() == Some(&admin)));
+}
+
+#[tokio::test]
+async fn channel_scope_recovers_superseded_requests_and_refuses_revoked_or_person_grants() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::new("service").unwrap();
+    let admin = OwnerId::new("admin").unwrap();
+    let grant = grant(&store, &owner, CodeGrantKind::Workspace).await;
+    ensure_pending_channel_repository(&store, &owner, grant.id, "C1", "acme/first", "U1", "Casey")
+        .await
+        .unwrap();
+    entities::code_channel_repository_confirm::Entity::update_many()
+        .col_expr(
+            entities::code_channel_repository_confirm::Column::State,
+            sea_orm::sea_query::Expr::value("superseded"),
+        )
+        .filter(entities::code_channel_repository_confirm::Column::GrantId.eq(grant.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let retried = ensure_pending_channel_repository(
+        &store,
+        &owner,
+        grant.id,
+        "C1",
+        "acme/first",
+        "U2",
+        "Jordan",
+    )
+    .await
+    .unwrap();
+    assert_eq!(retried.state, CodeChannelRepositoryState::Pending);
+    assert_eq!(retried.set_by_identity, "U2");
+    let repos = vec!["acme/first".to_owned()];
+    let (approve, request) = tokio::join!(
+        approve_channel_repositories(&store, &owner, grant.id, "C1", &repos, &admin),
+        ensure_pending_channel_repository(
+            &store,
+            &owner,
+            grant.id,
+            "C1",
+            "acme/first",
+            "U1",
+            "Casey"
+        ),
+    );
+    assert!(approve.unwrap());
+    request.unwrap();
+    assert!(
+        channel_repository_is_confirmed(&store, &owner, grant.id, "C1", "acme/first")
+            .await
+            .unwrap()
+    );
+    revoke_external_grant(&store, &owner, grant.id, "test")
+        .await
+        .unwrap();
+    assert!(
+        !approve_channel_repositories(&store, &owner, grant.id, "C1", &repos, &admin)
+            .await
+            .unwrap()
+    );
+    assert!(
+        confirm_channel_repository(&store, &owner, grant.id, "C1", "acme/first", &admin)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let personal = self::grant(&store, &owner, CodeGrantKind::Person).await;
+    assert!(
+        !approve_channel_repositories(&store, &owner, personal.id, "C1", &repos, &admin)
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn channel_scope_preserves_existing_mixed_case_approvals() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::new("service").unwrap();
+    let admin = OwnerId::new("admin").unwrap();
+    let grant = grant(&store, &owner, CodeGrantKind::Workspace).await;
+    ensure_pending_channel_repository(&store, &owner, grant.id, "C1", "ACME/Tools", "U1", "Casey")
+        .await
+        .unwrap();
+    confirm_channel_repository(&store, &owner, grant.id, "C1", "ACME/Tools", &admin)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        channel_repository_is_confirmed(&store, &owner, grant.id, "C1", "acme/tools")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !channel_repository_is_confirmed(&store, &owner, grant.id, "C2", "acme/tools")
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn channel_scope_bulk_approval_clears_historical_case_aliases() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::new("service").unwrap();
+    let admin = OwnerId::new("admin").unwrap();
+    let grant = grant(&store, &owner, CodeGrantKind::Workspace).await;
+    ensure_pending_channel_repository(&store, &owner, grant.id, "C1", "ACME/Tools", "U1", "Casey")
+        .await
+        .unwrap();
+    ensure_pending_channel_repository(&store, &owner, grant.id, "C1", "acme/tools", "U2", "Jordan")
+        .await
+        .unwrap();
+    assert_eq!(
+        list_channel_repository_confirms(&store, &owner, grant.id)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(approve_channel_repositories(
+        &store,
+        &owner,
+        grant.id,
+        "C1",
+        &["acme/tools".to_owned()],
+        &admin
+    )
+    .await
+    .unwrap());
+    let rows = list_channel_repository_confirms(&store, &owner, grant.id)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].repository, "acme/tools");
+    assert_eq!(rows[0].state, CodeChannelRepositoryState::Confirmed);
+    assert_eq!(rows[0].set_by_identity, "U1");
+}

--- a/crates/tidebreak-desktop/ui/src/WorkspaceApprovalRoute.tsx
+++ b/crates/tidebreak-desktop/ui/src/WorkspaceApprovalRoute.tsx
@@ -146,8 +146,10 @@ export function WorkspaceApprovalView({
                 <p className="text-sm leading-relaxed">
                   Run channel sessions for {channelLabel(page.channel_kind)}{" "}
                   workspace {page.workspace_name} as {page.display_name}? The
-                  shared identity&apos;s forge credential is the ceiling; you
-                  still confirm each channel&apos;s repository.
+                  shared GitHub identity must have access to each repository. In
+                  Settings → Channels, approve the repositories each channel can
+                  use. Agents can then choose any approved repository and work
+                  across them.
                 </p>
                 <div className="flex gap-2">
                   <Button

--- a/crates/tidebreak-desktop/ui/src/api/client/code-grants.test.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/code-grants.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiClient, HttpError } from "../../api";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("channel repository approval", () => {
+  it("encodes both path segments, sends explicit repositories, and accepts 204", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://localhost", "test-token");
+    await expect(
+      client.approveWorkspaceGrantChannelRepositories("grant/1", "C/#1", [
+        "acme/tools",
+        "https://github.com/acme/web",
+      ]),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      "http://localhost/deployment/code/grants/workspace/grant%2F1/channels/C%2F%231/repositories/approve",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          repositories: ["acme/tools", "https://github.com/acme/web"],
+        }),
+      },
+    );
+  });
+
+  it("preserves an admin-only authorization failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ message: "administrator access required" }),
+            { status: 403 },
+          ),
+        ),
+    );
+    const client = new ApiClient("http://localhost", "test-token");
+    await expect(
+      client.approveWorkspaceGrantChannelRepositories("grant-1", "C1", [
+        "acme/tools",
+      ]),
+    ).rejects.toEqual(new HttpError(403, "403: administrator access required"));
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/api/client/code-grants.ts
+++ b/crates/tidebreak-desktop/ui/src/api/client/code-grants.ts
@@ -84,6 +84,23 @@ export function withCodeGrantsApi<TBase extends Constructor<HttpCore>>(
       );
     }
 
+    /** Approve explicit repositories for a channel under a workspace grant. */
+    approveWorkspaceGrantChannelRepositories(
+      grantId: string,
+      channelId: string,
+      repositories: string[],
+    ): Promise<void> {
+      return this.json(
+        `/deployment/code/grants/workspace/${encodeURIComponent(grantId)}/channels/${encodeURIComponent(channelId)}/repositories/approve`,
+        {
+          method: "POST",
+          headers: this.headers(true),
+          body: JSON.stringify({ repositories }),
+        },
+        204,
+      );
+    }
+
     async getWorkspaceGrantPage(id: string): Promise<CodeConnectPage> {
       return requireParsed(
         parseCodeConnectPage(

--- a/crates/tidebreak-desktop/ui/src/settings/ChannelsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ChannelsPanel.dom.test.tsx
@@ -180,13 +180,11 @@ describe("ChannelsPanel", () => {
       />,
     );
     const channel = await screen.findByRole("region", { name: "Channel C1" });
-    await userEvent
-      .setup()
-      .click(
-        within(channel).getByRole("button", {
-          name: "Approve all pending repositories",
-        }),
-      );
+    await userEvent.setup().click(
+      within(channel).getByRole("button", {
+        name: "Approve all pending repositories",
+      }),
+    );
     await waitFor(() =>
       expect(approveWorkspaceGrantChannelRepositories).toHaveBeenCalledWith(
         workspace.id,
@@ -380,15 +378,13 @@ describe("ChannelsPanel", () => {
 
   it("keeps revoked workspace scopes visible without offering approval controls", async () => {
     const client = {
-      listCodeGrants: vi
-        .fn()
-        .mockResolvedValue([
-          {
-            ...workspace,
-            revoked_at: "2026-09-09T10:00:00Z",
-            revoked_reason: "Administrator revoked access",
-          },
-        ]),
+      listCodeGrants: vi.fn().mockResolvedValue([
+        {
+          ...workspace,
+          revoked_at: "2026-09-09T10:00:00Z",
+          revoked_reason: "Administrator revoked access",
+        },
+      ]),
     } as unknown as ApiClient;
     render(<ChannelsPanel client={client} />);
     await screen.findByRole("region", { name: "Channel C1" });

--- a/crates/tidebreak-desktop/ui/src/settings/ChannelsPanel.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ChannelsPanel.dom.test.tsx
@@ -34,6 +34,54 @@ const stolen: CodeGrantSnapshot = {
     "a rotated refresh token was replayed; the credential is treated as stolen",
 };
 
+const workspace: CodeGrantSnapshot = {
+  id: "6b1f9a34-0000-4000-8000-000000000009",
+  kind: "workspace",
+  channel_kind: "slack",
+  external_identity: "T-ACME",
+  display_name: "tidebreak-slack",
+  workspace_identity: "T-ACME",
+  workspace_name: "Acme Corp",
+  created_at: "2026-09-08T10:00:00Z",
+  channels: [
+    {
+      channel_id: "C1",
+      repository: "acme/tools",
+      state: "confirmed",
+      set_by_identity: "U1",
+      set_by_display: "Casey",
+    },
+    {
+      channel_id: "C1",
+      repository: "acme/web",
+      state: "pending",
+      set_by_identity: "U1",
+      set_by_display: "Casey",
+    },
+    {
+      channel_id: "C1",
+      repository: "acme/api",
+      state: "pending",
+      set_by_identity: "U1",
+      set_by_display: "Casey",
+    },
+    {
+      channel_id: "C1",
+      repository: "acme/legacy",
+      state: "superseded",
+      set_by_identity: "U1",
+      set_by_display: "Casey",
+    },
+    {
+      channel_id: "C2",
+      repository: "acme/private",
+      state: "pending",
+      set_by_identity: "U2",
+      set_by_display: "Sam",
+    },
+  ],
+};
+
 afterEach(cleanup);
 
 describe("ChannelsPanel", () => {
@@ -86,25 +134,6 @@ describe("ChannelsPanel", () => {
   });
 
   it("shows workspace grants with their channels and a revoke control", async () => {
-    const workspace: CodeGrantSnapshot = {
-      id: "6b1f9a34-0000-4000-8000-000000000009",
-      kind: "workspace",
-      channel_kind: "slack",
-      external_identity: "T-ACME",
-      display_name: "tidebreak-slack",
-      workspace_identity: "T-ACME",
-      workspace_name: "Acme Corp",
-      created_at: "2026-09-08T10:00:00Z",
-      channels: [
-        {
-          channel_id: "C1",
-          repository: "acme/tools",
-          state: "confirmed",
-          set_by_identity: "U1",
-          set_by_display: "Casey",
-        },
-      ],
-    };
     const revokeCodeGrant = vi.fn(async () => ({
       ...workspace,
       revoked_at: "2026-09-08T11:00:00Z",
@@ -115,8 +144,312 @@ describe("ChannelsPanel", () => {
     } as unknown as ApiClient;
     render(<ChannelsPanel client={client} />);
     await screen.findByText("Workspace Acme Corp");
-    expect(screen.getByText(/C1 · acme\/tools \(confirmed\)/)).toBeTruthy();
+    const channel = screen.getByRole("region", { name: "Channel C1" });
+    expect(within(channel).getByText("acme/tools")).toBeTruthy();
+    expect(within(channel).getByText("Approved repositories")).toBeTruthy();
+    expect(within(channel).getByText("Pending approval")).toBeTruthy();
+    expect(within(channel).getByText("Previous repositories (1)")).toBeTruthy();
+    expect(within(channel).queryByText("acme/private")).toBeNull();
     expect(screen.getByRole("button", { name: "Revoke" })).toBeTruthy();
+  });
+
+  it("approves every pending repository in one channel and reloads its scope", async () => {
+    const approved = {
+      ...workspace,
+      channels: workspace.channels?.map((entry) =>
+        entry.channel_id === "C1" && entry.state === "pending"
+          ? { ...entry, state: "confirmed" }
+          : entry,
+      ),
+    };
+    const listCodeGrants = vi
+      .fn()
+      .mockResolvedValueOnce([workspace])
+      .mockResolvedValueOnce([approved]);
+    const approveWorkspaceGrantChannelRepositories = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    render(
+      <ChannelsPanel
+        client={
+          {
+            listCodeGrants,
+            approveWorkspaceGrantChannelRepositories,
+          } as unknown as ApiClient
+        }
+      />,
+    );
+    const channel = await screen.findByRole("region", { name: "Channel C1" });
+    await userEvent
+      .setup()
+      .click(
+        within(channel).getByRole("button", {
+          name: "Approve all pending repositories",
+        }),
+      );
+    await waitFor(() =>
+      expect(approveWorkspaceGrantChannelRepositories).toHaveBeenCalledWith(
+        workspace.id,
+        "C1",
+        ["acme/web", "acme/api"],
+      ),
+    );
+    await waitFor(() =>
+      expect(within(channel).queryByText("Pending approval")).toBeNull(),
+    );
+    expect(listCodeGrants).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Repositories approved for C1.",
+    );
+    expect(
+      within(screen.getByRole("region", { name: "Channel C2" })).getByText(
+        "Pending approval",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("caps a large pending approval at the first 100 repositories", async () => {
+    const channels = Array.from({ length: 101 }, (_, index) => ({
+      channel_id: "C1",
+      repository: `acme/repository-${index}`,
+      state: "pending",
+      set_by_identity: "U1",
+      set_by_display: "Casey",
+    }));
+    const approveWorkspaceGrantChannelRepositories = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const listCodeGrants = vi
+      .fn()
+      .mockResolvedValue([{ ...workspace, channels }]);
+    render(
+      <ChannelsPanel
+        client={
+          {
+            listCodeGrants,
+            approveWorkspaceGrantChannelRepositories,
+          } as unknown as ApiClient
+        }
+      />,
+    );
+    await userEvent
+      .setup()
+      .click(await screen.findByRole("button", { name: "Approve first 100" }));
+    await waitFor(() =>
+      expect(approveWorkspaceGrantChannelRepositories).toHaveBeenCalledWith(
+        workspace.id,
+        "C1",
+        channels.slice(0, 100).map((entry) => entry.repository),
+      ),
+    );
+    expect(approveWorkspaceGrantChannelRepositories).toHaveBeenCalledTimes(1);
+    expect(listCodeGrants).toHaveBeenCalledTimes(2);
+  });
+
+  it("adds a channel before its first task with trimmed explicit names and URLs", async () => {
+    const listCodeGrants = vi
+      .fn()
+      .mockResolvedValue([{ ...workspace, channels: [] }]);
+    const approveWorkspaceGrantChannelRepositories = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    render(
+      <ChannelsPanel
+        client={
+          {
+            listCodeGrants,
+            approveWorkspaceGrantChannelRepositories,
+          } as unknown as ApiClient
+        }
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByRole("button", { name: "Add channel" }),
+    );
+    const form = screen.getByRole("form", { name: "Add channel repositories" });
+    await user.type(
+      within(form).getByRole("textbox", { name: /Slack channel ID/ }),
+      "  CNEW123  ",
+    );
+    await user.type(
+      within(form).getByRole("textbox", { name: /Repositories/ }),
+      " acme/tools , https://github.com/acme/web\nacme/tools ",
+    );
+    await user.click(
+      within(form).getByRole("button", { name: "Approve repositories" }),
+    );
+    await waitFor(() =>
+      expect(approveWorkspaceGrantChannelRepositories).toHaveBeenCalledWith(
+        workspace.id,
+        "CNEW123",
+        ["acme/tools", "https://github.com/acme/web"],
+      ),
+    );
+    await waitFor(() => expect(screen.queryByRole("form")).toBeNull());
+    expect(listCodeGrants).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the editor after an authorization failure and does not report success", async () => {
+    const listCodeGrants = vi.fn().mockResolvedValue([workspace]);
+    const approveWorkspaceGrantChannelRepositories = vi
+      .fn()
+      .mockRejectedValue(new Error("403: administrator access required"));
+    render(
+      <ChannelsPanel
+        client={
+          {
+            listCodeGrants,
+            approveWorkspaceGrantChannelRepositories,
+          } as unknown as ApiClient
+        }
+      />,
+    );
+    const user = userEvent.setup();
+    const channel = await screen.findByRole("region", { name: "Channel C1" });
+    await user.click(
+      within(channel).getByRole("button", { name: "Add repositories" }),
+    );
+    const editor = within(channel).getByRole("textbox", {
+      name: /Repositories/,
+    });
+    await user.type(editor, "acme/extra");
+    await user.click(
+      within(channel).getByRole("button", { name: "Approve repositories" }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "403: administrator access required",
+    );
+    expect(editor).toHaveValue("acme/extra");
+    expect(listCodeGrants).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(
+      within(channel).getByRole("button", { name: "Approve repositories" }),
+    ).toBeEnabled();
+  });
+
+  it("reports saved approvals separately from a failed refresh and retries only the read", async () => {
+    const listCodeGrants = vi
+      .fn()
+      .mockResolvedValueOnce([workspace])
+      .mockRejectedValueOnce(new Error("Connection lost"))
+      .mockResolvedValueOnce([workspace]);
+    const approveWorkspaceGrantChannelRepositories = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    render(
+      <ChannelsPanel
+        client={
+          {
+            listCodeGrants,
+            approveWorkspaceGrantChannelRepositories,
+          } as unknown as ApiClient
+        }
+      />,
+    );
+    const user = userEvent.setup();
+    const channel = await screen.findByRole("region", { name: "Channel C1" });
+    await user.click(
+      within(channel).getByRole("button", { name: "Add repositories" }),
+    );
+    await user.type(
+      within(channel).getByRole("textbox", { name: /Repositories/ }),
+      "acme/extra",
+    );
+    await user.click(
+      within(channel).getByRole("button", { name: "Approve repositories" }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Repositories were approved, but the list could not refresh. Error: Connection lost",
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Repositories approved for C1.",
+    );
+    expect(screen.queryByRole("form")).toBeNull();
+    expect(
+      within(channel).getByRole("button", { name: "Add repositories" }),
+    ).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Refresh grants" }));
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+    expect(listCodeGrants).toHaveBeenCalledTimes(3);
+    expect(approveWorkspaceGrantChannelRepositories).toHaveBeenCalledTimes(1);
+    expect(
+      within(channel).getByRole("button", { name: "Add repositories" }),
+    ).toBeEnabled();
+  });
+
+  it("keeps revoked workspace scopes visible without offering approval controls", async () => {
+    const client = {
+      listCodeGrants: vi
+        .fn()
+        .mockResolvedValue([
+          {
+            ...workspace,
+            revoked_at: "2026-09-09T10:00:00Z",
+            revoked_reason: "Administrator revoked access",
+          },
+        ]),
+    } as unknown as ApiClient;
+    render(<ChannelsPanel client={client} />);
+    await screen.findByRole("region", { name: "Channel C1" });
+    expect(screen.getByText("acme/tools")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", {
+        name: /Approve|Add channel|Add repositories|Revoke/,
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects missing channel IDs, wildcard scopes, and more than 100 repositories", async () => {
+    const approveWorkspaceGrantChannelRepositories = vi.fn();
+    render(
+      <ChannelsPanel
+        client={
+          {
+            listCodeGrants: vi
+              .fn()
+              .mockResolvedValue([{ ...workspace, channels: [] }]),
+            approveWorkspaceGrantChannelRepositories,
+          } as unknown as ApiClient
+        }
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByRole("button", { name: "Add channel" }),
+    );
+    const channelId = screen.getByRole("textbox", { name: /Slack channel ID/ });
+    const repositories = screen.getByRole("textbox", { name: /Repositories/ });
+    const approve = screen.getByRole("button", {
+      name: "Approve repositories",
+    });
+    await user.click(approve);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Enter the Slack channel ID.",
+    );
+    await user.type(channelId, "CNEW");
+    await user.click(approve);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Enter between 1 and 100 explicit repositories.",
+    );
+    await user.type(repositories, "acme/*");
+    await user.click(approve);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Wildcards are not supported.",
+    );
+    await user.clear(repositories);
+    await user.click(repositories);
+    await user.paste(
+      Array.from(
+        { length: 101 },
+        (_, index) => `acme/repository-${index}`,
+      ).join("\n"),
+    );
+    await user.click(approve);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Enter between 1 and 100 explicit repositories.",
+    );
+    expect(approveWorkspaceGrantChannelRepositories).not.toHaveBeenCalled();
   });
 
   it("says where connecting starts when nothing is connected", async () => {

--- a/crates/tidebreak-desktop/ui/src/settings/ChannelsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ChannelsPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/empty";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
+import { WorkspaceGrantRepositories } from "./WorkspaceGrantRepositories";
 
 /**
  * The grants an external channel holds on this machine, grouped by the
@@ -29,19 +30,26 @@ export function ChannelsPanel({ client }: { client: ApiClient }) {
   const [loading, setLoading] = useState(true);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [refreshFailed, setRefreshFailed] = useState(false);
   const { confirm, dialog } = useConfirm();
 
-  const reload = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setGrants(await client.listCodeGrants());
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [client]);
+  const reload = useCallback(
+    async (failureContext?: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        setGrants(await client.listCodeGrants());
+        setRefreshFailed(false);
+      } catch (err) {
+        setError([failureContext, String(err)].filter(Boolean).join(" "));
+        setRefreshFailed(true);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [client],
+  );
 
   useEffect(() => {
     void reload();
@@ -97,12 +105,38 @@ export function ChannelsPanel({ client }: { client: ApiClient }) {
     }
   }
 
+  async function approveRepositories(
+    grantId: string,
+    channelId: string,
+    repositories: string[],
+  ): Promise<boolean> {
+    setWorking(true);
+    setError(null);
+    setNotice(null);
+    try {
+      await client.approveWorkspaceGrantChannelRepositories(
+        grantId,
+        channelId,
+        repositories,
+      );
+    } catch (err) {
+      setError(`Repositories could not be approved. ${String(err)}`);
+      setWorking(false);
+      return false;
+    }
+    setNotice(`Repositories approved for ${channelId}.`);
+    await reload("Repositories were approved, but the list could not refresh.");
+    setWorking(false);
+    return true;
+  }
+
   const groups = groupByWorkspace(grants ?? []);
+  const disabled = loading || working || refreshFailed;
 
   return (
     <SettingsPanel
       title="Channels"
-      description="External channels that can reach coding sessions on this machine. Each grant is one linked person in one channel workspace; revoking it cuts their access immediately."
+      description="Manage the people and Slack workspaces that can reach coding sessions on this machine. For channel sessions, approve the repositories that agents can choose from. GitHub access is still required."
       busy={loading || working}
     >
       {loading && grants === null ? (
@@ -112,7 +146,12 @@ export function ChannelsPanel({ client }: { client: ApiClient }) {
       ) : grants === null ? (
         <div className="flex flex-col items-start gap-3">
           <SettingsError>{error}</SettingsError>
-          <Button type="button" variant="outline" size="sm" onClick={reload}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void reload()}
+          >
             Try again
           </Button>
         </div>
@@ -144,52 +183,49 @@ export function ChannelsPanel({ client }: { client: ApiClient }) {
               {group.grants.map((grant) => (
                 <li
                   key={grant.id}
-                  className="flex flex-wrap items-center justify-between gap-2 rounded-md border px-3 py-2"
+                  className="flex flex-col gap-3 rounded-md border px-3 py-2"
                 >
-                  <div className="flex min-w-0 items-start gap-3">
-                    <ChannelAvatar grant={grant} />
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium">
-                        {grant.kind === "workspace"
-                          ? `Workspace ${grant.workspace_name ?? grant.workspace_identity}`
-                          : (grant.display_name ?? grant.external_identity)}
-                      </p>
-                      {grant.kind !== "workspace" && grant.display_name && (
-                        <p className="truncate font-mono text-xs text-muted-foreground">
-                          {grant.external_identity}
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex min-w-0 items-start gap-3">
+                      <ChannelAvatar grant={grant} />
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">
+                          {grant.kind === "workspace"
+                            ? `Workspace ${grant.workspace_name ?? grant.workspace_identity}`
+                            : (grant.display_name ?? grant.external_identity)}
                         </p>
-                      )}
-                      {grant.kind === "workspace" &&
-                        grant.channels &&
-                        grant.channels.length > 0 && (
-                          <ul className="mt-1 text-xs text-muted-foreground">
-                            {grant.channels.map((channel) => (
-                              <li
-                                key={`${channel.channel_id}:${channel.repository}`}
-                              >
-                                {channel.channel_id} · {channel.repository} (
-                                {channel.state})
-                              </li>
-                            ))}
-                          </ul>
+                        {grant.kind !== "workspace" && grant.display_name && (
+                          <p className="truncate font-mono text-xs text-muted-foreground">
+                            {grant.external_identity}
+                          </p>
                         )}
-                      <p className="text-xs text-muted-foreground">
-                        {grant.revoked_at
-                          ? `Revoked ${formatDay(grant.revoked_at)} — ${grant.revoked_reason ?? "no reason recorded"}`
-                          : `Connected ${formatDay(grant.created_at)}`}
-                      </p>
+                        <p className="text-xs text-muted-foreground">
+                          {grant.revoked_at
+                            ? `Revoked ${formatDay(grant.revoked_at)} — ${grant.revoked_reason ?? "no reason recorded"}`
+                            : `Connected ${formatDay(grant.created_at)}`}
+                        </p>
+                      </div>
                     </div>
+                    {!grant.revoked_at && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={disabled}
+                        onClick={() => void revokeOne(grant)}
+                      >
+                        Revoke
+                      </Button>
+                    )}
                   </div>
-                  {!grant.revoked_at && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={working}
-                      onClick={() => void revokeOne(grant)}
-                    >
-                      Revoke
-                    </Button>
+                  {grant.kind === "workspace" && (
+                    <WorkspaceGrantRepositories
+                      grant={grant}
+                      disabled={disabled}
+                      onApprove={(channelId, repositories) =>
+                        approveRepositories(grant.id, channelId, repositories)
+                      }
+                    />
                   )}
                 </li>
               ))}
@@ -200,7 +236,7 @@ export function ChannelsPanel({ client }: { client: ApiClient }) {
                 variant="outline"
                 size="sm"
                 className="self-start"
-                disabled={working}
+                disabled={disabled}
                 onClick={() => void revokeWorkspace(group)}
               >
                 Revoke this workspace
@@ -209,7 +245,32 @@ export function ChannelsPanel({ client }: { client: ApiClient }) {
           </SettingsSection>
         ))
       )}
-      {grants !== null && error && <SettingsError>{error}</SettingsError>}
+      {notice && (
+        <p
+          className="notice-surface notice-success rounded-md border px-3 py-2 text-sm"
+          role="status"
+        >
+          {notice}
+        </p>
+      )}
+      {grants !== null && error && (
+        <div className="notice-surface notice-critical flex flex-col items-start gap-2 rounded-md border px-3 py-2">
+          <p className="text-sm break-words" role="alert">
+            {error}
+          </p>
+          {refreshFailed && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={loading || working}
+              onClick={() => void reload()}
+            >
+              Refresh grants
+            </Button>
+          )}
+        </div>
+      )}
       {dialog}
     </SettingsPanel>
   );

--- a/crates/tidebreak-desktop/ui/src/settings/WorkspaceGrantRepositories.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/WorkspaceGrantRepositories.tsx
@@ -1,0 +1,318 @@
+import { useId, useState, type FormEvent } from "react";
+
+import type { CodeGrantSnapshot } from "../api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { SettingsField } from "./primitives";
+
+type ChannelRepository = NonNullable<CodeGrantSnapshot["channels"]>[number];
+type ApproveRepositories = (
+  channelId: string,
+  repositories: string[],
+) => Promise<boolean>;
+
+export function WorkspaceGrantRepositories({
+  grant,
+  disabled,
+  onApprove,
+}: {
+  grant: CodeGrantSnapshot;
+  disabled: boolean;
+  onApprove: ApproveRepositories;
+}) {
+  const [addingChannel, setAddingChannel] = useState(false);
+  const channels = new Map<string, ChannelRepository[]>();
+  for (const repository of grant.channels ?? []) {
+    const entries = channels.get(repository.channel_id) ?? [];
+    entries.push(repository);
+    channels.set(repository.channel_id, entries);
+  }
+  const canApprove = !grant.revoked_at && grant.channel_kind === "slack";
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4 border-t pt-3">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-sm font-medium">Channel repositories</h3>
+        {canApprove && (
+          <p className="text-sm text-muted-foreground">
+            Admins approve repositories for each channel once. Agents can choose
+            any approved repository and work across them. The shared GitHub
+            identity must also have access. To use newly approved repositories,
+            ask the agent to retry in Slack.
+          </p>
+        )}
+      </div>
+      {channels.size === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No channel repositories yet. Approve repositories before the first
+          task by adding a Slack channel ID.
+        </p>
+      ) : (
+        <div className="flex flex-col divide-y">
+          {[...channels.entries()].map(([channelId, repositories]) => (
+            <ChannelRepositoryGroup
+              key={channelId}
+              channelId={channelId}
+              repositories={repositories}
+              canApprove={canApprove}
+              disabled={disabled}
+              onApprove={onApprove}
+            />
+          ))}
+        </div>
+      )}
+      {canApprove &&
+        (addingChannel ? (
+          <RepositoryApprovalForm
+            disabled={disabled}
+            onApprove={onApprove}
+            onClose={() => setAddingChannel(false)}
+          />
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="self-start"
+            disabled={disabled}
+            onClick={() => setAddingChannel(true)}
+          >
+            Add channel
+          </Button>
+        ))}
+    </div>
+  );
+}
+
+function ChannelRepositoryGroup({
+  channelId,
+  repositories,
+  canApprove,
+  disabled,
+  onApprove,
+}: {
+  channelId: string;
+  repositories: ChannelRepository[];
+  canApprove: boolean;
+  disabled: boolean;
+  onApprove: ApproveRepositories;
+}) {
+  const [editing, setEditing] = useState(false);
+  const headingId = useId();
+  const approved = repositories.filter((entry) => entry.state === "confirmed");
+  const pending = repositories.filter((entry) => entry.state === "pending");
+  const pendingRepositories = [
+    ...new Set(pending.map((entry) => entry.repository)),
+  ];
+  const previous = repositories.filter(
+    (entry) => entry.state !== "confirmed" && entry.state !== "pending",
+  );
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="flex min-w-0 flex-col gap-3 py-3 first:pt-0 last:pb-0"
+    >
+      <h4 id={headingId} className="break-all font-mono text-sm font-medium">
+        Channel {channelId}
+      </h4>
+      <div className="flex flex-col gap-1">
+        <p className="text-xs text-muted-foreground">Approved repositories</p>
+        {approved.length > 0 ? (
+          <RepositoryList repositories={approved} />
+        ) : (
+          <p className="text-sm text-muted-foreground">None approved yet.</p>
+        )}
+      </div>
+      {pending.length > 0 && (
+        <div className="flex flex-col items-start gap-2">
+          <div className="flex w-full min-w-0 flex-col gap-1">
+            <p className="text-xs text-muted-foreground">Pending approval</p>
+            <RepositoryList repositories={pending} />
+          </div>
+          {canApprove && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={disabled}
+              onClick={() =>
+                void onApprove(channelId, pendingRepositories.slice(0, 100))
+              }
+            >
+              {pendingRepositories.length > 100
+                ? "Approve first 100"
+                : "Approve all pending repositories"}
+            </Button>
+          )}
+        </div>
+      )}
+      {previous.length > 0 && (
+        <details className="text-sm text-muted-foreground">
+          <summary className="cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            Previous repositories ({previous.length})
+          </summary>
+          <ul className="mt-2 flex flex-col gap-1">
+            {previous.map((entry) => (
+              <li key={entry.repository} className="break-all">
+                <span className="font-mono">{entry.repository}</span> ·{" "}
+                {entry.state}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+      {canApprove &&
+        (editing ? (
+          <RepositoryApprovalForm
+            channelId={channelId}
+            disabled={disabled}
+            onApprove={onApprove}
+            onClose={() => setEditing(false)}
+          />
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="self-start"
+            disabled={disabled}
+            onClick={() => setEditing(true)}
+          >
+            Add repositories
+          </Button>
+        ))}
+    </section>
+  );
+}
+
+function RepositoryList({
+  repositories,
+}: {
+  repositories: ChannelRepository[];
+}) {
+  return (
+    <ul className="flex flex-col gap-1">
+      {repositories.map((entry) => (
+        <li key={entry.repository} className="break-all font-mono text-sm">
+          {entry.repository}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function RepositoryApprovalForm({
+  channelId,
+  disabled,
+  onApprove,
+  onClose,
+}: {
+  channelId?: string;
+  disabled: boolean;
+  onApprove: ApproveRepositories;
+  onClose: () => void;
+}) {
+  const [channel, setChannel] = useState(channelId ?? "");
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const errorId = useId();
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (disabled) return;
+    const repositories = [
+      ...new Set(
+        text
+          .split(/[\n,]+/)
+          .map((item) => item.trim())
+          .filter(Boolean),
+      ),
+    ];
+    if (!channel.trim()) {
+      setError("Enter the Slack channel ID.");
+      return;
+    }
+    if (repositories.length === 0 || repositories.length > 100) {
+      setError("Enter between 1 and 100 explicit repositories.");
+      return;
+    }
+    if (repositories.some((repository) => repository.includes("*"))) {
+      setError(
+        "Wildcards are not supported. Enter each repository explicitly.",
+      );
+      return;
+    }
+    setError(null);
+    if (await onApprove(channel.trim(), repositories)) onClose();
+  }
+
+  return (
+    <form
+      aria-label={
+        channelId
+          ? `Add repositories to ${channelId}`
+          : "Add channel repositories"
+      }
+      className="flex min-w-0 flex-col gap-3"
+      onSubmit={(event) => void submit(event)}
+    >
+      {!channelId && (
+        <SettingsField
+          label="Slack channel ID"
+          hint="Open the channel details in Slack to copy its channel ID."
+        >
+          <Input
+            value={channel}
+            onChange={(event) => setChannel(event.target.value)}
+            placeholder="C0123456789"
+            disabled={disabled}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </SettingsField>
+      )}
+      <SettingsField
+        label="Repositories"
+        hint="Enter GitHub owner/repository names or URLs, one per line or separated by commas. Approvals add to this channel’s existing access. Wildcards are not supported. Up to 100 repositories per approval."
+      >
+        <Textarea
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          placeholder={"acme/service\nhttps://github.com/acme/web"}
+          rows={3}
+          className="font-mono"
+          disabled={disabled}
+          autoComplete="off"
+          spellCheck={false}
+          aria-describedby={error ? errorId : undefined}
+          aria-invalid={Boolean(error)}
+        />
+      </SettingsField>
+      {error && (
+        <p
+          id={errorId}
+          className="notice-surface notice-critical rounded-md border px-3 py-2 text-sm"
+          role="alert"
+        >
+          {error}
+        </p>
+      )}
+      <div className="flex flex-wrap gap-2">
+        <Button type="submit" size="sm" disabled={disabled}>
+          Approve repositories
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/stories/ChannelsPanel.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/ChannelsPanel.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
 
 import type { ApiClient, CodeGrantSnapshot } from "@/api";
 import { ChannelsPanel } from "@/settings/ChannelsPanel";
@@ -100,4 +101,192 @@ export const LoadFailed: Story = {
 /** Only the theft-revoked grant: the reason is the notification of record. */
 export const RevokedForTokenReuse: Story = {
   args: { client: stubClient([stolen]) },
+};
+
+const workspace: CodeGrantSnapshot = {
+  ...live,
+  id: "6b1f9a34-0000-4000-8000-000000000009",
+  kind: "workspace",
+  external_identity: "T04ACME",
+  display_name: "tidebreak-slack",
+  channels: [
+    {
+      channel_id: "C04ENGINEERING",
+      repository: "acme/service",
+      state: "confirmed",
+      set_by_identity: "U04CASEY",
+      set_by_display: "Casey Nakamura",
+    },
+    {
+      channel_id: "C04ENGINEERING",
+      repository: "acme/web",
+      state: "pending",
+      set_by_identity: "U04SAM",
+      set_by_display: "Sam Okafor",
+    },
+    {
+      channel_id: "C04ENGINEERING",
+      repository: "acme/infrastructure",
+      state: "pending",
+      set_by_identity: "U04SAM",
+      set_by_display: "Sam Okafor",
+    },
+    {
+      channel_id: "C04ENGINEERING",
+      repository: "acme/legacy",
+      state: "superseded",
+      set_by_identity: "U04CASEY",
+      set_by_display: "Casey Nakamura",
+    },
+    {
+      channel_id: "C04DESIGN",
+      repository: "acme/design-system",
+      state: "confirmed",
+      set_by_identity: "U04CASEY",
+      set_by_display: "Casey Nakamura",
+    },
+  ],
+};
+
+function approvalClient({
+  failSave = false,
+  failRefresh = false,
+  initialGrant = workspace,
+}: {
+  failSave?: boolean;
+  failRefresh?: boolean;
+  initialGrant?: CodeGrantSnapshot;
+} = {}): ApiClient {
+  let grants = [structuredClone(initialGrant), live];
+  let saved = false;
+  return {
+    listCodeGrants: async () => {
+      if (saved && failRefresh)
+        throw new Error("The connection was lost while refreshing grants.");
+      return grants;
+    },
+    approveWorkspaceGrantChannelRepositories: async (
+      grantId: string,
+      channelId: string,
+      repositories: string[],
+    ) => {
+      if (failSave) throw new Error("403: administrator access required");
+      saved = true;
+      grants = grants.map((grant) => {
+        if (grant.id !== grantId) return grant;
+        const channels = (grant.channels ?? []).filter(
+          (entry) =>
+            entry.channel_id !== channelId ||
+            !repositories.includes(entry.repository),
+        );
+        return {
+          ...grant,
+          channels: [
+            ...channels,
+            ...repositories.map((repository) => ({
+              channel_id: channelId,
+              repository,
+              state: "confirmed",
+              set_by_identity: "U04CASEY",
+              set_by_display: "Casey Nakamura",
+            })),
+          ],
+        };
+      });
+    },
+  } as unknown as ApiClient;
+}
+
+export const ChannelRepositories: Story = {
+  render: () => <ChannelsPanel client={approvalClient()} />,
+};
+
+export const BeforeFirstTask: Story = {
+  render: () => (
+    <ChannelsPanel
+      client={approvalClient({ initialGrant: { ...workspace, channels: [] } })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Add channel" }),
+    );
+    await expect(
+      canvas.getByRole("textbox", { name: /Slack channel ID/ }),
+    ).toBeVisible();
+  },
+};
+
+export const ApprovalFailed: Story = {
+  render: () => <ChannelsPanel client={approvalClient({ failSave: true })} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", {
+        name: "Approve all pending repositories",
+      }),
+    );
+    await expect(await canvas.findByRole("alert")).toHaveTextContent(
+      "administrator access required",
+    );
+  },
+};
+
+export const ApprovedButRefreshFailed: Story = {
+  render: () => (
+    <ChannelsPanel client={approvalClient({ failRefresh: true })} />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", {
+        name: "Approve all pending repositories",
+      }),
+    );
+    await expect(await canvas.findByRole("alert")).toHaveTextContent(
+      "Repositories were approved, but the list could not refresh.",
+    );
+    await expect(canvas.getByRole("status")).toHaveTextContent(
+      "Repositories approved for C04ENGINEERING.",
+    );
+  },
+};
+
+export const ApprovedRepositories: Story = {
+  render: () => <ChannelsPanel client={approvalClient()} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole("button", {
+        name: "Approve all pending repositories",
+      }),
+    );
+    await expect(await canvas.findByRole("status")).toHaveTextContent(
+      "Repositories approved for C04ENGINEERING.",
+    );
+    await expect(
+      canvas.queryByText("Pending approval"),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const LongRepositories: Story = {
+  args: {
+    client: stubClient([
+      {
+        ...workspace,
+        channels: [
+          {
+            channel_id: "C04ENGINEERING",
+            repository:
+              "acme-platform-engineering/customer-identity-and-shared-access-management-service",
+            state: "confirmed",
+            set_by_identity: "U04CASEY",
+            set_by_display: "Casey Nakamura",
+          },
+        ],
+      },
+    ]),
+  },
 };

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -411,6 +411,10 @@ pub fn app(state: AppState) -> Router {
             "/deployment/code/grants/workspace/{id}/channels/{channel_id}/repositories/confirm",
             post(routes::code::confirm_workspace_channel_repository),
         )
+        .route(
+            "/deployment/code/grants/workspace/{id}/channels/{channel_id}/repositories/approve",
+            post(routes::code::approve_workspace_channel_repositories),
+        )
         .route_layer(axum::middleware::from_fn(auth::require_admin));
 
     // The engine-facing browser channel. Authenticated per request by the

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -331,6 +331,7 @@ pub async fn external_get_or_create(
         None => None,
     };
     let repository = match registered.as_ref() {
+        Some(repo) if grant.kind.is_workspace() => Some(workspace_repository_scope(repo)?),
         Some(repo) => match (repo.origin_owner.as_deref(), repo.origin_name.as_deref()) {
             (Some(owner), Some(name)) => Some(format!("{owner}/{name}")),
             _ => body.repository.clone(),
@@ -533,6 +534,30 @@ pub async fn external_attach_binding(
     }
 }
 
+/// An unqualified channel approval names a repository on github.com only.
+fn workspace_repository_scope(repo: &tidebreak_core::CodeRepo) -> Result<String, ServerError> {
+    let origin_unknown = || {
+        ServerError::conflict_kind(
+            "repo_origin_unknown",
+            "channel repository approval requires a recorded github.com origin",
+        )
+    };
+    if !repo
+        .origin_host
+        .as_deref()
+        .is_some_and(|host| host.eq_ignore_ascii_case("github.com"))
+    {
+        return Err(origin_unknown());
+    }
+    let (Some(owner), Some(name)) = (repo.origin_owner.as_deref(), repo.origin_name.as_deref())
+    else {
+        return Err(origin_unknown());
+    };
+    tidebreak_server_core::code::runtime::CodeRuntime::canonical_external_repository(&format!(
+        "{owner}/{name}"
+    ))
+}
+
 async fn require_binding_repository(
     runtime: &crate::code::runtime::CodeRuntime,
     grant: &CodeExternalGrant,
@@ -553,16 +578,7 @@ async fn require_binding_repository(
     if let Some(workspace_id) = session.workspace_id {
         let workspace = runtime.get_workspace(&grant.owner, workspace_id).await?;
         let repo = runtime.get_repo(&grant.owner, workspace.repo_id).await?;
-        let repository = repo
-            .origin_owner
-            .zip(repo.origin_name)
-            .map(|(owner, name)| format!("{owner}/{name}"))
-            .ok_or_else(|| {
-                ServerError::conflict_kind(
-                    "repo_origin_unknown",
-                    "the repository records no origin to confirm",
-                )
-            })?;
+        let repository = workspace_repository_scope(&repo)?;
         if !tidebreak_core::db::code::channel_repository_is_confirmed(
             &runtime.db,
             &grant.owner,

--- a/crates/tidebreak-server-api/src/routes/code/grants.rs
+++ b/crates/tidebreak-server-api/src/routes/code/grants.rs
@@ -411,3 +411,24 @@ pub async fn confirm_workspace_channel_repository(
         .ok_or_else(|| ServerError::not_found("repository confirmation not found"))?;
     Ok(StatusCode::NO_CONTENT)
 }
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApproveRepositoriesBody {
+    pub repositories: Vec<String>,
+}
+
+/// `POST /deployment/code/grants/workspace/{id}/channels/{channel_id}/repositories/approve`
+pub async fn approve_workspace_channel_repositories(
+    code: ScopedCode,
+    Path((id, channel_id)): Path<(tidebreak_core::CodeGrantId, String)>,
+    Json(body): Json<ApproveRepositoriesBody>,
+) -> Result<StatusCode, ServerError> {
+    if !code
+        .approve_workspace_channel_repositories(id, &channel_id, &body.repositories)
+        .await?
+    {
+        return Err(ServerError::not_found("workspace grant not found"));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -67,9 +67,10 @@ pub(crate) use git::{
     write_workspace_check_logs,
 };
 pub(crate) use grants::{
-    approve_workspace_grant, confirm_workspace_channel_repository, connect_approve,
-    connect_complete, connect_probe, connect_start, connect_status, connect_view, list_grants,
-    revoke_grant, revoke_workspace_grants, start_workspace_grant, view_workspace_grant,
+    approve_workspace_channel_repositories, approve_workspace_grant,
+    confirm_workspace_channel_repository, connect_approve, connect_complete, connect_probe,
+    connect_start, connect_status, connect_view, list_grants, revoke_grant,
+    revoke_workspace_grants, start_workspace_grant, view_workspace_grant,
 };
 pub(crate) use harnesses::{
     check_harness_updates, install_harness, list_harness_models, list_harnesses, refresh_harnesses,

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -2700,6 +2700,432 @@ async fn call_json(
     (status, json)
 }
 
+async fn repository_scope_workspace_grant(
+    runtime: &CodeRuntime,
+    owner: &OwnerId,
+    workspace: &str,
+    token: &str,
+) -> tidebreak_core::CodeExternalGrant {
+    tidebreak_core::db::code::mint_external_grant(
+        &runtime.db,
+        owner,
+        tidebreak_core::db::code::MintGrantSubject {
+            channel_kind: "slack",
+            external_identity: workspace,
+            workspace_identity: workspace,
+            kind: tidebreak_core::CodeGrantKind::Workspace,
+        },
+        &crate::code::grants::hash_adapter_token(token),
+        &crate::code::grants::hash_adapter_token(&format!("refresh-{token}")),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn channel_repository_preapproval_is_additive_and_scoped_before_session_attempts() {
+    let (router, runtime, first_repo_id, service, dir) = workspace_grant_app().await;
+    let token = "workspace-preapproval-token";
+    let grant = repository_scope_workspace_grant(&runtime, &service, "T1", token).await;
+    assert!(tidebreak_core::db::code::set_repo_origin(
+        &runtime.db,
+        &service,
+        first_repo_id,
+        "github.com",
+        "ACME",
+        "Tools"
+    )
+    .await
+    .unwrap());
+    let mut second_repo = runtime.get_repo(&service, first_repo_id).await.unwrap();
+    second_repo.id = RepoId::new();
+    second_repo.root_path = dir.path().join("api").display().to_string();
+    second_repo.display_name = "api".into();
+    second_repo.origin_name = Some("API".into());
+    insert_repo(&runtime.db, &second_repo).await.unwrap();
+    assert!(runtime
+        .list_channel_repository_confirms(&service, grant.id)
+        .await
+        .unwrap()
+        .is_empty());
+    let approve = format!(
+        "/deployment/code/grants/workspace/{}/channels/C1/repositories/approve",
+        grant.id
+    );
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &approve,
+        ALICE_TOKEN,
+        Some(serde_json::json!({
+            "repositories": ["https://github.com/ACME/TOOLS.git/", "acme/API", "ACME/tools"]
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let rows = runtime
+        .list_channel_repository_confirms(&service, grant.id)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2, "canonical aliases create one approval");
+    assert!(rows
+        .iter()
+        .all(|row| row.state == tidebreak_core::CodeChannelRepositoryState::Confirmed));
+    assert!(rows
+        .iter()
+        .all(|row| row.confirmed_by.as_ref().map(OwnerId::as_str) == Some("user:alice")));
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &approve,
+        ALICE_TOKEN,
+        Some(serde_json::json!({
+            "repositories": ["acme/third"]
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &approve,
+        ALICE_TOKEN,
+        Some(serde_json::json!({
+            "repositories": ["acme/tools"]
+        })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NO_CONTENT,
+        "repeating an approval is idempotent"
+    );
+    assert_eq!(
+        runtime
+            .list_channel_repository_confirms(&service, grant.id)
+            .await
+            .unwrap()
+            .len(),
+        3
+    );
+
+    // Neither repository needs a failed session attempt or setter metadata first.
+    for (index, repo_id) in [first_repo_id, second_repo.id].into_iter().enumerate() {
+        let (status, body) = call_json(&router, "POST", "/external/code/sessions", token, Some(serde_json::json!({
+            "external_key": format!("T1/C1/{}.1", index + 1), "repo_id": repo_id, "channel_id": "C1"
+        }))).await;
+        assert_eq!(status, StatusCode::CREATED, "{body}");
+    }
+    let source_session = bound_session_id(&runtime, &service, "T1/C1/1.1").await;
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &format!(
+            "/deployment/code/grants/workspace/{}/channels/C3/repositories/approve",
+            grant.id
+        ),
+        ALICE_TOKEN,
+        Some(serde_json::json!({"repositories":["acme/tools"]})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (status, body) = call_json(
+        &router,
+        "POST",
+        &format!("/external/code/sessions/{source_session}/bindings"),
+        token,
+        Some(serde_json::json!({"external_key":"T1/C3/1.1", "channel_id":"C3"})),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "a mixed-case registered origin matches destination approval: {body}"
+    );
+    let (status, body) = call_json(
+        &router,
+        "POST",
+        "/external/code/sessions",
+        token,
+        Some(serde_json::json!({
+            "external_key": "T1/C2/1.1", "repo_id": first_repo_id, "channel_id": "C2",
+            "set_by": {"identity": "U1", "display": "Casey"}
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        body["kind"], "repository_unconfirmed",
+        "another channel has no inherited scope"
+    );
+
+    let other_token = "other-workspace-preapproval-token";
+    let other_grant = repository_scope_workspace_grant(&runtime, &service, "T2", other_token).await;
+    let (status, body) = call_json(
+        &router,
+        "POST",
+        "/external/code/sessions",
+        other_token,
+        Some(serde_json::json!({
+            "external_key": "T2/C1/1.1", "repo_id": first_repo_id, "channel_id": "C1",
+            "set_by": {"identity": "U1", "display": "Casey"}
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        body["kind"], "repository_unconfirmed",
+        "another grant has no inherited scope"
+    );
+    assert!(!tidebreak_core::db::code::channel_repository_is_confirmed(
+        &runtime.db,
+        &service,
+        other_grant.id,
+        "C1",
+        "acme/tools"
+    )
+    .await
+    .unwrap());
+    for repository in ["acme/tools", "acme/api", "acme/third"] {
+        assert!(tidebreak_core::db::code::channel_repository_is_confirmed(
+            &runtime.db,
+            &service,
+            grant.id,
+            "C1",
+            repository
+        )
+        .await
+        .unwrap());
+    }
+}
+
+#[tokio::test]
+async fn channel_repository_preapproval_never_matches_other_or_missing_registered_hosts() {
+    let (router, runtime, repo_id, service, dir) = workspace_grant_app().await;
+    let token = "preapproval-host-token";
+    let grant = repository_scope_workspace_grant(&runtime, &service, "T1", token).await;
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &format!(
+            "/deployment/code/grants/workspace/{}/channels/C1/repositories/approve",
+            grant.id
+        ),
+        ALICE_TOKEN,
+        Some(serde_json::json!({"repositories":["acme/tools"]})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let template = runtime.get_repo(&service, repo_id).await.unwrap();
+    for (index, host) in [Some("gitlab.example"), None].into_iter().enumerate() {
+        let mut other = template.clone();
+        other.id = RepoId::new();
+        other.root_path = dir
+            .path()
+            .join(format!("other-host-{index}"))
+            .display()
+            .to_string();
+        other.origin_host = host.map(str::to_owned);
+        insert_repo(&runtime.db, &other).await.unwrap();
+        let (status, body) = call_json(
+            &router, "POST", "/external/code/sessions", token,
+            Some(serde_json::json!({"external_key":format!("T1/C1/{}.1", index + 1), "repo_id":other.id, "channel_id":"C1", "repository":"acme/tools"})),
+        ).await;
+        assert_eq!(status, StatusCode::CONFLICT, "{host:?}: {body}");
+        assert_eq!(body["kind"], "repo_origin_unknown");
+    }
+    let (status, body) = call_json(
+        &router,
+        "POST",
+        "/external/code/sessions",
+        token,
+        Some(serde_json::json!({"external_key":"T1/C1/3.1", "repo_id":repo_id, "channel_id":"C1"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    let session_id = bound_session_id(&runtime, &service, "T1/C1/3.1").await;
+    assert!(tidebreak_core::db::code::set_repo_origin(
+        &runtime.db,
+        &service,
+        repo_id,
+        "gitlab.example",
+        "acme",
+        "tools",
+    )
+    .await
+    .unwrap());
+    let (status, body) = call_json(
+        &router,
+        "POST",
+        &format!("/external/code/sessions/{session_id}/bindings"),
+        token,
+        Some(serde_json::json!({"external_key":"T1/C1/4.1", "channel_id":"C1"})),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "a changed host cannot reuse the GitHub approval: {body}"
+    );
+    assert_eq!(body["kind"], "repo_origin_unknown");
+    let rows = runtime
+        .list_channel_repository_confirms(&service, grant.id)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].repository, "acme/tools");
+}
+
+#[tokio::test]
+async fn channel_repository_preapproval_refuses_nonadmin_service_missing_revoked_and_person_grants()
+{
+    let (router, runtime, _repo_id, service, _dir) = workspace_grant_app().await;
+    let grant =
+        repository_scope_workspace_grant(&runtime, &service, "T1", "preapproval-auth-token").await;
+    let approve =
+        |id| format!("/deployment/code/grants/workspace/{id}/channels/C1/repositories/approve");
+    let body = serde_json::json!({"repositories": ["acme/tools"]});
+    for token in [BOB_TOKEN, CAROL_TOKEN] {
+        let (status, _) = call_json(
+            &router,
+            "POST",
+            &approve(grant.id),
+            token,
+            Some(body.clone()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &approve(grant.id),
+        "unrecognized-token",
+        Some(body.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &approve(tidebreak_core::CodeGrantId::new()),
+        ALICE_TOKEN,
+        Some(body.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let (person, _) = runtime
+        .mint_adapter_grant(&service, "slack", "U-person", "T1")
+        .await
+        .unwrap();
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &approve(person.id),
+        ALICE_TOKEN,
+        Some(body.clone()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(runtime
+        .list_channel_repository_confirms(&service, person.id)
+        .await
+        .unwrap()
+        .is_empty());
+    runtime
+        .revoke_adapter_grant_any_owner(grant.id, "test revocation")
+        .await
+        .unwrap()
+        .unwrap();
+    let (status, _) = call_json(&router, "POST", &approve(grant.id), ALICE_TOKEN, Some(body)).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(runtime
+        .list_channel_repository_confirms(&service, grant.id)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn channel_repository_preapproval_rejects_invalid_batches_without_partial_writes() {
+    let (router, runtime, _repo_id, service, _dir) = workspace_grant_app().await;
+    let grant =
+        repository_scope_workspace_grant(&runtime, &service, "T1", "preapproval-atomic-token")
+            .await;
+    let approve = format!(
+        "/deployment/code/grants/workspace/{}/channels/C1/repositories/approve",
+        grant.id
+    );
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &approve,
+        ALICE_TOKEN,
+        Some(serde_json::json!({"repositories":["acme/existing"]})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let too_many: Vec<String> = (0..101).map(|index| format!("acme/repo-{index}")).collect();
+    for repositories in [
+        serde_json::json!([]),
+        serde_json::json!(too_many),
+        serde_json::json!(["acme/new", "*"]),
+        serde_json::json!(["acme/new", "acme/*"]),
+        serde_json::json!(["acme/new", "not-a-repository"]),
+        serde_json::json!(["acme/new", "acme/name/extra"]),
+        serde_json::json!(["acme/new", "https://other.example/acme/tools"]),
+        serde_json::json!(["acme/new", ""]),
+    ] {
+        let (status, _) = call_json(
+            &router,
+            "POST",
+            &approve,
+            ALICE_TOKEN,
+            Some(serde_json::json!({"repositories":repositories})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let rows = runtime
+            .list_channel_repository_confirms(&service, grant.id)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "no valid prefix of a refused batch is saved");
+        assert_eq!(rows[0].repository, "acme/existing");
+        assert_eq!(
+            rows[0].state,
+            tidebreak_core::CodeChannelRepositoryState::Confirmed
+        );
+    }
+    for channel in [
+        "%20".to_owned(),
+        "C%20one".to_owned(),
+        "C%2Fother".to_owned(),
+        "C".repeat(129),
+    ] {
+        let uri = format!(
+            "/deployment/code/grants/workspace/{}/channels/{channel}/repositories/approve",
+            grant.id
+        );
+        let (status, _) = call_json(
+            &router,
+            "POST",
+            &uri,
+            ALICE_TOKEN,
+            Some(serde_json::json!({"repositories":["acme/new"]})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{channel}");
+    }
+    assert_eq!(
+        runtime
+            .list_channel_repository_confirms(&service, grant.id)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
 #[tokio::test]
 async fn a_service_principal_starts_a_workspace_handshake_and_an_admin_approves_it() {
     let (router, runtime, repo_id, service, dir) = workspace_grant_app().await;

--- a/crates/tidebreak-server/src/code/grants.rs
+++ b/crates/tidebreak-server/src/code/grants.rs
@@ -543,6 +543,55 @@ impl super::runtime::CodeRuntime {
         .await?)
     }
 
+    /// Add exact repositories to one channel's approved scope before a session starts.
+    pub async fn approve_workspace_channel_repositories_as_admin(
+        &self,
+        admin: &OwnerId,
+        grant_id: CodeGrantId,
+        channel_id: &str,
+        repositories: &[String],
+    ) -> Result<bool, ServerError> {
+        let channel_id = bounded_connect_value("channel_id", channel_id, 128)?;
+        if !channel_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(ServerError::bad_request(
+                "channel_id must use letters, digits, hyphens, or underscores",
+            ));
+        }
+        if repositories.is_empty() || repositories.len() > 100 {
+            return Err(ServerError::bad_request(
+                "approve between 1 and 100 exact repositories",
+            ));
+        }
+        // Parse the entire batch before any write. Admission uses the same
+        // canonical names, so aliases cannot approve a different repository.
+        let repositories = repositories
+            .iter()
+            .map(|repository| Self::canonical_external_repository(repository))
+            .collect::<Result<std::collections::BTreeSet<_>, _>>()?
+            .into_iter()
+            .collect::<Vec<_>>();
+        let Some(grant) =
+            tidebreak_core::db::code::get_external_grant_all_owners(&self.db, grant_id).await?
+        else {
+            return Ok(false);
+        };
+        if !grant.kind.is_workspace() || grant.revoked_at.is_some() {
+            return Ok(false);
+        }
+        Ok(tidebreak_core::db::code::approve_channel_repositories(
+            &self.db,
+            &grant.owner,
+            grant_id,
+            &channel_id,
+            &repositories,
+            admin,
+        )
+        .await?)
+    }
+
     pub async fn revoke_adapter_grant_any_owner(
         &self,
         grant_id: CodeGrantId,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -1059,6 +1059,27 @@ impl ScopedCode {
             .await
     }
 
+    pub async fn approve_workspace_channel_repositories(
+        &self,
+        grant_id: tidebreak_core::CodeGrantId,
+        channel_id: &str,
+        repositories: &[String],
+    ) -> Result<bool, ServerError> {
+        if !self.allow_unscoped_delivery || self.is_service {
+            return Err(ServerError::forbidden(
+                "a human administrator must approve channel repositories",
+            ));
+        }
+        self.runtime
+            .approve_workspace_channel_repositories_as_admin(
+                &self.owner,
+                grant_id,
+                channel_id,
+                repositories,
+            )
+            .await
+    }
+
     pub async fn start_workspace_handshake(
         &self,
         channel_kind: &str,

--- a/crates/tidebreak-server/src/code/self_drive.rs
+++ b/crates/tidebreak-server/src/code/self_drive.rs
@@ -141,7 +141,7 @@ impl Tool for SessionTool {
     fn spec(&self) -> ToolSpec {
         let (description, properties, required) = match self.name {
             "code_repos" => ("List repositories available to this conversation's personal or bot identity. Choose repositories from the task; the conversation does not need a default repository.", json!({}), json!([])),
-            "code_session_create" => ("Start independent work in a repository and return its child session. Use a different request_key for each task and reuse it on retries. You may start children in different repositories. Read their results with code_wait before answering. Repository access and channel confirmation apply.", json!({
+            "code_session_create" => ("Start independent work in a repository and return its child session. Use a different request_key for each task and reuse it on retries. You may start children in different repositories. Read their results with code_wait before answering. Repository access and the channel’s approved repository scope apply.", json!({
                 "repository":{"type":"string","description":"GitHub owner/name"},
                 "task":{"type":"string","maxLength":16000},
                 "request_key":{"type":"string","maxLength":128,"description":"Stable key for this task, reused on retries."},
@@ -373,7 +373,7 @@ impl SessionTool {
                     "Parent conversation",
                 )
                 .await?;
-                return Err(ServerError::conflict_kind("repository_unconfirmed", format!("An administrator must confirm {origin} for this Slack channel in Tidebreak Channels settings. Ask for that confirmation, then retry this request_key.")));
+                return Err(ServerError::conflict_kind("repository_unconfirmed", format!("This channel does not yet allow {origin}. Ask an administrator to add the repositories this task needs together in Tidebreak Settings > Channels. A chat answer does not change access. After the scope is saved, retry this request_key.")));
             }
         }
         if let Some(lender) = &auth.lender {

--- a/docs/decisions/0092-workspace-grants.md
+++ b/docs/decisions/0092-workspace-grants.md
@@ -16,9 +16,13 @@ Adapter grants have a kind, `person` or `workspace`. Existing rows are person gr
 
 A workspace grant is owned by a service-kind principal and covers one Slack workspace. A service principal starts the handshake (`POST /code/grants/workspace`). On a gateway-authenticated machine the machine enrolls the gateway delegation at start with the service's own lease, because that identity never has a browser. An admin approves (`POST /deployment/code/grants/workspace/{id}/approve`). The adapter completes as for a person handshake. The handshake records `approved_by` as the admin's owner id.
 
-Under a workspace grant, external get-or-create requires a `channel_id`. An unconfirmed `(channel, repository)` pair is refused (`409 repository_unconfirmed`) and recorded as pending with the body's `set_by`. An admin confirms. A later different repository supersedes the pending row. Person grants are unchanged.
+Under a workspace grant, external get-or-create requires a `channel_id`. An unconfirmed `(channel, repository)` pair is refused (`409 repository_unconfirmed`) and recorded as pending with the body's `set_by`. An administrator approves the channel’s repository scope in Settings > Channels. The scope can contain several explicit repositories and can be approved before the first task. Each approval persists for that channel and grant. Additional requests remain pending independently so a task can select several repositories. Person grants are unchanged.
 
-The shared identity's forge credential is the ceiling. The admin's confirmation per channel and repository is the gate.
+The shared identity's forge credential is the ceiling. The channel’s approved repository scope is the gate. Approval never grants GitHub access that the shared identity lacks.
+
+`POST /deployment/code/grants/workspace/{id}/channels/{channel_id}/repositories/approve` adds a batch of explicit repositories to that scope. The endpoint requires administrator authority, validates and canonicalizes the entire batch before writing, and commits all approvals together. Existing single-repository confirmations remain supported. Revoking the workspace grant removes its authority.
+
+The scope flow replaces the original rule that a later request supersedes an earlier pending repository. Existing superseded requests can be approved explicitly or become pending again when retried.
 
 Messages under a workspace grant take the actor from the body. `PUT /external/code/sessions/{id}/access` replaces that session's `external:<channel kind>:<user id>` contribute rows with the adapter's list. Revoking the workspace grant fences every channel session it tagged.
 
@@ -40,7 +44,9 @@ Revisit this if a workspace grant must cover more than one Slack workspace, or i
 
 - A service principal starts a workspace handshake; a person cannot.
 - A non-admin cannot approve; an admin can, and the adapter completes.
-- A channel session refuses until the repository is confirmed, then runs.
+- An administrator approves several repositories before a task starts; the channel can then use each repository without another confirmation.
+- Requests for several repositories remain pending together; an invalid batch changes nothing.
+- Another channel or grant cannot reuse the scope. Revoked and person grants cannot receive a channel scope.
 - The actor from the body lands on the turn; a person grant refuses a body actor.
 - Access rows are replaced by the adapter's list.
 - Revoking the workspace grant fences every channel session at once.

--- a/docs/decisions/0094-repository-optional-conversations-on-the-internal-engine.md
+++ b/docs/decisions/0094-repository-optional-conversations-on-the-internal-engine.md
@@ -38,7 +38,10 @@ Children inherit the parent's owner, grant, and forge identity. Machine children
 the parent's permission mode. Children placed in a configured sandbox use Allow under
 the sandbox's confinement policy. Child creation is Sensitive; reads and waits are
 ReadOnly. A revoked grant refuses discovery, creation, and child reads. Workspace grants
-require channel repository confirmation before cloning.
+require an approved channel repository scope before cloning. An administrator can approve
+several repositories together in Settings > Channels before any child starts. A child
+inside that scope needs no further channel confirmation. Requests outside the scope
+remain pending independently until the administrator adds them.
 
 Child creation uses a stable `request_key`. A retry after `repository_preparing`
 observes the same owner's clone job. If a crash commits the child binding before its

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -921,3 +921,24 @@ checks workspace membership before calling; attachment does not change the
 session's access rows. Each bound thread reads the same event stream with its
 own cursor. Snapshots expose `external_origins` and preserve `external_origin`
 as the first thread for older clients. Decision 93 records the boundary.
+
+### Approve a channel’s repository scope
+
+After connecting the Slack workspace, open Tidebreak **Settings > Channels** as
+an administrator. Add the Slack channel ID and the GitHub repositories that the
+channel may use, then approve them together. You can do this before anyone starts
+a task. You can also approve the repositories that a task has already requested
+together from the channel’s pending list.
+
+The agent can choose any repository in that channel’s approved scope and work
+across several repositories without asking for the same approval again. The
+GitHub connection must still permit each repository. Approvals apply only to the
+selected channel and workspace grant; revoking the grant cuts off that scope.
+Adding repositories preserves existing approvals. A chat answer does not grant
+access: after the administrator saves the scope, retry the waiting task.
+
+Administrators can also add scope through
+`POST /deployment/code/grants/workspace/{id}/channels/{channel_id}/repositories/approve`
+with `{"repositories":["acme/frontend","acme/backend"]}`. The endpoint accepts
+1–100 explicit repository names or GitHub URLs, canonicalizes them, and commits
+the whole batch together. Wildcards are not accepted.


### PR DESCRIPTION
Slack tasks that choose several repositories stop at a confirmation prompt that Channels settings cannot fulfill. Channels now lets an administrator approve an explicit repository scope before the first task, or approve the pending repositories together. Agents can choose and work across that scope without asking for the same approval again.

The scope is additive and stays tied to one channel and workspace grant. A human administrator must approve it, and the shared GitHub identity must still have access. The API validates and canonicalizes the full batch before committing up to 100 approvals together. Person grants and the existing single-repository confirmation endpoint remain compatible.

Pending requests no longer replace each other. Older superseded requests can be retried, and approval collapses historical casing aliases so an approved repository cannot remain displayed as pending. Registered-repository admission and thread attachment also require the matching GitHub origin.

Validation:
- Focused core and HTTP tests cover preapproval, several repositories, channel/grant isolation, mixed-case aliases, unsupported origins, rejected batches, and revoked or non-admin authority.
- Channels DOM, API-client, and style-contract tests pass. TypeScript, Biome, and Storybook build pass.
- Rust formatting and diff checks pass.
- Browser automation and screenshot review were not run, per the requested no-computer-use constraint. Storybook includes setup, pending, approved, failure, and long-content states.
