### PR TITLE
fix(slack): register the sandbox's installed engine for subscription pairing

### DIFF
--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -29,7 +29,7 @@ use tidebreak_core::{
 };
 
 use super::ingest::{ingest_events, IngestBinding, IngestOutcome};
-use super::wire::{EventCursor, SandboxMessage, SpawnArguments};
+use super::wire::{EventCursor, SandboxMessage, SpawnArguments, SpawnEmbeddedEngine};
 use super::{
     apply_attention, fence_session, journal_event, persist_session, reap_session,
     recover_dead_worker, replace_attention, RemoteReapError, RemoteSandboxError, RemoteSessionHost,
@@ -48,6 +48,12 @@ pub struct RemoteSpawnSettings {
     pub profile: String,
     /// Engine and Allow mode supplied by the declared supervised image.
     pub engine: Option<tidebreak_core::HarnessKind>,
+    /// Further engines the supervised image runs, one chosen per session,
+    /// honored only under [`Self::embedded_engine_registration`].
+    pub engines: Vec<tidebreak_core::HarnessKind>,
+    /// Whether spawns name the session's engine for the environment to bind
+    /// (gateway decision 118).
+    pub embedded_engine_registration: bool,
     /// Concurrent live incarnations one owner may hold.
     pub incarnation_cap: usize,
     /// Per-spawn spend ceiling in micro-USD, when one is set.
@@ -63,9 +69,20 @@ impl RemoteSpawnSettings {
         let Some(engine) = self.engine else {
             return Ok(());
         };
-        if session.harness_kind != engine {
+        let admitted =
+            self.embedded_engine_registration && self.engines.contains(&session.harness_kind);
+        if session.harness_kind != engine && !admitted {
+            let choices = if self.embedded_engine_registration && !self.engines.is_empty() {
+                self.engines
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(" or ")
+            } else {
+                engine.to_string()
+            };
             return Err(format!(
-                "this sandbox profile runs {engine}; select that engine to start the session"
+                "this sandbox profile runs {choices}; select that engine to start the session"
             ));
         }
         if session.permission_mode != tidebreak_core::PermissionMode::Allow {
@@ -75,6 +92,20 @@ impl RemoteSpawnSettings {
             return Err("this sandbox profile does not support fast mode".into());
         }
         Ok(())
+    }
+
+    /// The engine identity a spawn declares for the environment to bind:
+    /// the session's external engine, when this machine registers engines.
+    /// The in-process engine is Tidebreak itself and never binds.
+    #[must_use]
+    pub fn embedded_engine(&self, session: &Session) -> Option<SpawnEmbeddedEngine> {
+        if !self.embedded_engine_registration || session.harness_kind.is_in_process() {
+            return None;
+        }
+        Some(SpawnEmbeddedEngine {
+            engine: session.harness_kind.as_str().to_owned(),
+            engine_session_id: session.id.as_uuid().to_string(),
+        })
     }
 }
 
@@ -546,6 +577,7 @@ impl RemoteDriver<'_> {
             wall_clock_timeout_seconds: None,
             spend_ceiling_microusd: settings.spend_ceiling_microusd,
             max_turns: None,
+            embedded_engine: settings.embedded_engine(session),
         };
         match provisioner.spawn(&owner, session.id, &arguments).await {
             Ok(lease) => {
@@ -1103,6 +1135,8 @@ mod tests {
         RemoteSpawnSettings {
             profile: "tidebreak-remote".to_owned(),
             engine: None,
+            engines: Vec::new(),
+            embedded_engine_registration: false,
             incarnation_cap: 2,
             spend_ceiling_microusd: Some(5_000_000),
             session_spend_ceiling_microusd: None,
@@ -1164,6 +1198,42 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    /// Under registration the spawn names the session's engine and UUID for
+    /// the environment to bind; without it the spawn stays engine-free, and
+    /// a listed engine other than the default is admitted for the session.
+    #[tokio::test]
+    async fn registration_names_the_session_engine_on_the_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, workspace, repo) = seed(dir.path()).await;
+        let fake = FakeProvisioner::default();
+        let mut settings = settings();
+        settings.engine = Some(tidebreak_core::HarnessKind::ClaudeCode);
+        settings.engines = vec![
+            tidebreak_core::HarnessKind::ClaudeCode,
+            tidebreak_core::HarnessKind::Codex,
+        ];
+        session.harness_kind = tidebreak_core::HarnessKind::Codex;
+        assert!(settings.validate_execution(&session).is_err());
+        assert!(settings.embedded_engine(&session).is_none());
+
+        settings.embedded_engine_registration = true;
+        assert!(settings.validate_execution(&session).is_ok());
+        let driver = driver!(&db, &bus, &fake, &settings);
+        driver
+            .submit_turn(&mut session, &workspace, &repo, "build it")
+            .await
+            .unwrap();
+        let spawns = fake.spawns.lock().unwrap();
+        assert_eq!(
+            spawns[0].embedded_engine,
+            Some(SpawnEmbeddedEngine {
+                engine: "codex".to_owned(),
+                engine_session_id: session.id.as_uuid().to_string(),
+            })
+        );
+        assert_eq!(spawns[0].harness, "custom");
     }
 
     /// A first turn on a fresh remote session reserves, spawns from the

--- a/crates/tidebreak-code-remote/src/wire.rs
+++ b/crates/tidebreak-code-remote/src/wire.rs
@@ -75,6 +75,21 @@ pub struct SpawnArguments {
     /// Optional turn budget including the spawn-task turn.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_turns: Option<u32>,
+    /// The session's installed engine for the environment to bind, sent
+    /// only when this machine registers engines (gateway decision 118).
+    /// The environment admits it for the `custom` harness on its managed
+    /// supervised profile and refuses it anywhere else.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedded_engine: Option<SpawnEmbeddedEngine>,
+}
+
+/// The engine identity a spawn asserts for the environment to bind.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct SpawnEmbeddedEngine {
+    /// Engine token the supervised image installs (`claude_code`, `codex`).
+    pub engine: String,
+    /// The Tidebreak session UUID the engine runs for.
+    pub engine_session_id: String,
 }
 
 /// One git repository a spawn declares.
@@ -311,6 +326,30 @@ mod tests {
             ["harness", "profile", "repository", "task"]
                 .iter()
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// An engine binding travels as its own object beside the harness, in
+    /// the field names the environment defines.
+    #[test]
+    fn spawn_arguments_carry_the_engine_binding_when_declared() {
+        let arguments = SpawnArguments {
+            profile: "tidebreak".to_owned(),
+            harness: "custom".to_owned(),
+            task: "fix the flaky test".to_owned(),
+            embedded_engine: Some(SpawnEmbeddedEngine {
+                engine: "codex".to_owned(),
+                engine_session_id: "018f0000-0000-7000-8000-000000000000".to_owned(),
+            }),
+            ..SpawnArguments::default()
+        };
+        let value = serde_json::to_value(&arguments).unwrap();
+        assert_eq!(
+            value["embedded_engine"],
+            serde_json::json!({
+                "engine": "codex",
+                "engine_session_id": "018f0000-0000-7000-8000-000000000000",
+            })
         );
     }
 

--- a/crates/tidebreak-core/src/config.rs
+++ b/crates/tidebreak-core/src/config.rs
@@ -257,6 +257,21 @@ pub struct Config {
     pub runtime_profile: Option<String>,
     /// Engine packaged in a supervised sandbox profile, when explicitly declared.
     pub runtime_engine: Option<crate::HarnessKind>,
+    /// Further engines the supervised image runs, one chosen per session,
+    /// when the gateway registers each sandbox's installed engine
+    /// (`TIDEBREAK_RUNTIME_ENGINES`). Read only with
+    /// [`Config::runtime_embedded_engine_registration`]; otherwise
+    /// [`Config::runtime_engine`] remains the only choice.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtime_engines: Vec<crate::HarnessKind>,
+    /// Whether spawns authenticate this machine's add-on identity and name
+    /// the session's engine, so the gateway binds the sandbox's installed
+    /// engine and pairs the caller's subscription for it (gateway decision
+    /// 118). Managed provisioning sets
+    /// `TIDEBREAK_RUNTIME_EMBEDDED_ENGINE_REGISTRATION=true`; a custom
+    /// profile that omits it keeps its existing exchange and spawn shape.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub runtime_embedded_engine_registration: bool,
     /// The permission mode an external (channel-bound) session starts in
     /// when it runs on this machine's own engine and the channel names none
     /// (decision 88). `ask` unless the operator says otherwise: an unattended
@@ -414,6 +429,8 @@ impl Config {
             runtime_endpoint: None,
             runtime_profile: None,
             runtime_engine: None,
+            runtime_engines: Vec::new(),
+            runtime_embedded_engine_registration: false,
             external_permission_mode: crate::PermissionMode::DEFAULT,
             external_permission_ceiling: crate::PermissionMode::DEFAULT,
             runtime_concurrency_cap: default_runtime_concurrency_cap(),
@@ -494,6 +511,12 @@ impl Config {
             config.with_runtime_engine_var(std::env::var("TIDEBREAK_RUNTIME_ENGINE").ok())
         })
         .and_then(|config| {
+            config.with_runtime_embedded_engine_vars(
+                std::env::var("TIDEBREAK_RUNTIME_EMBEDDED_ENGINE_REGISTRATION").ok(),
+                std::env::var("TIDEBREAK_RUNTIME_ENGINES").ok(),
+            )
+        })
+        .and_then(|config| {
             config.with_external_permission_vars(
                 std::env::var("TIDEBREAK_EXTERNAL_PERMISSION_MODE").ok(),
                 std::env::var("TIDEBREAK_EXTERNAL_PERMISSION_CEILING").ok(),
@@ -518,6 +541,60 @@ impl Config {
                 AgentError::config("TIDEBREAK_RUNTIME_ENGINE must name a supported external engine")
             })?;
         self.runtime_engine = Some(engine);
+        Ok(self)
+    }
+
+    /// Apply `TIDEBREAK_RUNTIME_EMBEDDED_ENGINE_REGISTRATION` and
+    /// `TIDEBREAK_RUNTIME_ENGINES`.
+    ///
+    /// Registration needs a sandbox runtime profile to register against.
+    /// The engine list is read only under registration, because without it
+    /// the gateway never learns which engine a sandbox runs and
+    /// `TIDEBREAK_RUNTIME_ENGINE` remains the only choice.
+    pub fn with_runtime_embedded_engine_vars(
+        mut self,
+        registration: Option<String>,
+        engines: Option<String>,
+    ) -> Result<Self> {
+        let registration = match registration
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+        {
+            None => false,
+            Some(value) => value.parse::<bool>().map_err(|_| {
+                AgentError::config(format!(
+                    "invalid TIDEBREAK_RUNTIME_EMBEDDED_ENGINE_REGISTRATION: {value}"
+                ))
+            })?,
+        };
+        if registration && self.runtime_profile.is_none() {
+            return Err(AgentError::config(
+                "TIDEBREAK_RUNTIME_EMBEDDED_ENGINE_REGISTRATION requires a sandbox runtime profile",
+            ));
+        }
+        let mut parsed = Vec::new();
+        if registration {
+            for token in engines
+                .as_deref()
+                .unwrap_or_default()
+                .split(',')
+                .map(str::trim)
+                .filter(|token| !token.is_empty())
+            {
+                let kind = crate::HarnessKind::from_str(token)
+                    .filter(|kind| !kind.is_in_process())
+                    .ok_or_else(|| {
+                        AgentError::config(format!(
+                            "TIDEBREAK_RUNTIME_ENGINES names an unsupported engine: {token}"
+                        ))
+                    })?;
+                if !parsed.contains(&kind) {
+                    parsed.push(kind);
+                }
+            }
+        }
+        self.runtime_embedded_engine_registration = registration;
+        self.runtime_engines = parsed;
         Ok(self)
     }
 
@@ -684,6 +761,8 @@ impl Config {
             runtime_endpoint,
             runtime_profile,
             runtime_engine: None,
+            runtime_engines: Vec::new(),
+            runtime_embedded_engine_registration: false,
             external_permission_mode: crate::PermissionMode::DEFAULT,
             external_permission_ceiling: crate::PermissionMode::DEFAULT,
             runtime_concurrency_cap: default_runtime_concurrency_cap(),
@@ -1071,6 +1150,46 @@ mod tests {
         .unwrap();
         assert_eq!(config.runtime_endpoint.as_deref(), Some("primary"));
         assert_eq!(config.runtime_profile.as_deref(), Some("tidebreak-remote"));
+    }
+
+    #[test]
+    fn embedded_engine_registration_needs_a_profile_and_gates_the_engine_list() {
+        let config = Config::desktop("/data");
+        assert!(config
+            .clone()
+            .with_runtime_embedded_engine_vars(Some("true".into()), None)
+            .is_err());
+        assert!(config
+            .clone()
+            .with_runtime_embedded_engine_vars(Some("yes".into()), None)
+            .is_err());
+        // Without registration the list is not a choice the gateway can
+        // honor, so it is not read.
+        let ignored = config
+            .clone()
+            .with_runtime_embedded_engine_vars(None, Some("claude_code,codex".into()))
+            .unwrap();
+        assert!(!ignored.runtime_embedded_engine_registration);
+        assert!(ignored.runtime_engines.is_empty());
+
+        let mut configured = config;
+        configured.runtime_endpoint = Some("tidebreak".into());
+        configured.runtime_profile = Some("tidebreak".into());
+        let registered = configured
+            .clone()
+            .with_runtime_embedded_engine_vars(
+                Some("true".into()),
+                Some(" claude_code, codex ,claude_code".into()),
+            )
+            .unwrap();
+        assert!(registered.runtime_embedded_engine_registration);
+        assert_eq!(
+            registered.runtime_engines,
+            vec![crate::HarnessKind::ClaudeCode, crate::HarnessKind::Codex]
+        );
+        assert!(configured
+            .with_runtime_embedded_engine_vars(Some("true".into()), Some("internal".into()))
+            .is_err());
     }
 
     #[test]

--- a/crates/tidebreak-server-api/src/tests/code.rs
+++ b/crates/tidebreak-server-api/src/tests/code.rs
@@ -231,6 +231,8 @@ pub(super) async fn code_app_with_options(
             RemoteSpawnSettings {
                 profile: "test-remote".to_owned(),
                 engine: None,
+                engines: Vec::new(),
+                embedded_engine_registration: false,
                 incarnation_cap: 2,
                 spend_ceiling_microusd: None,
                 session_spend_ceiling_microusd: None,

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -121,6 +121,8 @@ fn remote_settings() -> crate::code::remote::driver::RemoteSpawnSettings {
     crate::code::remote::driver::RemoteSpawnSettings {
         profile: "tidebreak-remote".to_owned(),
         engine: None,
+        engines: Vec::new(),
+        embedded_engine_registration: false,
         incarnation_cap: 2,
         spend_ceiling_microusd: None,
         session_spend_ceiling_microusd: None,

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -64,6 +64,8 @@ pub(crate) fn configured_settings(
     RemoteSpawnSettings {
         profile,
         engine: config.runtime_engine,
+        engines: config.runtime_engines.clone(),
+        embedded_engine_registration: config.runtime_embedded_engine_registration,
         incarnation_cap: config.runtime_concurrency_cap,
         spend_ceiling_microusd: config.runtime_spawn_spend_ceiling_microusd,
         session_spend_ceiling_microusd: config.runtime_session_spend_ceiling_microusd,
@@ -471,6 +473,8 @@ mod tests {
         RemoteSpawnSettings {
             profile: "tidebreak-remote".to_owned(),
             engine: None,
+            engines: Vec::new(),
+            embedded_engine_registration: false,
             incarnation_cap: 2,
             spend_ceiling_microusd: None,
             session_spend_ceiling_microusd: None,

--- a/crates/tidebreak-server/src/code/self_drive.rs
+++ b/crates/tidebreak-server/src/code/self_drive.rs
@@ -726,6 +726,8 @@ mod tests {
                     super::super::remote::driver::RemoteSpawnSettings {
                         profile: "test-confined".into(),
                         engine: Some(HarnessKind::ClaudeCode),
+                        engines: Vec::new(),
+                        embedded_engine_registration: false,
                         incarnation_cap: 8,
                         spend_ceiling_microusd: None,
                         session_spend_ceiling_microusd: None,

--- a/crates/tidebreak-server/src/lib.rs
+++ b/crates/tidebreak-server/src/lib.rs
@@ -1475,6 +1475,7 @@ async fn bind_inner(
                 &endpoint,
                 gateway
                     .runtime_tokens(&endpoint)
+                    .authenticating_host(state.config.runtime_embedded_engine_registration)
                     .with_external_delegations(db.clone()),
             )
             .map_err(|error| AgentError::config(format!("sandbox runtime client: {error}")))?;

--- a/crates/tidebreak-server/src/obo_gateway.rs
+++ b/crates/tidebreak-server/src/obo_gateway.rs
@@ -152,6 +152,19 @@ impl EmbeddedEngine {
     }
 }
 
+/// What an exchange asserts beyond the subject token.
+#[derive(Clone, Copy)]
+enum ExchangeBinding<'a> {
+    /// Ordinary on-behalf-of inference or a capability read.
+    None,
+    /// This machine's add-on identity alone, so the gateway records runtime
+    /// authority a later spawn can bind an engine under (gateway decision
+    /// 118).
+    Host,
+    /// The installed engine a session runs, signed by the add-on identity.
+    Engine(SessionId, &'a EmbeddedEngine),
+}
+
 /// What this process remembers about one caller.
 ///
 /// `subject` is the most recent machine-bound bearer that caller presented,
@@ -219,6 +232,8 @@ struct ExchangeResponse {
     engine_version: Option<String>,
     #[serde(default)]
     engine_session_id: Option<String>,
+    #[serde(default)]
+    runtime_add_on: Option<String>,
 }
 
 /// The forge identity a hosted machine's git operations act as.
@@ -550,6 +565,7 @@ impl OboGateway {
             gateway: self.clone(),
             audience: format!("runtime:{endpoint_slug}"),
             external: None,
+            authenticate_host: false,
             slots: std::sync::Mutex::new(HashMap::new()),
         })
     }
@@ -637,7 +653,11 @@ impl OboGateway {
             subject.clone()
         };
         let minted = self
-            .exchange_with(&subject, INFERENCE_AUDIENCE, Some((session, engine)))
+            .exchange_with(
+                &subject,
+                INFERENCE_AUDIENCE,
+                ExchangeBinding::Engine(session, engine),
+            )
             .await?;
         let token = minted.token.to_string();
         cached.retain(|_, held| held.is_fresh());
@@ -653,23 +673,25 @@ impl OboGateway {
     /// handles. Every other non-success is a refusal too — this never retries
     /// onto another credential.
     async fn exchange(&self, subject: &str, audience: &str) -> Result<CachedToken> {
-        self.exchange_with(subject, audience, None).await
+        self.exchange_with(subject, audience, ExchangeBinding::None)
+            .await
     }
 
-    /// The exchange, optionally binding the token to the installed engine a
-    /// session runs (gateway decision 118).
+    /// The exchange, optionally asserting this machine's add-on identity or
+    /// the installed engine a session runs (gateway decision 118).
     ///
-    /// A binding rides this machine's registered add-on identity, so a
-    /// caller's bearer alone never asserts an engine. The gateway echoes the
-    /// engine, version, and session it bound; anything short of an exact
-    /// echo is refused rather than used, because a token the gateway minted
-    /// as ordinary Tidebreak inference would silently run the engine's turns
-    /// off the caller's subscription.
+    /// Either assertion rides the registered add-on credentials, so a
+    /// caller's bearer alone never claims an engine or runtime authority.
+    /// The gateway echoes what it bound: the engine, version, and session,
+    /// or the add-on whose runtime authority it recorded. Anything short of
+    /// an exact echo is refused rather than used, because a token the
+    /// gateway minted as ordinary Tidebreak inference would silently run
+    /// the engine's turns off the caller's subscription.
     async fn exchange_with(
         &self,
         subject: &str,
         audience: &str,
-        engine: Option<(SessionId, &EmbeddedEngine)>,
+        binding: ExchangeBinding<'_>,
     ) -> Result<CachedToken> {
         let mut form: Vec<(&str, &str)> = vec![
             ("grant_type", TOKEN_EXCHANGE_GRANT),
@@ -677,14 +699,15 @@ impl OboGateway {
             ("subject_token_type", SUBJECT_TOKEN_TYPE),
             ("audience", audience),
         ];
-        let bound = engine.map(|(session, engine)| {
-            (
+        let bound = match binding {
+            ExchangeBinding::Engine(session, engine) => Some((
                 engine.kind.as_str(),
                 engine.version.as_str(),
                 session.as_uuid().to_string(),
-            )
-        });
-        if let Some((kind, version, session)) = &bound {
+            )),
+            ExchangeBinding::None | ExchangeBinding::Host => None,
+        };
+        if !matches!(binding, ExchangeBinding::None) {
             let (client_id, client_secret) =
                 self.machine_credentials.as_ref().ok_or_else(|| {
                     AgentError::config(
@@ -692,11 +715,13 @@ impl OboGateway {
                          set GATEWAY_CLIENT_ID and GATEWAY_CLIENT_SECRET",
                     )
                 })?;
+            form.push(("client_id", client_id.as_str()));
+            form.push(("client_secret", client_secret.as_str()));
+        }
+        if let Some((kind, version, session)) = &bound {
             form.push(("engine", kind));
             form.push(("engine_version", version));
             form.push(("engine_session_id", session.as_str()));
-            form.push(("client_id", client_id.as_str()));
-            form.push(("client_secret", client_secret.as_str()));
         }
         let response = self
             .client
@@ -734,6 +759,15 @@ impl OboGateway {
                         .into(),
                 ));
             }
+        }
+        if matches!(binding, ExchangeBinding::Host)
+            && exchanged.runtime_add_on.as_deref() != Some("tidebreak")
+        {
+            return Err(AgentError::InvalidTarget(
+                "the Model Gateway did not record this machine's runtime authority (gateway \
+                 decision 118); a sandbox spawned on this token could not bind its engine"
+                    .into(),
+            ));
         }
         Ok(CachedToken {
             token: exchanged.access_token.into(),
@@ -1425,6 +1459,9 @@ pub struct RuntimeTokens {
     gateway: Arc<OboGateway>,
     audience: String,
     external: Option<Arc<external::ExternalDelegations>>,
+    /// Whether each exchange asserts the machine's add-on identity, so the
+    /// gateway records runtime authority for engine-bound spawns.
+    authenticate_host: bool,
     slots: std::sync::Mutex<HashMap<(OwnerId, SessionId), RuntimeTokenSlot>>,
 }
 
@@ -1441,6 +1478,21 @@ impl RuntimeTokens {
                 self.gateway.clone(),
                 db,
             ))),
+            authenticate_host: self.authenticate_host,
+            slots: std::sync::Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Assert the machine's add-on identity on every runtime exchange, so a
+    /// spawn on the minted token may name the session's installed engine for
+    /// the gateway to bind (gateway decision 118). Off, the exchange keeps
+    /// the shape a custom profile without registration expects.
+    pub fn authenticating_host(self: Arc<Self>, enabled: bool) -> Arc<Self> {
+        Arc::new(Self {
+            gateway: self.gateway.clone(),
+            audience: self.audience.clone(),
+            external: self.external.clone(),
+            authenticate_host: enabled,
             slots: std::sync::Mutex::new(HashMap::new()),
         })
     }
@@ -1509,8 +1561,13 @@ impl crate::code::remote::RuntimeTokenSource for RuntimeTokens {
                 "this machine holds no live Model Gateway session for you; sign in again".into(),
             ));
         };
+        let binding = if self.authenticate_host {
+            ExchangeBinding::Host
+        } else {
+            ExchangeBinding::None
+        };
         let minted = gateway
-            .exchange(&subject, &self.audience)
+            .exchange_with(&subject, &self.audience, binding)
             .await
             .map_err(runtime_token_error)?;
         // Revocation may commit while the exchange is in flight.
@@ -1951,6 +2008,8 @@ mod tests {
         /// The last `(engine, engine_version, engine_session_id)` an
         /// exchange declared.
         last_engine: Arc<std::sync::Mutex<Option<(String, String, String)>>>,
+        /// How many exchanges carried the add-on client credentials.
+        host_auth_exchanges: Arc<AtomicUsize>,
     }
 
     impl FakeGateway {
@@ -1968,6 +2027,7 @@ mod tests {
                 last_attribution: Arc::new(std::sync::Mutex::new(None)),
                 engine_ack: Arc::new(std::sync::atomic::AtomicBool::new(true)),
                 last_engine: Arc::new(std::sync::Mutex::new(None)),
+                host_auth_exchanges: Arc::new(AtomicUsize::new(0)),
                 catalog: Arc::new(std::sync::Mutex::new(serde_json::json!({
                     "models": [
                         {
@@ -2061,6 +2121,18 @@ mod tests {
                         }
                         let serial = state.mints.fetch_add(1, Ordering::SeqCst);
                         let engine = form.get("engine").cloned();
+                        let host_authenticated = form.contains_key("client_id");
+                        if host_authenticated {
+                            assert_eq!(
+                                form.get("client_id").map(String::as_str),
+                                Some("tidebreak")
+                            );
+                            assert_eq!(
+                                form.get("client_secret").map(String::as_str),
+                                Some("test-machine-secret")
+                            );
+                            state.host_auth_exchanges.fetch_add(1, Ordering::SeqCst);
+                        }
                         let label = if audience == CATALOG_AUDIENCE {
                             "catalog"
                         } else if audience.starts_with("runtime:") {
@@ -2076,6 +2148,12 @@ mod tests {
                             "expires_in": state.lifetime.load(Ordering::SeqCst),
                             "scope": "inference:invoke",
                         });
+                        if host_authenticated
+                            && audience.starts_with("runtime:")
+                            && state.engine_ack.load(Ordering::SeqCst)
+                        {
+                            body["runtime_add_on"] = serde_json::json!("tidebreak");
+                        }
                         if let Some(engine) = engine {
                             // An engine binding authenticates the add-on with
                             // its client credentials beside the subject
@@ -2470,6 +2548,59 @@ mod tests {
         let again = tokens.runtime_token(&alice, session).await.unwrap();
         assert_eq!(again.secret, token.secret);
         assert_eq!(gateway.served(), 1);
+        server.abort();
+    }
+
+    /// Under registration the runtime exchange asserts the add-on identity
+    /// and requires the gateway to record runtime authority; without a
+    /// machine identity, or without the echo, it refuses rather than
+    /// minting a token no spawn could bind an engine on.
+    #[tokio::test]
+    async fn runtime_tokens_authenticate_the_host_under_registration() {
+        use crate::code::remote::RuntimeTokenSource;
+        let gateway = FakeGateway::new();
+        let (inference, server) = gateway.clone().start().await;
+        let alice = owner("user:alice");
+        let session = SessionId::new();
+
+        // No machine identity: the exchange never runs.
+        inference.record_caller(&alice, "mg_at_alice".into());
+        let tokens = inference
+            .runtime_tokens("tidebreak")
+            .authenticating_host(true);
+        assert!(tokens.runtime_token(&alice, session).await.is_err());
+        assert_eq!(gateway.served(), 0);
+        drop(tokens);
+
+        let inference = Arc::new(
+            Arc::try_unwrap(inference)
+                .ok()
+                .expect("fresh gateway")
+                .with_machine_credentials_for_test("tidebreak", "test-machine-secret"),
+        );
+        inference.record_caller(&alice, "mg_at_alice".into());
+        let tokens = inference
+            .runtime_tokens("tidebreak")
+            .authenticating_host(true);
+        let token = tokens.runtime_token(&alice, session).await.unwrap();
+        assert!(token.secret.starts_with("mg_at_runtime_"));
+        assert_eq!(gateway.host_auth_exchanges.load(Ordering::SeqCst), 1);
+
+        // Off, the exchange keeps its ordinary shape.
+        let plain = inference.runtime_tokens("tidebreak");
+        plain.runtime_token(&alice, SessionId::new()).await.unwrap();
+        assert_eq!(gateway.host_auth_exchanges.load(Ordering::SeqCst), 1);
+
+        // A gateway that mints without recording authority is refused.
+        gateway.engine_ack.store(false, Ordering::SeqCst);
+        let refused = tokens
+            .runtime_token(&alice, SessionId::new())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{refused:?}").contains("runtime authority"),
+            "{refused:?}"
+        );
         server.abort();
     }
 

--- a/crates/tidebreak-supervised-agent/src/control.rs
+++ b/crates/tidebreak-supervised-agent/src/control.rs
@@ -25,11 +25,14 @@ pub const MAX_BATCH_BYTES: usize = 192 * 1024;
 /// Each one means this agent built a request the endpoint will never accept:
 /// a schema it does not speak, an event kind the stream refuses, a payload
 /// over the ceiling, or more deliverables than one poll may carry.
-const FATAL_REJECTIONS: [&str; 4] = [
+const FATAL_REJECTIONS: [&str; 5] = [
     "supervisor_poll_schema_unsupported",
     "sandbox_event_invalid",
     "sandbox_event_too_large",
     "sandbox_event_flood",
+    // The admitted identity, image, or lease does not match what this agent
+    // registers; no retry changes any of those.
+    "sandbox_embedded_engine_rejected",
 ];
 
 /// One poll's outcome, when it is not instructions.

--- a/crates/tidebreak-supervised-agent/src/drive.rs
+++ b/crates/tidebreak-supervised-agent/src/drive.rs
@@ -24,7 +24,7 @@ use crate::control::{Control, Outbox, PollFailure};
 use crate::engine::{Engine, SteerOutcome, TurnEnd, TurnHandle, TurnRequest, TurnSource};
 use crate::inputs::{Inputs, RunMode, POLL_INTERVAL};
 use crate::wip::{self, CheckpointPoint, WipContext};
-use crate::wire::{SupervisorMessage, SupervisorPoll};
+use crate::wire::{EmbeddedEngineRegistration, SupervisorMessage, SupervisorPoll};
 use crate::{EXIT_CONTROL_FATAL, EXIT_ENGINE_FAILED};
 
 /// Consecutive retryable poll failures before the agent gives up.
@@ -90,6 +90,9 @@ pub struct Driver<E> {
     push_denied: bool,
     /// Checkpoint state, when the run has clones worth preserving.
     wip: Option<WipContext>,
+    /// The installed engine to register on every poll, when the environment
+    /// admitted an identity for this run.
+    embedded_engine: Option<EmbeddedEngineRegistration>,
 }
 
 impl<E: Engine> Driver<E> {
@@ -120,7 +123,18 @@ impl<E: Engine> Driver<E> {
             research: inputs.repositories.is_empty(),
             push_denied: inputs.forge_push_denied,
             wip: None,
+            embedded_engine: None,
         }
+    }
+
+    /// Registers the installed engine under the environment's admitted
+    /// identity: sent on every poll, required to be echoed exactly, and
+    /// sent once before the first turn because inference is refused until
+    /// the environment has accepted it.
+    #[must_use]
+    pub fn with_embedded_engine(mut self, registration: EmbeddedEngineRegistration) -> Self {
+        self.embedded_engine = Some(registration);
+        self
     }
 
     /// Overrides the poll cadence. Tests shrink it; production keeps the
@@ -158,6 +172,11 @@ impl<E: Engine> Driver<E> {
 
     /// Runs the loop until the endpoint stops the agent or something fails.
     pub async fn run(mut self) -> Result<(), DriveError> {
+        if self.embedded_engine.is_some() {
+            // Register before any turn: the environment refuses the engine's
+            // inference until it has accepted the installed binary.
+            self.poll(true).await?;
+        }
         self.outbox.push(
             "supervisor_started",
             serde_json::json!({
@@ -398,9 +417,24 @@ impl<E: Engine> Driver<E> {
     async fn poll(&mut self, idle: bool) -> Result<(), DriveError> {
         let batch = self.outbox.take_batch();
         let mut poll = SupervisorPoll::new(idle, self.delivered_through);
+        poll.embedded_engine.clone_from(&self.embedded_engine);
         poll.events.clone_from(&batch);
         match self.control.poll(&poll).await {
             Ok(instructions) => {
+                if self.embedded_engine.is_some()
+                    && instructions.embedded_engine != self.embedded_engine
+                {
+                    // A reply without the exact echo left the registration
+                    // unaccepted, and the engine's turns would each fail on
+                    // refused inference. Stop loudly instead.
+                    return Err(DriveError {
+                        code: EXIT_CONTROL_FATAL,
+                        message: "the control endpoint did not acknowledge the installed \
+                                  engine registration; inference stays unavailable, so the run \
+                                  stops rather than failing every turn"
+                            .to_owned(),
+                    });
+                }
                 self.consecutive_failures = 0;
                 for message in instructions.messages {
                     if message.seq > self.seen_through {
@@ -602,6 +636,9 @@ mod tests {
     /// Everything the mock supervisor records and serves.
     #[derive(Default)]
     struct MockSupervisor {
+        /// Withhold the engine registration echo, as an environment that did
+        /// not accept it would.
+        withhold_engine_ack: bool,
         events: Vec<(String, serde_json::Value)>,
         polls: Vec<serde_json::Value>,
         messages: Vec<(i64, String, bool)>,
@@ -665,7 +702,13 @@ mod tests {
         if !messages.is_empty() {
             supervisor.message_batches += 1;
         }
+        let embedded_engine = if supervisor.withhold_engine_ack {
+            serde_json::Value::Null
+        } else {
+            body.get("embedded_engine").cloned().unwrap_or_default()
+        };
         Json(serde_json::json!({
+            "embedded_engine": embedded_engine,
             "sandbox_id": "018f0000-0000-7000-8000-000000000000",
             "state": if supervisor.stop.is_some() { "completing" } else { "running" },
             "stop": supervisor.stop.is_some(),
@@ -836,6 +879,71 @@ mod tests {
             .nth(index)
             .map(|(_, payload)| payload.clone())
             .unwrap_or_else(|| panic!("no {kind} event at index {index}"))
+    }
+
+    fn registration() -> EmbeddedEngineRegistration {
+        EmbeddedEngineRegistration {
+            engine_session_id: "018f0000-0000-7000-8000-000000000001".to_owned(),
+            engine: "codex".to_owned(),
+            engine_version: "0.147.0".to_owned(),
+        }
+    }
+
+    /// An admitted engine is registered on a poll that precedes the first
+    /// turn, and every later poll repeats it.
+    #[tokio::test]
+    async fn an_admitted_engine_registers_before_the_first_turn() {
+        let (state, url) = start_supervisor().await;
+        let engine = MockEngine::new();
+        engine.finish(TurnEnd::Completed { success: true });
+        let run = tokio::spawn(
+            driver(engine.clone(), &url, &inputs("turn", None))
+                .with_embedded_engine(registration())
+                .run(),
+        );
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "turn_completed")
+        })
+        .await;
+        {
+            let supervisor = state.lock().unwrap();
+            assert_eq!(
+                supervisor.polls[0]["embedded_engine"],
+                serde_json::to_value(registration()).unwrap(),
+                "the first poll registers the engine"
+            );
+            assert!(supervisor
+                .polls
+                .iter()
+                .all(|poll| poll.get("embedded_engine").is_some()));
+        }
+        assert_eq!(engine.turns().len(), 1);
+        state.lock().unwrap().stop = Some("cancelled".to_owned());
+        run.await.unwrap().unwrap();
+    }
+
+    /// Without the exact echo the registration was not accepted, and the
+    /// run stops before the engine starts a turn it could not run.
+    #[tokio::test]
+    async fn an_unacknowledged_registration_stops_the_run_before_any_turn() {
+        let (state, url) = start_supervisor().await;
+        state.lock().unwrap().withhold_engine_ack = true;
+        let engine = MockEngine::new();
+        let error = driver(engine.clone(), &url, &inputs("turn", None))
+            .with_embedded_engine(registration())
+            .run()
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, EXIT_CONTROL_FATAL);
+        assert!(
+            error.message.contains("did not acknowledge"),
+            "{}",
+            error.message
+        );
+        assert!(engine.turns().is_empty());
     }
 
     #[tokio::test]

--- a/crates/tidebreak-supervised-agent/src/inputs.rs
+++ b/crates/tidebreak-supervised-agent/src/inputs.rs
@@ -59,6 +59,11 @@ pub const INCARNATION_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_INCARNATION";
 /// because a typo here would otherwise drive the wrong engine for the whole
 /// run.
 pub const ENGINE_VARIABLE: &str = "TIDEBREAK_AGENT_ENGINE";
+/// The engine identity the environment admitted for this sandbox, as the
+/// JSON object `{"engine": ..., "engine_session_id": ...}` (gateway decision
+/// 118). Present only for a managed supervised run; the agent registers the
+/// installed binary under it before its first turn.
+pub const EMBEDDED_ENGINE_VARIABLE: &str = "MODEL_GATEWAY_SANDBOX_EMBEDDED_ENGINE";
 
 const DEFAULT_SUPERVISOR_ENDPOINT: &str = "127.0.0.1:15003";
 /// Poll cadence, matching the endpoint's expected liveness rhythm.
@@ -113,6 +118,18 @@ pub struct Inputs {
     pub incarnation: u32,
     /// Engine CLI the agent drives.
     pub engine: HarnessKind,
+    /// The admitted engine identity to register the installed binary under,
+    /// when the environment declared one.
+    pub embedded_engine: Option<EmbeddedEngineIdentity>,
+}
+
+/// The engine identity the environment admitted for this sandbox.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EmbeddedEngineIdentity {
+    /// The engine the environment admitted; always the one the agent drives.
+    pub engine: HarnessKind,
+    /// The Tidebreak session UUID the engine runs for.
+    pub engine_session_id: String,
 }
 
 /// A missing or unusable input, carrying the exit code and the variable name.
@@ -159,6 +176,7 @@ pub struct RawInputs {
     pub sandbox_id: Option<String>,
     pub incarnation: Option<String>,
     pub engine: Option<String>,
+    pub embedded_engine: Option<String>,
 }
 
 impl RawInputs {
@@ -182,6 +200,7 @@ impl RawInputs {
             sandbox_id: var(SANDBOX_ID_VARIABLE),
             incarnation: var(INCARNATION_VARIABLE),
             engine: var(ENGINE_VARIABLE),
+            embedded_engine: var(EMBEDDED_ENGINE_VARIABLE),
         }
     }
 }
@@ -298,6 +317,10 @@ pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
         })?,
     };
 
+    let embedded_engine = optional(raw.embedded_engine)
+        .map(|declared| parse_embedded_engine(&declared, engine))
+        .transpose()?;
+
     Ok(Inputs {
         task,
         workspace_branch,
@@ -313,6 +336,55 @@ pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
         sandbox_id: optional(raw.sandbox_id),
         incarnation,
         engine,
+        embedded_engine,
+    })
+}
+
+/// Parses the admitted engine identity, refusing one that names a different
+/// engine than the agent drives: registering the wrong binary would pair a
+/// subscription the turns cannot use.
+fn parse_embedded_engine(
+    declared: &str,
+    engine: HarnessKind,
+) -> Result<EmbeddedEngineIdentity, InputError> {
+    #[derive(serde::Deserialize)]
+    struct Declared {
+        engine: String,
+        engine_session_id: String,
+    }
+    let parsed: Declared = serde_json::from_str(declared).map_err(|error| {
+        InputError::unusable(
+            EMBEDDED_ENGINE_VARIABLE,
+            &format!("expected a JSON object with engine and engine_session_id: {error}"),
+        )
+    })?;
+    let admitted = HarnessKind::from_str(&parsed.engine).ok_or_else(|| {
+        InputError::unusable(
+            EMBEDDED_ENGINE_VARIABLE,
+            &format!("unknown engine {:?}", parsed.engine),
+        )
+    })?;
+    if admitted != engine {
+        return Err(InputError::unusable(
+            EMBEDDED_ENGINE_VARIABLE,
+            &format!(
+                "admits {admitted} but {ENGINE_VARIABLE} selects {engine}; the two must agree"
+            ),
+        ));
+    }
+    let session = parsed.engine_session_id.trim();
+    let uuid_shaped = session.len() == 36
+        && session.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+        && session.chars().any(|c| c.is_ascii_hexdigit() && c != '0');
+    if !uuid_shaped {
+        return Err(InputError::unusable(
+            EMBEDDED_ENGINE_VARIABLE,
+            "engine_session_id is not a non-nil UUID",
+        ));
+    }
+    Ok(EmbeddedEngineIdentity {
+        engine: admitted,
+        engine_session_id: session.to_owned(),
     })
 }
 
@@ -519,6 +591,47 @@ mod tests {
             ..minimal()
         };
         assert_eq!(resolve(raw).unwrap().engine, HarnessKind::Codex);
+    }
+
+    /// The admitted identity is honored only when it names the engine the
+    /// agent drives and a real session UUID.
+    #[test]
+    fn an_admitted_engine_identity_must_match_the_driven_engine() {
+        let session = "018f0000-0000-7000-8000-000000000001";
+        let raw = RawInputs {
+            engine: Some("codex".to_owned()),
+            embedded_engine: Some(format!(
+                r#"{{"engine":"codex","engine_session_id":"{session}"}}"#
+            )),
+            ..minimal()
+        };
+        assert_eq!(
+            resolve(raw).unwrap().embedded_engine,
+            Some(EmbeddedEngineIdentity {
+                engine: HarnessKind::Codex,
+                engine_session_id: session.to_owned(),
+            })
+        );
+        assert_eq!(resolve(minimal()).unwrap().embedded_engine, None);
+
+        for declared in [
+            format!(r#"{{"engine":"claude_code","engine_session_id":"{session}"}}"#),
+            r#"{"engine":"codex","engine_session_id":"00000000-0000-0000-0000-000000000000"}"#
+                .to_owned(),
+            "not json".to_owned(),
+        ] {
+            let raw = RawInputs {
+                engine: Some("codex".to_owned()),
+                embedded_engine: Some(declared.clone()),
+                ..minimal()
+            };
+            let error = resolve(raw).unwrap_err();
+            assert!(
+                error.message.contains(EMBEDDED_ENGINE_VARIABLE),
+                "{declared}: {}",
+                error.message
+            );
+        }
     }
 
     /// A typo must not silently drive the default engine for the whole run.

--- a/crates/tidebreak-supervised-agent/src/main.rs
+++ b/crates/tidebreak-supervised-agent/src/main.rs
@@ -29,6 +29,7 @@ use tidebreak_supervised_agent::harness_engine::{
 use tidebreak_supervised_agent::inputs::{resolve, RawInputs};
 use tidebreak_supervised_agent::trust::TrustOptions;
 use tidebreak_supervised_agent::wip::WipContext;
+use tidebreak_supervised_agent::wire::EmbeddedEngineRegistration;
 use tidebreak_supervised_agent::{bootstrap, effort, EXIT_MISSING_INPUT};
 
 #[tokio::main]
@@ -63,6 +64,27 @@ async fn run() -> i32 {
 
     let host = HostEnv::from_process();
     let probe = adapter.probe(&host).await;
+    // An admitted identity is registered with the exact installed version.
+    // A binary that reports none cannot be registered, and the environment
+    // would refuse every inference request, so stop here instead.
+    let embedded_engine = match inputs.embedded_engine.as_ref() {
+        None => None,
+        Some(identity) => match installed_version(probe.version.as_deref()) {
+            Some(version) => Some(EmbeddedEngineRegistration {
+                engine_session_id: identity.engine_session_id.clone(),
+                engine: identity.engine.as_str().to_owned(),
+                engine_version: version,
+            }),
+            None => {
+                eprintln!(
+                    "the installed {} binary reported no usable version ({:?}), so the \
+                     environment cannot register it and would refuse its inference",
+                    inputs.engine, probe.version
+                );
+                return EXIT_MISSING_INPUT;
+            }
+        },
+    };
     // Resolving the ladder can shell out to the engine's model catalog, so
     // only do it when there is a request to reconcile.
     let effective = match inputs.reasoning_effort.as_deref() {
@@ -151,6 +173,9 @@ async fn run() -> i32 {
     if let Some(wip) = wip {
         driver = driver.with_wip(wip);
     }
+    if let Some(registration) = embedded_engine {
+        driver = driver.with_embedded_engine(registration);
+    }
     match driver.run().await {
         Ok(()) => 0,
         Err(error) => {
@@ -158,6 +183,18 @@ async fn run() -> i32 {
             error.code
         }
     }
+}
+
+/// The version token the environment accepts: the binary's leading version
+/// word, in the bounded vocabulary the registration allows.
+fn installed_version(reported: Option<&str>) -> Option<String> {
+    let version = reported?.split_whitespace().next()?;
+    let allowed = !version.is_empty()
+        && version.len() <= 128
+        && version
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || b".-+_".contains(&c));
+    allowed.then(|| version.to_owned())
 }
 
 /// Resolves symlinks so path comparisons and git commands agree; a path that

--- a/crates/tidebreak-supervised-agent/src/wire.rs
+++ b/crates/tidebreak-supervised-agent/src/wire.rs
@@ -18,11 +18,30 @@ use serde::{Deserialize, Serialize};
 /// rather than silently drifting.
 pub const SUPERVISOR_POLL_SCHEMA_VERSION: u32 = 1;
 
+/// The installed engine this agent registers under the environment's
+/// admitted identity (gateway decision 118).
+///
+/// Sent on every poll while the run has one; the environment echoes exactly
+/// what it accepted, and inference stays unavailable until it does.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EmbeddedEngineRegistration {
+    /// The Tidebreak session UUID the engine runs for.
+    pub engine_session_id: String,
+    /// Engine token the environment admitted (`claude_code`, `codex`).
+    pub engine: String,
+    /// Version the installed binary reported.
+    pub engine_version: String,
+}
+
 /// One turn of the poll loop, as the agent reports it.
 #[derive(Clone, Debug, Serialize)]
 pub struct SupervisorPoll {
     /// Always [`SUPERVISOR_POLL_SCHEMA_VERSION`].
     pub schema_version: u32,
+    /// The installed engine to register, while the run has an admitted
+    /// identity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedded_engine: Option<EmbeddedEngineRegistration>,
     /// Whether the engine is idle rather than mid-turn. Process state, not
     /// judgement: no engine turn is running.
     pub idle: bool,
@@ -44,6 +63,7 @@ impl SupervisorPoll {
     pub fn new(idle: bool, delivered_through_seq: Option<i64>) -> Self {
         Self {
             schema_version: SUPERVISOR_POLL_SCHEMA_VERSION,
+            embedded_engine: None,
             idle,
             delivered_through_seq,
             events: Vec::new(),
@@ -82,6 +102,10 @@ impl SupervisorEvent {
 /// on these promptly is tidiness, not correctness.
 #[derive(Clone, Debug, Deserialize)]
 pub struct SupervisorInstructions {
+    /// The engine registration the environment accepted under the current
+    /// execution lease, echoed exactly.
+    #[serde(default)]
+    pub embedded_engine: Option<EmbeddedEngineRegistration>,
     /// Whether the agent should stop the engine and exit.
     #[serde(default)]
     pub stop: bool,


### PR DESCRIPTION
## Problem

Slack tasks run in gateway sandboxes on the managed supervised profile, which permits only the `custom` harness. A custom sandbox carries the Generic client identity. Anthropic and OpenAI pair a consumer subscription only with their own engine, so every Claude Code or Codex turn in one of those sandboxes is metered even when the person connected a subscription. Attribution to the person works; subscription use does not.

Follows #3303, which fixed the same gap for engine children relayed by a hosted machine.

## Fix

Gateway decision 118 admits an engine per sandbox when the machine proves its add-on identity, the spawn names the session's engine, and the supervised agent registers the installed binary under the admitted identity. This change sends all three.

- Under `TIDEBREAK_RUNTIME_EMBEDDED_ENGINE_REGISTRATION=true`, the runtime token exchange authenticates with `GATEWAY_CLIENT_ID` and `GATEWAY_CLIENT_SECRET` and requires the gateway to echo `runtime_add_on: "tidebreak"`. `TIDEBREAK_RUNTIME_ENGINES` lists the engines the image runs, one chosen per session; without registration it is not read and `TIDEBREAK_RUNTIME_ENGINE` stays the only choice. Managed provisioning already sets all three (`deploy/tidebreak/sandbox-runtime.v1.json` in the gateway).
- The spawn carries `embedded_engine` with the session's engine token and UUID for the gateway to bind.
- The supervised agent reads `MODEL_GATEWAY_SANDBOX_EMBEDDED_ENGINE`, which the gateway injects, refuses it if it names a different engine than `TIDEBREAK_AGENT_ENGINE`, registers the installed binary's version on a poll before its first turn and on every poll after, and stops the run if the environment does not echo the registration exactly. Inference stays refused until the gateway accepts the registration, so failing every turn would be the alternative. A `sandbox_embedded_engine_rejected` reply is fatal rather than retried.

A custom profile without the registration flag keeps its existing exchange, spawn, and poll shape.

## Validation

- `cargo test -p tidebreak-core --lib -- config::tests::embedded_engine config::tests::runtime_engine`: 2 passed.
- `cargo test -p tidebreak-code-remote --lib -- registration_names spawn_arguments the_first_turn`: 4 passed, including the spawn naming the session engine and the engine list admitting a non-default engine only under registration.
- `cargo test -p tidebreak-server-core --lib -- obo_gateway harness_llm remote::service`: 85 passed, including the runtime exchange asserting the add-on identity, refusing without a machine identity, and refusing an unacknowledged mint.
- `cargo test -p tidebreak-supervised-agent -- inputs drive`: 34 passed, including identity parsing, registration on the poll before the first turn, and stopping before any turn when the echo is withheld.
- `cargo clippy` on the five touched crates with tests and `cargo fmt --all --check`: clean.
