### PR TITLE
fix(desktop): small code-mode component bugs from the audit

### DIFF
--- a/crates/tidebreak-desktop/ui/src/ChangeSummaryCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/ChangeSummaryCard.tsx
@@ -5,7 +5,6 @@ import {
   Check,
   FileImage,
   FileText,
-  Loader2,
   RotateCcw,
 } from "lucide-react";
 import type {
@@ -15,6 +14,7 @@ import type {
 } from "./api";
 import type { ExecFilePreviewAvailability } from "./generated/wire";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import {
   Collapsible,
   CollapsibleContent,
@@ -418,9 +418,8 @@ function RevisionPreview({
         ) : loaded.status === "error" ? (
           <PreviewNotice>{loaded.message}</PreviewNotice>
         ) : (
-          <Loader2
-            className="animate-spin text-muted-foreground"
-            size={18}
+          <Spinner
+            className="text-muted-foreground"
             aria-label={`Loading ${revision} preview`}
           />
         )}

--- a/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.tsx
+++ b/crates/tidebreak-desktop/ui/src/ComposerToolsMenu.tsx
@@ -1,12 +1,5 @@
 import { useState } from "react";
-import {
-  Brain,
-  FolderPlus,
-  LoaderCircle,
-  Package,
-  Paperclip,
-  Plus,
-} from "lucide-react";
+import { Brain, FolderPlus, Package, Paperclip, Plus } from "lucide-react";
 
 import type { NetworkPolicy, ReasoningEffort } from "./api";
 import { ReasoningEffortSubMenu } from "./ModelMenu";
@@ -16,6 +9,7 @@ import {
   networkPolicyLabel,
 } from "./NetworkPolicyDialog";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -139,7 +133,7 @@ export function ComposerToolsMenu({
               data-first-task-target="attach-files"
             >
               {attachFiles.attaching ? (
-                <LoaderCircle className="size-4 animate-spin" />
+                <Spinner className="size-4" />
               ) : (
                 <Paperclip className="size-4" />
               )}
@@ -153,7 +147,7 @@ export function ComposerToolsMenu({
               data-first-task-target="attach-folder"
             >
               {attachFolder.working ? (
-                <LoaderCircle className="size-4 animate-spin" />
+                <Spinner className="size-4" />
               ) : (
                 <FolderPlus className="size-4" />
               )}

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoInline.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoInline.tsx
@@ -76,7 +76,10 @@ export function AddRepoInline({
       {/* The reading of the value sits under the value, not under the
           destination the value happens to also need. */}
       {state.blocked ? (
-        <p className="text-critical text-xs" data-testid="add-repo-blocked">
+        <p
+          className="text-critical text-xs break-words"
+          data-testid="add-repo-blocked"
+        >
           {state.blocked}
         </p>
       ) : (
@@ -124,7 +127,10 @@ export function AddRepoInline({
         </div>
       )}
       {state.error && (
-        <p className="text-critical text-xs" data-testid="add-repo-error">
+        <p
+          className="text-critical text-xs break-words"
+          data-testid="add-repo-error"
+        >
           {state.error}
         </p>
       )}

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -67,7 +67,6 @@ import {
 } from "./CodeUpdatesStore";
 
 type Stage = "sources" | "local" | "git_url" | "github" | "progress";
-type SourceKey = "local" | "git_url" | "github";
 
 type PaletteOpening = {
   id: number;
@@ -869,7 +868,7 @@ export function AddRepoPalette({
                   {unavailable.map((source) => (
                     <p
                       key={source.kind}
-                      className="text-xs text-muted-foreground"
+                      className="text-xs text-muted-foreground break-words"
                     >
                       {source.remediation}
                     </p>
@@ -1091,7 +1090,7 @@ function LocalStage({
           disabled={busy}
         />
       </label>
-      {error && <p className="text-sm text-critical">{error}</p>}
+      {error && <p className="text-sm text-critical break-words">{error}</p>}
       <FormSubmit
         busy={busy}
         disabled={!path.trim()}
@@ -1181,7 +1180,7 @@ function GitUrlStage({
           disabled={busy}
         />
       </label>
-      {error && <p className="text-sm text-critical">{error}</p>}
+      {error && <p className="text-sm text-critical break-words">{error}</p>}
       <FormSubmit
         busy={busy}
         disabled={
@@ -1304,7 +1303,7 @@ function GithubStage({
           disabled={busy}
         />
       </label>
-      {error && <p className="text-sm text-critical">{error}</p>}
+      {error && <p className="text-sm text-critical break-words">{error}</p>}
       <FormSubmit
         busy={busy}
         disabled={
@@ -1369,7 +1368,6 @@ function GithubRepoField({
           onChange={(event) => onChange(event.target.value)}
           placeholder="owner/repo"
           disabled={busy}
-          autoFocus
         />
       ) : (
         <Popover
@@ -1767,6 +1765,3 @@ function Hint({ keys, label }: { keys: string[]; label: string }) {
     </span>
   );
 }
-
-export type { SourceKey };
-export { SOURCES };

--- a/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
@@ -6,7 +6,6 @@ import {
   ExternalLink,
   GitBranch,
   GitPullRequest,
-  LoaderCircle,
   MessageSquareText,
   RefreshCw,
   RotateCcw,
@@ -32,6 +31,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { openInBrowser } from "@/openInBrowser";
 import { RouteFrame } from "@/RouteFrame";
@@ -324,7 +324,7 @@ function CodeArchiveBody() {
               role="status"
               className="flex items-center gap-1.5 text-muted-foreground"
             >
-              <LoaderCircle className="size-3.5 animate-spin" />
+              <Spinner className="size-3.5" />
               Searching conversations…
             </span>
           )}
@@ -364,7 +364,7 @@ function CodeArchiveBody() {
           <Empty className="min-h-72">
             <EmptyHeader>
               <EmptyMedia variant="icon">
-                <LoaderCircle className="animate-spin" />
+                <Spinner />
               </EmptyMedia>
               <EmptyTitle>Searching conversations</EmptyTitle>
               <EmptyDescription>
@@ -481,11 +481,7 @@ function CodeArchiveBody() {
                       disabled={Boolean(restoring)}
                       onClick={() => void restore(workspace.id)}
                     >
-                      {restoring === workspace.id ? (
-                        <LoaderCircle className="animate-spin" />
-                      ) : (
-                        <RotateCcw />
-                      )}
+                      {restoring === workspace.id ? <Spinner /> : <RotateCcw />}
                       Restore
                     </Button>
                     <Button

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -11,7 +11,6 @@ import {
   ChevronDown,
   Gauge,
   List,
-  LoaderCircle,
   Search,
   Sparkles,
   Zap,
@@ -40,15 +39,9 @@ import { reasoningEffortOptions } from "../ModelMenu";
 import { familyForModelId } from "../modelFamilies";
 import { providerLabel } from "../ModelSelection";
 import { PermissionModeMenu } from "../PermissionModeMenu";
-import {
-  ClaudeIcon,
-  OpenAIIcon,
-  OpenCodeIcon,
-  ProviderIcon,
-  XaiIcon,
-} from "../ProviderIcons";
-import { Logomark } from "../Logomark";
+import { ProviderIcon } from "../ProviderIcons";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -69,6 +62,7 @@ import {
   PERMISSION_MODE_UNAVAILABLE_REASON,
   SESSION_PERMISSION_MODE_LOCKED,
 } from "./labels";
+import { HARNESS_ICONS } from "./HarnessPicker";
 
 const MODES: PermissionMode[] = ["plan", "ask", "auto", "allow"];
 
@@ -168,14 +162,6 @@ export function PermissionModePicker({
 
 /** Rail entry that lifts the vendor filter off a mixed catalog. */
 const ALL_MODELS = "all";
-
-const HARNESS_ICONS: Record<HarnessKind, typeof ClaudeIcon> = {
-  claude_code: ClaudeIcon,
-  codex: OpenAIIcon,
-  opencode: OpenCodeIcon,
-  grok: XaiIcon,
-  internal: Logomark,
-};
 
 /** The mark for one picker row: vendor, then open-model family, then the engine. */
 function CodeModelMark({
@@ -578,7 +564,7 @@ export function FastModeToggle({
       onClick={() => onChange(!value)}
     >
       {pending ? (
-        <LoaderCircle className="size-4 animate-spin" />
+        <Spinner className="size-4" />
       ) : (
         <Zap className={cn("size-4", !value && "opacity-50")} />
       )}
@@ -624,7 +610,7 @@ export function ReasoningEffortMenu({
           data-ultra={topSelected ? "on" : undefined}
         >
           {pending ? (
-            <LoaderCircle className="size-4 animate-spin" />
+            <Spinner className="size-4" />
           ) : topSelected ? (
             <Sparkles className="size-4" />
           ) : (

--- a/crates/tidebreak-desktop/ui/src/code/CodeFileIcon.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeFileIcon.tsx
@@ -100,7 +100,7 @@ export function CodeFileIcon({
   );
 }
 
-export function fileIconSpec(path: string): FileIconSpec {
+function fileIconSpec(path: string): FileIconSpec {
   const name = path.split("/").pop()?.toLowerCase() ?? path.toLowerCase();
   const extension = name.includes(".") ? (name.split(".").pop() ?? "") : "";
 
@@ -130,7 +130,7 @@ export function fileIconSpec(path: string): FileIconSpec {
       kind: "package",
     };
   }
-  if (name.endsWith(".lock") || name.includes("lock.")) {
+  if (name.endsWith(".lock") || /(^|[-.])lock\.[a-z0-9]+$/i.test(name)) {
     return {
       icon: LockKeyhole,
       tone: "text-muted-foreground",

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -12,7 +12,8 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { Spinner } from "@/components/ui/spinner";
-import { cn } from "@/lib/utils";
+import { cn, friendlyErrorMessage } from "@/lib/utils";
+import { toast } from "sonner";
 import { RouteFrame } from "@/RouteFrame";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
 import { AddRepoPalette } from "./AddRepoPalette";
@@ -80,8 +81,8 @@ function CodeHomeBody() {
       useCodeUpdatesStore
         .getState()
         .apply({ type: "harness_install", install: snapshot });
-    } catch {
-      // Create still reports why, with the reason the server gave.
+    } catch (err) {
+      toast.error(friendlyErrorMessage(err, "Could not start the download"));
     }
   }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeInspector.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   Check,
   CircleCheck,
@@ -588,13 +594,17 @@ export function PrTab({
     (prResource ? prResource.busy !== null || prResource.refreshing : false) ||
     localMerging !== null;
 
+  const commentsRequestId = useRef(0);
   const loadComments = useCallback(async () => {
     if (prNumber === undefined) return;
+    const requestId = ++commentsRequestId.current;
     try {
       const snapshot = await client.getCodePrComments(workspaceId);
+      if (requestId !== commentsRequestId.current) return;
       setComments(snapshot.comments);
       setCommentsError(null);
     } catch (err) {
+      if (requestId !== commentsRequestId.current) return;
       setCommentsError(
         friendlyErrorMessage(err, "Could not load review comments"),
       );
@@ -1161,6 +1171,12 @@ function CheckList({
   };
 }) {
   const [open, setOpen] = useState(checks.length > 0);
+  const wasEmpty = useRef(checks.length === 0);
+  useEffect(() => {
+    const empty = checks.length === 0;
+    if (wasEmpty.current && !empty) setOpen(true);
+    wasEmpty.current = empty;
+  }, [checks.length]);
   return (
     <div className="flex flex-col gap-1">
       <button

--- a/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeQuickOpen.tsx
@@ -17,7 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Spinner } from "@/components/ui/spinner";
-import { fuzzyTokenScore, queryTokens } from "@/fuzzy";
+import { fuzzyScore, queryTokens } from "@/fuzzy";
 import { friendlyErrorMessage } from "@/lib/utils";
 
 const QUICK_OPEN_LIMIT = 5000;
@@ -49,6 +49,7 @@ export function CodeQuickOpen({
   const [openWorkspaceId, setOpenWorkspaceId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [paths, setPaths] = useState<string[]>([]);
+  const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const loadedKeyRef = useRef<string | null>(null);
@@ -67,6 +68,7 @@ export function CodeQuickOpen({
   useEffect(() => {
     loadedKeyRef.current = null;
     setPaths([]);
+    setTruncated(false);
     setLoading(false);
     setError(null);
     setQuery("");
@@ -90,6 +92,7 @@ export function CodeQuickOpen({
       .then((tree) => {
         if (cancelled) return;
         setPaths(tree.paths);
+        setTruncated(tree.truncated);
         loadedKeyRef.current = treeKey;
         setLoading(false);
       })
@@ -160,8 +163,17 @@ export function CodeQuickOpen({
           <CommandList className="max-h-[min(55vh,30rem)] min-h-20 p-1.5">
             {error ? (
               <p className="text-critical px-3 py-5 text-sm">{error}</p>
+            ) : loading ? (
+              <p className="text-muted-foreground px-3 py-5 text-sm">
+                Loading files…
+              </p>
             ) : (
               <>
+                {truncated && (
+                  <p className="text-muted-foreground px-3 py-2 text-xs">
+                    File list was truncated. Add a file filter to narrow it.
+                  </p>
+                )}
                 <CommandEmpty className="text-muted-foreground px-3 py-5 text-sm">
                   No filenames match{" "}
                   {query ? (
@@ -222,10 +234,7 @@ export function rankQuickOpenPaths(
   return paths
     .map((path) => {
       const target = pathQuery ? path.replace(/\\/g, "/") : fileName(path);
-      const score = tokens.reduce((total, token) => {
-        const next = fuzzyTokenScore(target.toLocaleLowerCase(), token);
-        return total < 0 || next < 0 ? -1 : total + next;
-      }, 0);
+      const score = fuzzyScore(target, query);
       return { path, score };
     })
     .filter((entry) => entry.score >= 0)

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -1,11 +1,5 @@
 import { useState, type ReactNode } from "react";
-import {
-  ArrowUpCircle,
-  ChevronDown,
-  Download,
-  Loader2,
-  RotateCw,
-} from "lucide-react";
+import { ArrowUpCircle, ChevronDown, Download, RotateCw } from "lucide-react";
 
 import type {
   CodeHarnessInstallSnapshot,
@@ -288,9 +282,7 @@ function DoctorRow({
               </span>
             )}
             <Badge variant={badge.variant} size="sm" className="shrink-0">
-              {downloading && (
-                <Loader2 className="size-3 animate-spin" aria-hidden="true" />
-              )}
+              {downloading && <Spinner className="size-3" aria-hidden="true" />}
               {badge.label}
             </Badge>
           </div>

--- a/crates/tidebreak-desktop/ui/src/code/HarnessInstallNote.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/HarnessInstallNote.tsx
@@ -1,4 +1,6 @@
-import { Loader2, TriangleAlert } from "lucide-react";
+import { TriangleAlert } from "lucide-react";
+
+import { Spinner } from "@/components/ui/spinner";
 
 import type { CodeHarnessInstallSnapshot } from "../api/types";
 import { HARNESS_LABELS } from "./labels";
@@ -21,7 +23,7 @@ export function HarnessInstallNote({
   const version = install.version ? ` ${install.version}` : "";
   if (install.error) {
     return (
-      <p className="text-destructive flex items-start gap-1.5 text-xs">
+      <p className="text-critical flex items-start gap-1.5 text-xs">
         <TriangleAlert
           className="mt-0.5 size-3.5 shrink-0"
           aria-hidden="true"
@@ -38,7 +40,7 @@ export function HarnessInstallNote({
       className="text-muted-foreground flex items-center gap-1.5 text-xs"
       role="status"
     >
-      <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden="true" />
+      <Spinner className="size-3.5" aria-hidden="true" />
       <span>
         Downloading {label}
         {version}. This runs once, and takes a few minutes.

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -1139,7 +1139,7 @@ export function NewWorkspaceDialog({
                 onRemove={removeImage}
               />
               {imageError && (
-                <p className="text-destructive text-xs" role="alert">
+                <p className="text-critical text-xs" role="alert">
                   {imageError}
                 </p>
               )}

--- a/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/PullRequestDetail.tsx
@@ -14,7 +14,6 @@ import {
   GitPullRequest,
   GitPullRequestClosed,
   GitPullRequestDraft,
-  LoaderCircle,
   MoreHorizontal,
   RefreshCw,
   ShieldAlert,
@@ -1045,7 +1044,7 @@ function PrAgentMenu({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button type="button" size="xs" variant="outline" disabled={starting}>
-          {starting ? <LoaderCircle className="animate-spin" /> : <Bot />}
+          {starting ? <Spinner /> : <Bot />}
           Fix with an agent
         </Button>
       </DropdownMenuTrigger>
@@ -1236,7 +1235,7 @@ function PrMergeBox({
               disabled={Boolean(busy)}
               onClick={() => onRun("ready", { type: "mark_ready" })}
             >
-              {busy === "ready" && <LoaderCircle className="animate-spin" />}
+              {busy === "ready" && <Spinner />}
               Mark ready
             </Button>
           )}
@@ -1261,9 +1260,7 @@ function PrMergeBox({
                   })
                 }
               >
-                {busy === mergeAction.kind && (
-                  <LoaderCircle className="animate-spin" />
-                )}
+                {busy === mergeAction.kind && <Spinner />}
                 {mergeAction.kind === "merge" ? <GitMerge /> : null}
                 {mergeAction.label}
               </Button>
@@ -1282,9 +1279,7 @@ function PrMergeBox({
                 disabled={Boolean(busy)}
                 onClick={() => setConfirmingStackMerge(true)}
               >
-                {busy === "merge-stack" && (
-                  <LoaderCircle className="animate-spin" />
-                )}
+                {busy === "merge-stack" && <Spinner />}
                 <GitMerge />
                 Merge stack ({mergeableStackLayers.length} layers)
               </Button>
@@ -1315,11 +1310,7 @@ function PrMergeBox({
                 })
               }
             >
-              {busy === "rerun" ? (
-                <LoaderCircle className="animate-spin" />
-              ) : (
-                <RefreshCw />
-              )}
+              {busy === "rerun" ? <Spinner /> : <RefreshCw />}
               Rerun failed
             </Button>
           )}
@@ -1331,7 +1322,7 @@ function PrMergeBox({
               disabled={Boolean(busy)}
               onClick={() => onRun("reopen", { type: "reopen" })}
             >
-              {busy === "reopen" && <LoaderCircle className="animate-spin" />}
+              {busy === "reopen" && <Spinner />}
               Reopen
             </Button>
           )}
@@ -1346,7 +1337,7 @@ function PrMergeBox({
                   aria-label="More pull request actions"
                 >
                   {busy === "close" || busy === "admin-merge" ? (
-                    <LoaderCircle className="animate-spin" />
+                    <Spinner />
                   ) : (
                     <MoreHorizontal />
                   )}
@@ -1523,7 +1514,7 @@ function ConfirmStrip({
           disabled={busy}
           onClick={onConfirm}
         >
-          {busy && <LoaderCircle className="animate-spin" />}
+          {busy && <Spinner />}
           {confirmLabel}
         </Button>
         <Button
@@ -1708,7 +1699,7 @@ function PrConversation({
               disabled={Boolean(busy) || !draft.trim()}
               onClick={onComment}
             >
-              {busy === "comment" && <LoaderCircle className="animate-spin" />}
+              {busy === "comment" && <Spinner />}
               Comment
             </Button>
           </div>

--- a/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { CircleAlert, LoaderCircle, Plus, X } from "lucide-react";
+import { CircleAlert, Plus, X } from "lucide-react";
 
 import type { ApiClient } from "@/api/client";
 import type { CodeRepoSnapshot, QuickAction } from "@/api/types";
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { Spinner } from "@/components/ui/spinner";
 import { friendlyErrorMessage } from "@/lib/utils";
 
 type RepoSettingsClient = Pick<ApiClient, "getCodeRepo" | "patchCodeRepo">;
@@ -222,9 +223,7 @@ export function RepositorySettings({
             checkout in place and marks the workspace Setup failed.
           </p>
         </div>
-        {(loading || busy) && (
-          <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
-        )}
+        {(loading || busy) && <Spinner className="size-3.5" />}
       </div>
       {error && (
         <div className="notice-surface notice-critical mb-4 flex flex-col items-stretch gap-2 rounded-md border px-3 py-2 text-xs min-[480px]:flex-row min-[480px]:items-center min-[480px]:justify-between">

--- a/crates/tidebreak-desktop/ui/src/code/RepositoryTriggerRules.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositoryTriggerRules.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { CircleAlert, LoaderCircle } from "lucide-react";
+import { CircleAlert } from "lucide-react";
 
 import type { ApiClient } from "@/api/client";
 import type {
@@ -9,6 +9,7 @@ import type {
   CodeTriggerSnapshot,
 } from "@/api/types";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { friendlyErrorMessage } from "@/lib/utils";
 import { CodeTriggerRules, type CodeTriggerTarget } from "./CodeTriggerRules";
 
@@ -147,7 +148,7 @@ export function RepositoryTriggerRules({
             {repository.name_with_owner}
           </p>
         </div>
-        {loading && <LoaderCircle className="size-4 animate-spin" />}
+        {loading && <Spinner className="size-4" />}
       </div>
       {error && (
         <div className="notice-surface notice-critical mb-4 flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs">

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   Archive,
   Ban,
@@ -498,6 +498,12 @@ function WorkspaceSubagentRows({
 }) {
   const running = subagents.filter((entry) => entry.status === "running");
   const [expanded, setExpanded] = useState(running.length > 0);
+  const wasEmpty = useRef(running.length === 0);
+  useEffect(() => {
+    const empty = running.length === 0;
+    if (wasEmpty.current && !empty) setExpanded(true);
+    wasEmpty.current = empty;
+  }, [running.length]);
   // A count, not a state: the session line above already says how many are
   // working, and the rows below say which.
   const summary =

--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserToolbar.tsx
@@ -21,7 +21,6 @@ import {
   History,
   Info,
   Laptop,
-  LoaderCircle,
   LockKeyhole,
   MoreHorizontal,
   Pause,
@@ -35,6 +34,7 @@ import {
 
 import { useConfirm } from "@/components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -321,7 +321,7 @@ export function BrowserToolbar({
               onFocus={(event) => event.currentTarget.select()}
             />
             {session.loadState === "loading" ? (
-              <LoaderCircle className="size-3.5 shrink-0 animate-spin text-muted-foreground motion-reduce:animate-none" />
+              <Spinner className="size-3.5 text-muted-foreground motion-reduce:animate-none" />
             ) : !compactToolbar ? (
               <Search className="size-3.5 shrink-0 text-muted-foreground/70" />
             ) : null}
@@ -453,7 +453,7 @@ export function BrowserToolbar({
                   }
                 >
                   {resetInProgress ? (
-                    <LoaderCircle className="animate-spin motion-reduce:animate-none" />
+                    <Spinner className="motion-reduce:animate-none" />
                   ) : (
                     <MoreHorizontal />
                   )}

--- a/crates/tidebreak-desktop/ui/src/code/delivery/DeliveryRepositoriesDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/DeliveryRepositoriesDialog.tsx
@@ -12,7 +12,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { LoaderCircle, Pin, PinOff, RefreshCw, X } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import { Pin, PinOff, RefreshCw, X } from "lucide-react";
 import { RepositorySettings } from "../RepositorySettings";
 import { RepositoryTriggerRules } from "../RepositoryTriggerRules";
 import {
@@ -215,7 +216,7 @@ export function DeliveryRepositoriesDialog({
                 disabled={resolving || !input.trim()}
                 onClick={() => void add()}
               >
-                {resolving && <LoaderCircle className="animate-spin" />}
+                {resolving && <Spinner />}
                 Add
               </Button>
             </div>

--- a/crates/tidebreak-desktop/ui/src/code/delivery/PullRequestList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/PullRequestList.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import type { CodeDeliveryPullRequestSummary } from "../../api/types";
-import { CornerDownRight, LoaderCircle, MessageSquare } from "lucide-react";
+import { CornerDownRight, MessageSquare } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
 import { GithubAvatar } from "../GithubAvatar";
 import {
   PR_GRID,
@@ -465,7 +466,7 @@ function PullRequestRow({
               onMerge();
             }}
           >
-            {busy && <LoaderCircle className="animate-spin" />}
+            {busy && <Spinner />}
             {mergeAction.label}
           </Button>
         ) : null}

--- a/crates/tidebreak-desktop/ui/src/code/delivery/PullRequestsSurface.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/PullRequestsSurface.tsx
@@ -26,7 +26,8 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty";
-import { GitPullRequest, LoaderCircle } from "lucide-react";
+import { GitPullRequest } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
 import { PendingDetailPane } from "./PendingDetail";
 import { PullRequestDetailPane } from "../PullRequestDetail";
 import type { PullRequestGrouping } from "./views";
@@ -259,7 +260,7 @@ export function PullRequestsSurface({
                 disabled={loadingMore}
                 onClick={() => void query(nextCursor, true)}
               >
-                {loadingMore && <LoaderCircle className="animate-spin" />}
+                {loadingMore && <Spinner />}
                 Load more
               </Button>
             </div>

--- a/crates/tidebreak-desktop/ui/src/code/delivery/RunsSurface.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/RunsSurface.tsx
@@ -28,7 +28,8 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty";
-import { LoaderCircle, Workflow } from "lucide-react";
+import { Workflow } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
 import { PendingDetailSheet } from "./PendingDetail";
 import { RunDetailSheet } from "./RunDetailSheet";
 import { RunList } from "./RunList";
@@ -310,7 +311,7 @@ export function RunsSurface({
                   disabled={loadingMore}
                   onClick={() => void query(nextCursor, true)}
                 >
-                  {loadingMore && <LoaderCircle className="animate-spin" />}
+                  {loadingMore && <Spinner />}
                   Load more
                 </Button>
               </div>

--- a/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -3,7 +3,6 @@ import { toast } from "sonner";
 import {
   ChevronDown,
   ChevronRight,
-  Loader2,
   Pencil,
   Plus,
   RefreshCw,
@@ -25,6 +24,7 @@ import {
   NoPublicDocumentGuidance,
 } from "./OpenApiDiscovery";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -817,7 +817,7 @@ export function ConnectedAppsPanel({
             disabled={saving || discovering || previewing}
             onClick={() => void findOpenApiDocument()}
           >
-            {discovering && <Loader2 size={14} className="animate-spin" />}
+            {discovering && <Spinner className="size-3.5" />}
             {discovering ? "Searching…" : "Find the OpenAPI document"}
           </Button>
         </div>
@@ -929,7 +929,7 @@ export function ConnectedAppsPanel({
               disabled={saving || previewing}
               onClick={() => void loadOperations()}
             >
-              {previewing && <Loader2 size={14} className="animate-spin" />}
+              {previewing && <Spinner className="size-3.5" />}
               {previewing ? "Fetching…" : "Fetch operations"}
             </Button>
           </div>
@@ -958,7 +958,7 @@ export function ConnectedAppsPanel({
             disabled={saving || previewing}
             onClick={() => void loadOperations()}
           >
-            {previewing && <Loader2 size={14} className="animate-spin" />}
+            {previewing && <Spinner className="size-3.5" />}
             {previewing ? "Loading…" : "Select operations…"}
           </Button>
           {formError && <SettingsError>{formError}</SettingsError>}
@@ -1041,7 +1041,7 @@ export function ConnectedAppsPanel({
           }
           onClick={() => void save()}
         >
-          {saving && <Loader2 size={14} className="animate-spin" />}
+          {saving && <Spinner className="size-3.5" />}
           {saving ? "Saving…" : "Save"}
         </Button>
         <Button

--- a/crates/tidebreak-desktop/ui/src/settings/OpenApiDiscovery.tsx
+++ b/crates/tidebreak-desktop/ui/src/settings/OpenApiDiscovery.tsx
@@ -1,7 +1,6 @@
-import { Loader2 } from "lucide-react";
-
 import type { SpecDiscoveryInfo } from "../api";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 
 /** A copyable OpenAPI 3 JSON document with one GET, a path parameter, and a
  * bearer header — enough to ingest when the vendor publishes nothing. */
@@ -100,7 +99,7 @@ export function DiscoveryResults({
   if (discovering) {
     return (
       <p className="flex items-center gap-2 text-sm text-muted-foreground">
-        <Loader2 size={14} className="animate-spin" />
+        <Spinner className="size-3.5" />
         Searching well-known OpenAPI locations…
       </p>
     );

--- a/crates/tidebreak-desktop/ui/src/stylesContract.test.ts
+++ b/crates/tidebreak-desktop/ui/src/stylesContract.test.ts
@@ -53,8 +53,9 @@ function offenders(pattern: RegExp, skip?: ReadonlySet<string>): string[] {
   return hits;
 }
 
-/** RefreshCw / RotateCw JSX that also carries animate-spin. */
-const SPINNING_LUCIDE_REFRESH = /<(RefreshCw|RotateCw)\b[^>]*animate-spin/;
+/** RefreshCw / RotateCw / Loader2 / LoaderCircle JSX that also carries animate-spin. */
+const SPINNING_LUCIDE_REFRESH =
+  /<(RefreshCw|RotateCw|Loader2|LoaderCircle)\b[^>]*animate-spin/;
 
 function spinningRefreshIcons(): string[] {
   const hits: string[] = [];
@@ -88,7 +89,7 @@ describe("styles contract (see DESIGN.md)", () => {
     expect(
       spinningRefreshIcons(),
       "Busy refresh controls swap to Spinner from components/ui/spinner.tsx. " +
-        "Lucide RefreshCw and RotateCw orbit under animate-spin. See DESIGN.md.",
+        "Lucide RefreshCw, RotateCw, Loader2, and LoaderCircle orbit under animate-spin. See DESIGN.md.",
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
1. CodeFileIcon: lock glyphs now match a `lock` path segment (`Cargo.lock`, `pnpm-lock.yaml`) instead of any filename containing `lock.`.
2. CodeHome: harness install failures toast with `friendlyErrorMessage` instead of swallowing the error.
3. CodeInspector `loadComments`: request counter so only the latest workspace response is applied.
4. CodeQuickOpen: show loading while the tree is in flight, keep `truncated`, and render the FilesPanel truncated note.
5. AddRepoPalette / AddRepoInline: `break-words` on server messages that may include long URLs.
6. AddRepoPalette: drop `autoFocus` on the empty GitHub owner/repo input.
7. CodeInspector CheckList and WorkspaceCard subagent rows: expand when the list first becomes non-empty without overriding a later manual collapse.
8. CodeComposer: import `HARNESS_ICONS` from HarnessPicker instead of copying it.
9. AddRepoPalette: remove unused `SourceKey` / `SOURCES` exports (and delete unused `SourceKey`).
10. CodeQuickOpen ranks with `fuzzyScore`; drop unused `fileIconSpec` export.
11. Replace Lucide `Loader2`/`LoaderCircle` + `animate-spin` with `Spinner` at the listed sites; forbid those glyphs in `stylesContract.test.ts`. Extra files the contract then required: `ChangeSummaryCard.tsx`, `ComposerToolsMenu.tsx`, `code/browser/BrowserToolbar.tsx`, `code/delivery/DeliveryRepositoriesDialog.tsx`, `code/delivery/PullRequestList.tsx`, `code/delivery/PullRequestsSurface.tsx`, `code/delivery/RunsSurface.tsx`, `settings/ConnectedAppsPanel.tsx`, `settings/OpenApiDiscovery.tsx`.
12. HarnessInstallNote and NewWorkspaceDialog: failure ink is `text-critical`.

Skipped:
- Item 1 extra test case: no dedicated test file exists for `CodeFileIcon.tsx`.

Checks (crates/tidebreak-desktop/ui):
- `pnpm exec biome format --write src` — Formatted 925 files in 985ms. Fixed 6 files.
- `pnpm exec biome format src` — Checked 925 files in 936ms. No fixes applied.
- `pnpm lint` — Checked 925 files in 1031ms. No fixes applied.
- `pnpm test` — Test Files  286 passed (286); Tests  2521 passed (2521)
- `pnpm build` — ✓ built in 13.16s