### PR TITLE
docs(code): correct stale comments and records found in the code-mode audit

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -145,7 +145,7 @@ export function CodeCenterTabs({
   /** Offer "New agent" in the plus menu. */
   onNewConversation?: () => void;
   onCloseConversation?: (sessionId: string | null) => void;
-  /** Copy this agent's transcript into the worktree and open a new agent on it. */
+  /** Copy this agent's transcript into private scratch (outside every worktree) and open a new agent on it. */
   onForkConversation?: (sessionId: string) => void;
   onSelectEditor: (index: number) => void;
   onCloseEditor: (index: number) => void;

--- a/crates/tidebreak-server/src/code/chrome/driver.rs
+++ b/crates/tidebreak-server/src/code/chrome/driver.rs
@@ -1,5 +1,7 @@
-//! Bounded scripts run in a Chrome isolated world. Page scripts cannot replace
-//! the reference table; every action checks the same live node and fingerprint.
+//! Snapshot scripts run in a Chrome isolated world. Viewport mapping and
+//! other evals that pass no world run in the page's main world. Page scripts
+//! cannot replace the reference table; every action checks the same live
+//! node and fingerprint.
 
 pub const SNAPSHOT_SCRIPT: &str = r#"(options => {
   const entries = new Map(), nodes = [];

--- a/crates/tidebreak-server/src/code/chrome/mod.rs
+++ b/crates/tidebreak-server/src/code/chrome/mod.rs
@@ -1,9 +1,10 @@
 //! Host-owned Chrome computer use for coding harnesses.
 //!
-//! The three adapters (in-app browser, native apps, Chrome) share one
-//! `computer_session` wire. This module provides the Chrome half: a direct
-//! CDP driver and a dispatch service that binds owner/session/connection/tab/
-//! origin, validates every call, rechecks grants at act time, and returns
+//! Native apps and Chrome share one `computer_session` wire; the in-app
+//! browser keeps its own channel. This module provides the Chrome half: a
+//! direct CDP driver and a dispatch service that binds
+//! owner/session/connection/tab/origin, validates every call, clones the
+//! grant once at connect and rechecks the fence at act time, and returns
 //! request-id outcomes through the shared transport types.
 
 pub mod cdp;

--- a/crates/tidebreak-server/src/code/ci_logs.rs
+++ b/crates/tidebreak-server/src/code/ci_logs.rs
@@ -4,7 +4,8 @@
 //! The fix-errors action used to hand an agent check names and URLs and let it
 //! find the logs itself: two or three `gh` calls before it saw an error line,
 //! and then a whole multi-megabyte job log in one read. This module does that
-//! fetch on the agent's behalf and bounds it.
+//! fetch on the agent's behalf. The fetch itself is unbounded; only the
+//! rendered output is capped.
 //!
 //! Files land under the workspace's private root, beside fork transcripts, so
 //! Git cannot index them and the session's `allowed_read_roots` already covers

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -230,8 +230,8 @@ pub struct WrittenTranscript {
 ///
 /// Every fork writes a fresh generation directory named by a UUID, so a
 /// child keeps reading a whole, immutable handoff no matter how many later
-/// forks the same session produces. The generation is kept for the worktree
-/// lifecycle; a failure before the transcript publishes removes the whole
+/// forks the same session produces. The generation is kept; nothing removes
+/// it today. A failure before the transcript publishes removes the whole
 /// directory rather than leaving a partial handoff for the child to trip
 /// over.
 pub(crate) async fn write_transcript(

--- a/crates/tidebreak-server/src/code/grants.rs
+++ b/crates/tidebreak-server/src/code/grants.rs
@@ -158,10 +158,9 @@ impl super::runtime::CodeRuntime {
     /// already holds a live grant — revoke first, so a re-link is an
     /// explicit replacement.
     ///
-    /// Production minting is not wired yet; tests (including
-    /// `src/tests/code_external.rs`) drive the token pair through this
-    /// helper. Keep it compiled only in tests until a connect-approval
-    /// path calls it.
+    /// Production minting goes through [`Self::complete_connect_handshake`].
+    /// This helper stays test-only (`src/tests/code_external.rs` drives the
+    /// token pair through it).
     #[cfg(any(test, feature = "test-support"))]
     pub async fn mint_adapter_grant(
         &self,
@@ -516,9 +515,10 @@ impl super::runtime::CodeRuntime {
         )
     }
 
-    /// An admin confirms a pending channel repository on a workspace grant.
-    /// The grant is owned by the service principal; this path resolves that
-    /// owner and then uses the owner-scoped store.
+    /// Record a channel-repository confirm for older clients. Decision 0096
+    /// removed the gate: these rows authorize nothing. The grant is owned by
+    /// the service principal; this path resolves that owner and then uses
+    /// the owner-scoped store.
     pub async fn confirm_workspace_channel_repository_as_admin(
         &self,
         admin: &OwnerId,
@@ -543,7 +543,8 @@ impl super::runtime::CodeRuntime {
         .await?)
     }
 
-    /// Add exact repositories to one channel's approved scope before a session starts.
+    /// Record exact repositories on one channel for older clients. Decision
+    /// 0096 removed the gate: these confirms authorize nothing.
     pub async fn approve_workspace_channel_repositories_as_admin(
         &self,
         admin: &OwnerId,

--- a/crates/tidebreak-server/src/code/harness_install.rs
+++ b/crates/tidebreak-server/src/code/harness_install.rs
@@ -125,7 +125,9 @@ impl CodeRuntime {
     ///
     /// Answers immediately in every case: the release is already installed,
     /// an install this process started is still running, or a fresh one is
-    /// now detached. Two callers never produce two installs.
+    /// now detached. Callers that share the same resolved version share one
+    /// install; a cold `latest` install (`version` unset) does not dedupe
+    /// against a later click that already knows the version.
     ///
     /// `deliberate` separates the two callers. A picker warms the engine
     /// because a surface opened, so a failed managed-Node install stays

--- a/crates/tidebreak-server/src/code/recap.rs
+++ b/crates/tidebreak-server/src/code/recap.rs
@@ -324,10 +324,11 @@ impl TurnRecapper {
 
     /// The bounded material one recap call reads.
     ///
-    /// Three parts, oldest context first: what the session was started to do,
-    /// what this turn was asked for, and what the turn actually did. The goal
-    /// is what keeps a recap of the fifth turn from reading as though the work
-    /// began there.
+    /// Four parts, oldest context first: what the session was started to do
+    /// (`<goal>`), what this turn was asked for (`<request>`), what the turn
+    /// actually did (`<did>`), and the engine's closing message (`<said>`).
+    /// The goal is what keeps a recap of the fifth turn from reading as
+    /// though the work began there.
     pub async fn turn_material(
         &self,
         owner: &OwnerId,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -1235,13 +1235,6 @@ impl ScopedCode {
             .await
     }
 
-    // ------------------------------------------------------------------
-    // Harness discovery. Probes describe the machine's binaries rather than
-    // any owner's rows, so they are the same answer for every principal; the
-    // per-harness unrecognized-event counts beside them are summed over the
-    // principal's own sessions.
-    // ------------------------------------------------------------------
-
     /// Reserve a validated image for a session the principal may drive.
     ///
     /// Publication is a write: it is what a later turn attachment is checked
@@ -1292,6 +1285,13 @@ impl ScopedCode {
     ) -> Result<Arc<dyn tidebreak_harness::HarnessAdapter>, ServerError> {
         self.runtime.adapter(kind)
     }
+
+    // ------------------------------------------------------------------
+    // Harness discovery. Probes describe the machine's binaries rather than
+    // any owner's rows, so they are the same answer for every principal; the
+    // per-harness unrecognized-event counts beside them are summed over the
+    // principal's own sessions.
+    // ------------------------------------------------------------------
 
     pub async fn probe(
         &self,

--- a/crates/tidebreak-server/src/code/trigger.rs
+++ b/crates/tidebreak-server/src/code/trigger.rs
@@ -1158,10 +1158,6 @@ fn linked_workspaces(
         .collect()
 }
 
-/// The bulk summary read as the digest the classifier is written against.
-///
-/// Both paths lowercase their host tokens already — `normalized_optional` here
-/// and `lower_token` in `gh.rs` — so the tokens pass straight through.
 /// Abort the trigger sweep when the runtime is dropped.
 ///
 /// The loop holds a [`Weak`] runtime handle: an `Arc` would keep the runtime

--- a/crates/tidebreak-server/src/code/watch.rs
+++ b/crates/tidebreak-server/src/code/watch.rs
@@ -530,7 +530,7 @@ async fn sweep_one(runtime: &Arc<CodeRuntime>, watch: &mut CodeWatch) -> Result<
         return park_watch(
             runtime.as_ref(),
             watch,
-            "the pull request digest is unavailable; is GitHub CLI signed in?",
+            "the pull request digest is unavailable; check that GitHub access is signed in",
         )
         .await;
     };

--- a/docs/decisions/0034-harness-discovery-credentials.md
+++ b/docs/decisions/0034-harness-discovery-credentials.md
@@ -6,6 +6,11 @@
 - Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),
   [`0033-code-mode-approvals.md`](0033-code-mode-approvals.md),
   [`docs/code-mode.md`](../code-mode.md)
+- Amended by: [`0071-hosted-engines-ride-the-callers-inference.md`](0071-hosted-engines-ride-the-callers-inference.md)
+  — children inherit an allowlist (`CHILD_ENV_ALLOWED_NAMES`), not the
+  probed shell environment minus Tidebreak-internal variables; hosted
+  engines receive injected relay credentials, so Tidebreak does inject
+  harness credentials on that path. The rest of this record stands.
 
 ## Context
 

--- a/docs/decisions/0071-hosted-engines-ride-the-callers-inference.md
+++ b/docs/decisions/0071-hosted-engines-ride-the-callers-inference.md
@@ -1,6 +1,6 @@
 # 71. Hosted engines ride the caller's inference
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-26
 - Owners: server
 - Related: [`0051-on-behalf-of-inference-for-hosted-machines.md`](0051-on-behalf-of-inference-for-hosted-machines.md),
@@ -32,14 +32,16 @@ worthless anywhere else.
 
 ## Decision
 
-1. **The server relays engine inference through the caller's grant.** Two
-   routes on the main listener, `/code/llm/anthropic/v1/messages` and
-   `/code/llm/openai/v1/responses`, stream requests through to the Model
-   Gateway's compat endpoints. Per request, the relay exchanges the owning
-   caller's live machine-bound token for a fresh inference token (the same
-   single-flight cache decision 51 uses for chat) and sends that upstream
-   in place of what the child presented. The session outlives any single
-   token because the exchange runs on every request.
+1. **The server relays engine inference through the caller's grant.** Three
+   routes on the main listener, `/code/llm/anthropic/v1/messages`,
+   `/code/llm/openai/v1/responses`, and `/code/llm/openai/v1/models`,
+   stream requests through to the Model Gateway's compat endpoints. Per
+   request, the relay exchanges the owning caller's live machine-bound
+   token for a fresh inference token (the same single-flight cache
+   decision 51 uses for chat) and sends that upstream in place of what
+   the child presented. The session outlives any single token because the
+   exchange runs on every request. The same relay key also authorizes
+   `POST /code/git/credential`.
 
 2. **The child authenticates with a session-scoped relay key.** At spawn on
    a machine that has an on-behalf-of gateway, the runtime mints an opaque


### PR DESCRIPTION
Comment-only corrections from the code-mode audit (server doc comments batch).

1. `trigger.rs`: removed leftover digest/`lower_token` paragraphs so `TriggerSweepGuard` docs start at abort-on-drop.
2. `watch.rs`: park message now says GitHub access is signed in (true for gh and forge REST). No test pinned the old string.
3. `fork.rs`: generation is kept; nothing removes it today.
4. `grants.rs`: production minting is `complete_connect_handshake`; confirm/approve comments now say decision 0096 kept them for older clients and they authorize nothing.
5. `scoped.rs`: moved the harness-discovery banner to sit above `probe`. No comment at 1062–1070 claimed a pre-session gate (error string is code, left unchanged).
6. `recap.rs`: prompt material has four blocks (`goal`, `request`, `did`, `said`).
7. `chrome/mod.rs`: native apps and Chrome share `computer_session`; in-app browser keeps its channel. Grant is cloned at connect; the fence is rechecked at act time.
8. `chrome/driver.rs`: snapshot scripts use an isolated world; evals that pass no world run in the main world.
9. `CodeCenterTabs.tsx`: fork copies the transcript into private scratch, outside every worktree.
10. `harness_install.rs`: same resolved version dedupes; a cold `latest` install (`version` unset) does not.
11. `ci_logs.rs`: fetch is unbounded; rendered output is capped.
12. Decision 0071: Status Accepted; three LLM routes plus `POST /code/git/credential` on the same relay key (`llm.rs`, not `git.rs`).
13. Decision 0034: Amended note — child env is an allowlist; 0071 injects relay credentials.

Skipped:
- Item 5 first half: `scoped.rs:1062-1070` has no doc comment about a gate before a session starts; only a forbidden error string, which is code.
- Item 2 tests: repo-wide search found only the park string in `watch.rs`.

Checks:
- `cargo fmt --all --check`
- `cargo test -p tidebreak-server-core --locked watch` (17 passed)
- `pnpm@10.18.3 install --frozen-lockfile` and `pnpm exec biome format src` in `crates/tidebreak-desktop/ui`
- `python3 scripts/adr.py check`