### PR TITLE
fix(hosted): bind relayed engine turns to the installed engine

### DIFF
--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -518,6 +518,7 @@ async fn a_sessions_git_borrows_the_persons_credential_from_the_loopback_route()
     let key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
         owner: owner.clone(),
         session: session_id,
+        engine: None,
     });
     let route = format!(
         "http://{addr}{}",
@@ -566,6 +567,7 @@ async fn a_sessions_git_borrows_the_persons_credential_from_the_loopback_route()
     let bot_key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
         owner: owner.clone(),
         session: bot_session.id,
+        engine: None,
     });
     let bot_lent = ask(
         "protocol=https\nhost=github.com\npath=acme/tools.git\n",
@@ -656,10 +658,12 @@ async fn a_sessions_git_borrows_the_standalone_deployment_token_from_the_loopbac
     let bot_key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
         owner: owner.clone(),
         session: session_id,
+        engine: None,
     });
     let person_key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
         owner: owner.clone(),
         session: person_session.id,
+        engine: None,
     });
     let route = format!(
         "http://{addr}{}",
@@ -2557,6 +2561,7 @@ async fn a_refused_borrow_answers_the_helper_and_journals_the_reason() {
         let key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
             owner: owner.clone(),
             session: session_id,
+            engine: None,
         });
         let refused = client
             .post(format!(

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -42,11 +42,16 @@ use std::path::Path;
 
 use crate::obo_gateway::{GatewayCompatModel, OboGateway};
 
-/// Whose inference a relay key spends.
+/// Whose inference a relay key spends, and which installed engine spends it.
 #[derive(Clone)]
 pub struct HarnessLlmSubject {
     pub owner: OwnerId,
     pub session: SessionId,
+    /// The engine child this key was issued to, when the worker could name
+    /// it. The relay exchanges an engine-bound token for it (gateway decision
+    /// 118) so the child's turns may draw on the caller's subscription for
+    /// that engine; `None` exchanges ordinary Tidebreak inference.
+    pub engine: Option<crate::obo_gateway::EmbeddedEngine>,
 }
 
 /// The gateway compat endpoint one relay route forwards to.
@@ -297,21 +302,32 @@ impl HarnessLlmRelay {
             ));
         };
         let bearer = async {
-            self.gateway_for_session(&subject.owner, subject.session)
-                .await?
-                .bearer_for(&subject.owner)
-                .await
+            let gateway = self
+                .gateway_for_session(&subject.owner, subject.session)
+                .await?;
+            match subject.engine.as_ref() {
+                Some(engine) => {
+                    gateway
+                        .bearer_for_engine(&subject.owner, subject.session, engine)
+                        .await
+                }
+                None => gateway.bearer_for(&subject.owner).await,
+            }
         }
         .await;
         match bearer {
             Ok(token) => Ok(token),
-            Err(error @ (AgentError::SignInRequired(_) | AgentError::InvalidTarget(_))) => {
-                Err(endpoint.error_response(
-                    StatusCode::UNAUTHORIZED,
-                    "authentication_error",
-                    &error.to_string(),
-                ))
-            }
+            // A machine without a gateway identity cannot bind an engine; that
+            // is a deployment fault the engine should report once, not retry.
+            Err(
+                error @ (AgentError::SignInRequired(_)
+                | AgentError::InvalidTarget(_)
+                | AgentError::Config(_)),
+            ) => Err(endpoint.error_response(
+                StatusCode::UNAUTHORIZED,
+                "authentication_error",
+                &error.to_string(),
+            )),
             Err(error) => Err(endpoint.error_response(
                 StatusCode::BAD_GATEWAY,
                 "api_error",
@@ -713,6 +729,18 @@ mod tests {
         HarnessLlmSubject {
             owner: owner(name),
             session: SessionId::new(),
+            engine: None,
+        }
+    }
+
+    fn engine_subject_for(name: &str) -> HarnessLlmSubject {
+        HarnessLlmSubject {
+            owner: owner(name),
+            session: SessionId::new(),
+            engine: crate::obo_gateway::EmbeddedEngine::installed(
+                HarnessKind::ClaudeCode,
+                Some("2.1.220"),
+            ),
         }
     }
 
@@ -728,6 +756,12 @@ mod tests {
     /// compat endpoint received, so a test can assert on the relayed request
     /// through the relayed response.
     async fn fake_gateway() -> Arc<OboGateway> {
+        Arc::new(fake_gateway_acknowledging(true).await)
+    }
+
+    /// The same gateway, minting `mg_it_<engine>` for an engine-bound
+    /// exchange and echoing the binding back only when `acknowledge_engine`.
+    async fn fake_gateway_acknowledging(acknowledge_engine: bool) -> OboGateway {
         async fn seen(headers: HeaderMap, RawQuery(query): RawQuery, body: String) -> Response {
             (
                 [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
@@ -745,13 +779,36 @@ mod tests {
         let app = axum::Router::new()
             .route(
                 "/oauth/token",
-                post(|| async {
-                    Json(serde_json::json!({
-                        "access_token": "mg_it_fresh",
-                        "expires_in": 3600,
-                        "token_type": "Bearer",
-                    }))
-                }),
+                post(
+                    move |axum::Form(form): axum::Form<HashMap<String, String>>| async move {
+                        let mut body = serde_json::json!({
+                            "access_token": "mg_it_fresh",
+                            "expires_in": 3600,
+                            "token_type": "Bearer",
+                        });
+                        if let Some(engine) = form.get("engine") {
+                            // The binding rides the machine's add-on identity,
+                            // asserted server-side so a drifted client fails
+                            // the test.
+                            assert!(
+                                form.get("client_id").is_some_and(|value| !value.is_empty())
+                                    && form
+                                        .get("client_secret")
+                                        .is_some_and(|value| !value.is_empty()),
+                                "an engine binding must authenticate the add-on"
+                            );
+                            body["access_token"] = serde_json::json!(format!("mg_it_{engine}"));
+                            if acknowledge_engine {
+                                body["engine"] = serde_json::json!(engine);
+                                body["engine_version"] =
+                                    serde_json::json!(form.get("engine_version"));
+                                body["engine_session_id"] =
+                                    serde_json::json!(form.get("engine_session_id"));
+                            }
+                        }
+                        Json(body)
+                    },
+                ),
             )
             .route(
                 "/compat/openai/v1/models",
@@ -770,7 +827,7 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-        Arc::new(OboGateway::new(&format!("http://{address}"), TEST_RESOURCE.to_owned()).unwrap())
+        OboGateway::new(&format!("http://{address}"), TEST_RESOURCE.to_owned()).unwrap()
     }
 
     fn bearer_headers(key: &str) -> HeaderMap {
@@ -907,6 +964,84 @@ mod tests {
             !text.contains(&key) && !text.contains("should-never-forward"),
             "child credentials never reach the gateway: {text}"
         );
+    }
+
+    /// An engine child's relayed turn is exchanged with the engine binding
+    /// the worker issued its key under, so the gateway can pair the caller's
+    /// subscription for that engine; the machine's add-on identity signs it.
+    #[tokio::test]
+    async fn forward_exchanges_an_engine_bound_token_for_an_engine_child() {
+        let obo = fake_gateway_acknowledging(true)
+            .await
+            .with_machine_credentials_for_test("tidebreak", "machine-secret");
+        obo.record_caller(&owner("thet"), Arc::from("mg_at_live"));
+        let relay = HarnessLlmRelay::new(Arc::new(obo));
+        let key = relay.issue(engine_subject_for("thet"));
+
+        let response = relay
+            .forward(
+                RelayEndpoint::AnthropicMessages,
+                &bearer_headers(&key),
+                None,
+                axum::body::Body::from(r#"{"model":"claude-opus-5"}"#),
+            )
+            .await;
+        let (status, text) = read_text(response).await;
+        assert_eq!(status, StatusCode::OK, "{text}");
+        assert!(
+            text.contains("auth=Bearer mg_it_claude_code"),
+            "the engine-bound token replaces the relay key: {text}"
+        );
+    }
+
+    /// A gateway that mints without echoing the binding is one that ran the
+    /// exchange as ordinary Tidebreak inference. The relay refuses the turn
+    /// instead of spending it off-subscription behind the engine's back.
+    #[tokio::test]
+    async fn forward_refuses_an_engine_binding_the_gateway_does_not_acknowledge() {
+        let obo = fake_gateway_acknowledging(false)
+            .await
+            .with_machine_credentials_for_test("tidebreak", "machine-secret");
+        obo.record_caller(&owner("thet"), Arc::from("mg_at_live"));
+        let relay = HarnessLlmRelay::new(Arc::new(obo));
+        let key = relay.issue(engine_subject_for("thet"));
+
+        let response = relay
+            .forward(
+                RelayEndpoint::AnthropicMessages,
+                &bearer_headers(&key),
+                None,
+                axum::body::Body::empty(),
+            )
+            .await;
+        let (status, text) = read_text(response).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{text}");
+        assert!(
+            text.contains("authentication_error") && text.contains("did not acknowledge"),
+            "{text}"
+        );
+    }
+
+    /// Without a machine identity there is nothing to sign the binding with;
+    /// the engine sees the deployment fault rather than a metered turn.
+    #[tokio::test]
+    async fn forward_refuses_an_engine_binding_without_a_machine_identity() {
+        let obo = fake_gateway_acknowledging(true).await;
+        obo.record_caller(&owner("thet"), Arc::from("mg_at_live"));
+        let relay = HarnessLlmRelay::new(Arc::new(obo));
+        let key = relay.issue(engine_subject_for("thet"));
+
+        let response = relay
+            .forward(
+                RelayEndpoint::AnthropicMessages,
+                &bearer_headers(&key),
+                None,
+                axum::body::Body::empty(),
+            )
+            .await;
+        let (status, text) = read_text(response).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{text}");
+        assert!(text.contains("GATEWAY_CLIENT_ID"), "{text}");
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -209,12 +209,13 @@ impl CodeRuntime {
                 ))
             }
         };
+        let engine_version = probe.version.clone().or(session.harness_version.clone());
         let attached = attach_engine(
             &self.db,
             &self.bus,
             session.id,
             session.harness_kind,
-            probe.version.clone().or(session.harness_version.clone()),
+            engine_version.clone(),
             None,
         )
         .await
@@ -334,9 +335,27 @@ impl CodeRuntime {
                     .ok_or_else(|| {
                         ServerError::internal("harness LLM relay: loopback base not set")
                     })?;
+                // Name the installed engine so the relay exchanges an
+                // engine-bound token for the child (gateway decision 118):
+                // that is what lets its turns draw on the caller's Claude or
+                // Codex subscription instead of being metered as Tidebreak.
+                let engine = crate::obo_gateway::EmbeddedEngine::installed(
+                    session.harness_kind,
+                    engine_version.as_deref(),
+                );
+                if engine.is_none() && relay.forwards_inference() {
+                    tracing::warn!(
+                        session = %session.id,
+                        harness = %session.harness_kind,
+                        "the installed engine reported no version, so its turns run as \
+                         ordinary Tidebreak inference and cannot use an engine-bound \
+                         subscription"
+                    );
+                }
                 let key = relay.issue(crate::code::harness_llm::HarnessLlmSubject {
                     owner: session.owner.clone(),
                     session: session.id,
+                    engine,
                 });
                 let (argv, mut env) = if relay.forwards_inference() {
                     crate::code::harness_llm::spawn_wiring(session.harness_kind, &base, &key)

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -45,7 +45,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::StreamExt as _;
 
-use tidebreak_core::{AgentError, OwnerId, Profile, Result, SessionId};
+use tidebreak_core::{AgentError, HarnessKind, OwnerId, Profile, Result, SessionId};
 use tidebreak_router::BearerTokenSource;
 
 /// Mint a replacement this close to expiry instead of using the cached token.
@@ -117,15 +117,54 @@ impl CachedToken {
     }
 }
 
+/// The installed engine one relayed session runs, as the gateway binds it
+/// (gateway decision 118).
+///
+/// An inference token exchanged with this binding keeps Tidebreak as its
+/// host attribution; the gateway reads the engine only to decide which of
+/// the caller's provider subscriptions the turn may draw on. Anthropic and
+/// OpenAI honor a consumer plan for their own engine alone, so a Claude Code
+/// or Codex child relayed without a binding is always metered. The version
+/// is the installed binary's, exactly as its `--version` prints it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EmbeddedEngine {
+    pub kind: HarnessKind,
+    pub version: String,
+}
+
+impl EmbeddedEngine {
+    /// The binding for an engine child, or `None` when there is nothing to
+    /// bind: the in-process engine is Tidebreak itself, and an engine whose
+    /// version the probe could not read cannot be named to the gateway
+    /// truthfully.
+    #[must_use]
+    pub fn installed(kind: HarnessKind, version: Option<&str>) -> Option<Self> {
+        if kind.is_in_process() {
+            return None;
+        }
+        let version = version
+            .map(str::trim)
+            .filter(|version| !version.is_empty())?;
+        Some(Self {
+            kind,
+            version: version.to_owned(),
+        })
+    }
+}
+
 /// What this process remembers about one caller.
 ///
 /// `subject` is the most recent machine-bound bearer that caller presented,
 /// and `token` is the inference token exchanged from it. The `token` mutex is
 /// also the single-flight gate: concurrent turns for the same user queue on it
-/// and all but the first find a fresh token already there.
+/// and all but the first find a fresh token already there. `engine_tokens`
+/// holds the engine-bound tokens the relay exchanges for the caller's
+/// sessions, one per session, engine, and version, because the gateway binds
+/// each of those immutably.
 struct UserSlot {
     subject: std::sync::Mutex<Arc<str>>,
     token: tokio::sync::Mutex<Option<CachedToken>>,
+    engine_tokens: tokio::sync::Mutex<HashMap<(SessionId, EmbeddedEngine), CachedToken>>,
     catalog: tokio::sync::Mutex<Option<CachedCatalog>>,
     git_forge: tokio::sync::Mutex<HashMap<GitForgeAttributionRequest, CachedGitForge>>,
 }
@@ -167,10 +206,19 @@ struct OAuthError {
 }
 
 /// A successful exchange.
+///
+/// The engine fields echo an engine binding the gateway accepted
+/// (gateway decision 118); an ordinary exchange carries none.
 #[derive(serde::Deserialize)]
 struct ExchangeResponse {
     access_token: String,
     expires_in: u64,
+    #[serde(default)]
+    engine: Option<String>,
+    #[serde(default)]
+    engine_version: Option<String>,
+    #[serde(default)]
+    engine_session_id: Option<String>,
 }
 
 /// The forge identity a hosted machine's git operations act as.
@@ -456,6 +504,7 @@ impl OboGateway {
                     Arc::new(UserSlot {
                         subject: std::sync::Mutex::new(bearer),
                         token: tokio::sync::Mutex::new(None),
+                        engine_tokens: tokio::sync::Mutex::new(HashMap::new()),
                         catalog: tokio::sync::Mutex::new(None),
                         git_forge: tokio::sync::Mutex::new(HashMap::new()),
                     }),
@@ -544,6 +593,58 @@ impl OboGateway {
         Ok(token)
     }
 
+    /// The current inference token for `owner`'s `session`, bound to the
+    /// installed `engine` that session runs, exchanging one if the cached
+    /// token is missing or near expiry.
+    ///
+    /// Cached per session, engine, and version: the gateway binds each of
+    /// those immutably, so a token for one never serves another.
+    ///
+    /// # Errors
+    /// Fails when this process holds no subject token for `owner`, no
+    /// machine identity to authenticate the binding with, or when the
+    /// gateway refuses the exchange or does not acknowledge the binding.
+    pub async fn bearer_for_engine(
+        &self,
+        owner: &OwnerId,
+        session: SessionId,
+        engine: &EmbeddedEngine,
+    ) -> Result<String> {
+        let slot = {
+            let users = self.users.lock().map_err(|_| {
+                AgentError::msg("on-behalf-of inference state is unavailable in this process")
+            })?;
+            users.get(owner).cloned()
+        };
+        let Some(slot) = slot else {
+            return Err(AgentError::SignInRequired(
+                "this machine holds no live Model Gateway session for you; sign in again".into(),
+            ));
+        };
+        let key = (session, engine.clone());
+        // One gate for all of a caller's engine tokens: an exchange is quick,
+        // and a second turn for the same session then finds a fresh token.
+        let mut cached = slot.engine_tokens.lock().await;
+        if let Some(current) = cached.get(&key) {
+            if current.is_fresh() {
+                return Ok(current.token.to_string());
+            }
+        }
+        let subject = {
+            let subject = slot.subject.lock().map_err(|_| {
+                AgentError::msg("on-behalf-of inference state is unavailable in this process")
+            })?;
+            subject.clone()
+        };
+        let minted = self
+            .exchange_with(&subject, INFERENCE_AUDIENCE, Some((session, engine)))
+            .await?;
+        let token = minted.token.to_string();
+        cached.retain(|_, held| held.is_fresh());
+        cached.insert(key, minted);
+        Ok(token)
+    }
+
     /// Exchange one caller bearer for a short-lived inference token.
     ///
     /// # Errors
@@ -552,12 +653,51 @@ impl OboGateway {
     /// handles. Every other non-success is a refusal too — this never retries
     /// onto another credential.
     async fn exchange(&self, subject: &str, audience: &str) -> Result<CachedToken> {
-        let form: [(&str, &str); 4] = [
+        self.exchange_with(subject, audience, None).await
+    }
+
+    /// The exchange, optionally binding the token to the installed engine a
+    /// session runs (gateway decision 118).
+    ///
+    /// A binding rides this machine's registered add-on identity, so a
+    /// caller's bearer alone never asserts an engine. The gateway echoes the
+    /// engine, version, and session it bound; anything short of an exact
+    /// echo is refused rather than used, because a token the gateway minted
+    /// as ordinary Tidebreak inference would silently run the engine's turns
+    /// off the caller's subscription.
+    async fn exchange_with(
+        &self,
+        subject: &str,
+        audience: &str,
+        engine: Option<(SessionId, &EmbeddedEngine)>,
+    ) -> Result<CachedToken> {
+        let mut form: Vec<(&str, &str)> = vec![
             ("grant_type", TOKEN_EXCHANGE_GRANT),
             ("subject_token", subject),
             ("subject_token_type", SUBJECT_TOKEN_TYPE),
             ("audience", audience),
         ];
+        let bound = engine.map(|(session, engine)| {
+            (
+                engine.kind.as_str(),
+                engine.version.as_str(),
+                session.as_uuid().to_string(),
+            )
+        });
+        if let Some((kind, version, session)) = &bound {
+            let (client_id, client_secret) =
+                self.machine_credentials.as_ref().ok_or_else(|| {
+                    AgentError::config(
+                        "this machine has no gateway identity to bind an installed engine with; \
+                         set GATEWAY_CLIENT_ID and GATEWAY_CLIENT_SECRET",
+                    )
+                })?;
+            form.push(("engine", kind));
+            form.push(("engine_version", version));
+            form.push(("engine_session_id", session.as_str()));
+            form.push(("client_id", client_id.as_str()));
+            form.push(("client_secret", client_secret.as_str()));
+        }
         let response = self
             .client
             .post(self.token_url.clone())
@@ -581,6 +721,19 @@ impl OboGateway {
             return Err(AgentError::msg(
                 "the Model Gateway returned an empty on-behalf-of token",
             ));
+        }
+        if let Some((kind, version, session)) = &bound {
+            let acknowledged = exchanged.engine.as_deref() == Some(*kind)
+                && exchanged.engine_version.as_deref() == Some(*version)
+                && exchanged.engine_session_id.as_deref() == Some(session.as_str());
+            if !acknowledged {
+                return Err(AgentError::InvalidTarget(
+                    "the Model Gateway did not acknowledge this session's installed engine \
+                     binding (gateway decision 118); refusing rather than running the engine \
+                     as ordinary Tidebreak inference"
+                        .into(),
+                ));
+            }
         }
         Ok(CachedToken {
             token: exchanged.access_token.into(),
@@ -1792,6 +1945,12 @@ mod tests {
         forge_answer: Arc<std::sync::Mutex<Option<serde_json::Value>>>,
         /// Last `attribution` query or body token the git surfaces saw.
         last_attribution: Arc<std::sync::Mutex<Option<String>>>,
+        /// Whether an engine-bound exchange echoes its binding back. Off
+        /// models a gateway that minted ordinary inference instead.
+        engine_ack: Arc<std::sync::atomic::AtomicBool>,
+        /// The last `(engine, engine_version, engine_session_id)` an
+        /// exchange declared.
+        last_engine: Arc<std::sync::Mutex<Option<(String, String, String)>>>,
     }
 
     impl FakeGateway {
@@ -1807,6 +1966,8 @@ mod tests {
                 git_refusal: Arc::new(std::sync::Mutex::new(None)),
                 forge_answer: Arc::new(std::sync::Mutex::new(None)),
                 last_attribution: Arc::new(std::sync::Mutex::new(None)),
+                engine_ack: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+                last_engine: Arc::new(std::sync::Mutex::new(None)),
                 catalog: Arc::new(std::sync::Mutex::new(serde_json::json!({
                     "models": [
                         {
@@ -1899,20 +2060,49 @@ mod tests {
                                 .into_response();
                         }
                         let serial = state.mints.fetch_add(1, Ordering::SeqCst);
+                        let engine = form.get("engine").cloned();
                         let label = if audience == CATALOG_AUDIENCE {
                             "catalog"
                         } else if audience.starts_with("runtime:") {
                             "runtime"
+                        } else if engine.is_some() {
+                            "engine"
                         } else {
                             "inference"
                         };
-                        Json(serde_json::json!({
+                        let mut body = serde_json::json!({
                             "access_token": format!("mg_at_{label}_{serial}_for_{subject}"),
                             "token_type": "Bearer",
                             "expires_in": state.lifetime.load(Ordering::SeqCst),
                             "scope": "inference:invoke",
-                        }))
-                        .into_response()
+                        });
+                        if let Some(engine) = engine {
+                            // An engine binding authenticates the add-on with
+                            // its client credentials beside the subject
+                            // (gateway decision 118), asserted server-side.
+                            assert_eq!(audience, INFERENCE_AUDIENCE, "engines bind llm only");
+                            assert_eq!(
+                                form.get("client_id").map(String::as_str),
+                                Some("tidebreak")
+                            );
+                            assert_eq!(
+                                form.get("client_secret").map(String::as_str),
+                                Some("test-machine-secret")
+                            );
+                            let version = form.get("engine_version").cloned().unwrap_or_default();
+                            let session =
+                                form.get("engine_session_id").cloned().unwrap_or_default();
+                            assert!(!version.is_empty() && !session.is_empty());
+                            if let Ok(mut last) = state.last_engine.lock() {
+                                *last = Some((engine.clone(), version.clone(), session.clone()));
+                            }
+                            if state.engine_ack.load(Ordering::SeqCst) {
+                                body["engine"] = serde_json::json!(engine);
+                                body["engine_version"] = serde_json::json!(version);
+                                body["engine_session_id"] = serde_json::json!(session);
+                            }
+                        }
+                        Json(body).into_response()
                     }
                 }),
             );
@@ -2143,6 +2333,121 @@ mod tests {
         assert!(token.ends_with("mg_at_alice"));
         assert_eq!(gateway.served(), 1);
         server.abort();
+    }
+
+    fn claude_code(version: &str) -> EmbeddedEngine {
+        EmbeddedEngine::installed(HarnessKind::ClaudeCode, Some(version)).unwrap()
+    }
+
+    /// An engine-bound exchange declares the installed engine, its version,
+    /// and the session, signed by the machine's add-on identity, and the
+    /// result is cached per session, engine, and version rather than shared
+    /// with the caller's ordinary inference token.
+    #[tokio::test]
+    async fn an_engine_bound_exchange_declares_the_engine_and_caches_per_binding() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let inference = Arc::new(
+            Arc::try_unwrap(inference)
+                .ok()
+                .expect("fresh gateway")
+                .with_machine_credentials_for_test("tidebreak", "test-machine-secret"),
+        );
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+        let session = SessionId::new();
+
+        let bound = inference
+            .bearer_for_engine(&alice, session, &claude_code("2.1.220"))
+            .await
+            .unwrap();
+        assert!(bound.starts_with("mg_at_engine_"), "{bound}");
+        assert_eq!(
+            gateway.last_engine.lock().unwrap().clone(),
+            Some((
+                "claude_code".to_owned(),
+                "2.1.220".to_owned(),
+                session.as_uuid().to_string()
+            ))
+        );
+
+        // Same binding: served from cache. The ordinary token, another
+        // session, and an upgraded binary each exchange again.
+        let again = inference
+            .bearer_for_engine(&alice, session, &claude_code("2.1.220"))
+            .await
+            .unwrap();
+        assert_eq!(again, bound);
+        assert_eq!(gateway.served(), 1);
+        let ordinary = inference.bearer_for(&alice).await.unwrap();
+        assert!(ordinary.starts_with("mg_at_inference_"), "{ordinary}");
+        inference
+            .bearer_for_engine(&alice, SessionId::new(), &claude_code("2.1.220"))
+            .await
+            .unwrap();
+        inference
+            .bearer_for_engine(&alice, session, &claude_code("2.1.221"))
+            .await
+            .unwrap();
+        assert_eq!(gateway.served(), 4);
+        server.abort();
+    }
+
+    /// A gateway that mints without echoing the binding minted ordinary
+    /// inference; the exchange refuses rather than caching that token under
+    /// the engine.
+    #[tokio::test]
+    async fn an_unacknowledged_engine_binding_is_refused() {
+        let gateway = FakeGateway::new();
+        gateway.engine_ack.store(false, Ordering::SeqCst);
+        let (inference, server) = gateway.clone().start().await;
+        let inference = Arc::try_unwrap(inference)
+            .ok()
+            .expect("fresh gateway")
+            .with_machine_credentials_for_test("tidebreak", "test-machine-secret");
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+
+        let error = inference
+            .bearer_for_engine(&alice, SessionId::new(), &claude_code("2.1.220"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AgentError::InvalidTarget(_)), "{error}");
+        server.abort();
+    }
+
+    /// Without a machine identity the binding cannot be signed, and the
+    /// exchange never degrades to ordinary inference on its own.
+    #[tokio::test]
+    async fn an_engine_binding_needs_the_machine_identity() {
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        inference.record_caller(&alice, "mg_at_alice".into());
+
+        let error = inference
+            .bearer_for_engine(&alice, SessionId::new(), &claude_code("2.1.220"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AgentError::Config(_)), "{error}");
+        assert_eq!(gateway.served(), 0);
+        server.abort();
+    }
+
+    /// The in-process engine is Tidebreak itself, and an engine with no
+    /// readable version cannot be named truthfully: neither binds.
+    #[test]
+    fn only_a_versioned_external_engine_binds() {
+        assert!(EmbeddedEngine::installed(HarnessKind::Internal, Some("1.0.0")).is_none());
+        assert!(EmbeddedEngine::installed(HarnessKind::Codex, None).is_none());
+        assert!(EmbeddedEngine::installed(HarnessKind::Codex, Some("  ")).is_none());
+        assert_eq!(
+            EmbeddedEngine::installed(HarnessKind::Codex, Some("0.147.0 \n")),
+            Some(EmbeddedEngine {
+                kind: HarnessKind::Codex,
+                version: "0.147.0".to_owned()
+            })
+        );
     }
 
     /// A runtime bearer is exchanged for the `runtime:{endpoint}` audience,

--- a/crates/tidebreak-server/src/obo_gateway/external.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external.rs
@@ -233,10 +233,16 @@ impl ExternalDelegations {
         // A revoke may commit while the mint is in flight. Recheck before
         // publishing its result into the slot or using it for an exchange.
         self.live_handshake(owner, grant).await?;
-        let gateway = Arc::new(OboGateway::new(
+        let mut gateway = OboGateway::new(
             &self.gateway.gateway_base_url,
             self.gateway.resource.clone(),
-        )?);
+        )?;
+        // A delegated session binds the installed engine it runs with the
+        // same machine identity the browser path uses: the gateway
+        // authenticates the binding by the registered add-on, not by whose
+        // consent the subject token came from.
+        gateway.machine_credentials = self.gateway.machine_credentials.clone();
+        let gateway = Arc::new(gateway);
         gateway.record_caller(owner, token.access_token.into());
         *held = Some(DelegatedGateway {
             expires_at: unix_time().saturating_add(token.expires_in),

--- a/crates/tidebreak-server/src/obo_gateway/external/tests.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external/tests.rs
@@ -398,6 +398,7 @@ async fn first_relay_request_after_restart_uses_the_persisted_session_grant() {
     let key = restarted.issue(HarnessLlmSubject {
         owner: owner.clone(),
         session: session.id,
+        engine: None,
     });
     let mut headers = HeaderMap::new();
     headers.insert("authorization", format!("Bearer {key}").parse().unwrap());


### PR DESCRIPTION
## Problem

On a hosted machine, every Claude Code, Codex, opencode, and Grok child sends inference through the server's relay, which exchanges the caller's machine token for an inference token with no engine information. The gateway stamps that token as client `tidebreak`. Anthropic and OpenAI pair a consumer subscription only with their own engine, so every relayed turn is metered even when the caller connected a subscription.

Local desktop sessions are unaffected: the desktop never relays engine children.

## Fix

The gateway's token exchange accepts an engine binding since decision 118: `engine`, `engine_version`, and `engine_session_id`, signed with the machine's registered add-on credentials (`GATEWAY_CLIENT_ID` / `GATEWAY_CLIENT_SECRET`). This change sends it.

- The worker names the installed engine and its probed version when it issues a relay key.
- The relay exchanges an engine-bound token for that key. The on-behalf-of module caches those tokens per session, engine, and version, because the gateway binds each immutably.
- The exchange requires the gateway to echo the binding back exactly and refuses otherwise. A mint without the echo ran ordinary Tidebreak inference, and using it would spend the engine's turns off-subscription behind its back.
- Delegated Slack gateways inherit the machine identity, so a delegated session binds the same way.
- An engine whose version the probe could not read is not bound, with a warning, rather than named untruthfully. The in-process engine keeps the Tidebreak identity.

Requires a gateway carrying decision 118 (v0.1.0-alpha.208 line or later). An older gateway refuses engine turns loudly instead of metering them silently.

## Out of scope

Slack tasks run in gateway sandboxes whose profile permits only the `custom` harness, so they carry the Generic identity. That needs the supervised engine registration half of decision 118 on the sandbox runtime side, tracked separately.

## Validation

- `cargo test -p tidebreak-server-core --lib -- obo_gateway harness_llm`: 78 passed, including new tests for the engine-bound exchange, per-binding caching, the unacknowledged-binding refusal, and the missing-machine-identity refusal.
- `cargo check -p tidebreak-server --tests`, `cargo clippy -p tidebreak-server-core --tests`, `cargo fmt --all --check`: clean.
