### PR TITLE
fix(desktop): code-mode workspace, browser, and delivery fixes from the audit

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/BrowserViewportControl.tsx
@@ -252,14 +252,13 @@ function CustomWidthField({
   const [draft, setDraft] = useState(String(viewport.customWidth));
   const [error, setError] = useState<string | null>(null);
 
-  // Keep the draft in sync when the viewport changes externally (preset switch).
+  // Keep the draft in sync when customWidth changes externally.
   useEffect(() => {
     setDraft(String(viewport.customWidth));
     setError(null);
   }, [viewport.customWidth]);
 
-  function commit(event: FormEvent) {
-    event.preventDefault();
+  function commitDraft(focusAfter = false) {
     const parsed = Number.parseInt(draft, 10);
     if (!Number.isFinite(parsed)) {
       setError("Enter a number");
@@ -275,7 +274,12 @@ function CustomWidthField({
     setError(null);
     onViewportChange({ preset: "custom", customWidth: clamped });
     setDraft(String(clamped));
-    inputRef.current?.focus();
+    if (focusAfter) inputRef.current?.focus();
+  }
+
+  function commit(event: FormEvent) {
+    event.preventDefault();
+    commitDraft(true);
   }
 
   return (
@@ -314,6 +318,7 @@ function CustomWidthField({
             setDraft(event.target.value);
             if (error) setError(null);
           }}
+          onBlur={() => commitDraft()}
           onFocus={(event) => event.currentTarget.select()}
         />
         <span className="text-2xs text-muted-foreground/70">px</span>

--- a/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/browser/CodeBrowserTab.tsx
@@ -162,7 +162,6 @@ function CodeBrowserTabSession({
     documentEpoch: runtime?.documentEpoch,
   });
   const signalRefresh = useRefreshSignals((state) => state.signal);
-  const surfaceRef = useRef<HTMLDivElement | null>(null);
   const mountedRef = useRef(true);
   const nativeReady = useRef(false);
   const nativePresence = useRef<"unknown" | "missing" | "present">("unknown");
@@ -1090,13 +1089,14 @@ function CodeBrowserTabSession({
   }
 
   async function runHostCommand(type: "reload" | "stop" | "back" | "forward") {
-    await runHostAction({ type });
+    return runHostAction({ type });
   }
 
-  async function runHostAction(action: BrowserHostAction) {
-    if (!host.available() || !nativeReady.current) return;
+  async function runHostAction(action: BrowserHostAction): Promise<boolean> {
+    if (!host.available() || !nativeReady.current) return false;
     try {
       recordRuntime(await host.command(workspaceId, browserId, action));
+      return true;
     } catch (error) {
       updateSession((current) =>
         failBrowserSession(
@@ -1104,6 +1104,7 @@ function CodeBrowserTabSession({
           friendlyErrorMessage(error, "The browser command failed"),
         ),
       );
+      return false;
     }
   }
 
@@ -1191,7 +1192,8 @@ function CodeBrowserTabSession({
   }
 
   async function stop() {
-    await runHostCommand("stop");
+    const ok = await runHostCommand("stop");
+    if (!ok) return;
     updateSession((current) => ({
       ...current,
       loadState: current.url ? "ready" : "idle",
@@ -1343,7 +1345,7 @@ function CodeBrowserTabSession({
           onDismiss={() => setSlow(false)}
         />
       )}
-      <div ref={surfaceRef} className="relative min-h-0 flex-1 overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
         <ViewportSurface
           viewport={viewport}
           showNative={showNative}

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserHost.ts
@@ -125,7 +125,6 @@ export type BrowserHostEvent = {
     | "agent_navigation_paused"
     | "agent_access_changed"
     | "agent_open_requested"
-    | "agent_activate_requested"
     | "agent_closed_tab"
     | "profile_reset_closing"
     | "profile_reset_deleting_data"

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserNavigation.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserNavigation.test.ts
@@ -70,5 +70,10 @@ describe("browser navigation", () => {
     expect(browserDisplayAddress("http://example.com/docs")).toBe(
       "http://example.com/docs",
     );
+    expect(browserSecurity("not a url")).toEqual({
+      kind: "insecure",
+      label: "Not secure",
+    });
+    expect(browserDisplayAddress("not a url")).toBe("not a url");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/browser/browserNavigation.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/browserNavigation.ts
@@ -75,14 +75,24 @@ export function validateBrowserUrl(value: string): BrowserTarget {
 }
 
 export function browserSecurity(url: string): BrowserSecurity {
-  const parsed = new URL(url);
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { kind: "insecure", label: "Not secure" };
+  }
   if (parsed.protocol === "https:") return { kind: "secure", label: "Secure" };
   if (isLoopbackHost(parsed.hostname)) return { kind: "local", label: "Local" };
   return { kind: "insecure", label: "Not secure" };
 }
 
 export function browserDisplayAddress(url: string): string {
-  const parsed = new URL(url);
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
   if (parsed.protocol === "http:") return parsed.href;
   const suffix = `${parsed.pathname}${parsed.search}${parsed.hash}`;
   return `${parsed.host}${suffix === "/" ? "" : suffix}`;

--- a/crates/tidebreak-desktop/ui/src/code/browser/foregroundBrowserScope.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/browser/foregroundBrowserScope.test.ts
@@ -6,16 +6,4 @@ describe("foregroundBrowserScope", () => {
   it("returns the prefixed scope for a chat id", () => {
     expect(foregroundBrowserScope("abc-123")).toBe("foreground-chat:abc-123");
   });
-
-  it("is deterministic", () => {
-    expect(foregroundBrowserScope("chat-1")).toBe(
-      foregroundBrowserScope("chat-1"),
-    );
-  });
-
-  it("creates disjoint scopes for different chat ids", () => {
-    expect(foregroundBrowserScope("chat-a")).not.toBe(
-      foregroundBrowserScope("chat-b"),
-    );
-  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/delivery/SaveViewDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/SaveViewDialog.tsx
@@ -59,7 +59,13 @@ export function SaveViewDialog({
     onOpenChange(false);
   };
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setName("");
+        onOpenChange(next);
+      }}
+    >
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Save this view</DialogTitle>

--- a/crates/tidebreak-desktop/ui/src/code/delivery/VirtualRows.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/VirtualRows.tsx
@@ -60,6 +60,7 @@ export function VirtualRows<T extends { id: string }>({
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(measure);
     if (scrollRef.current) observer.observe(scrollRef.current);
+    if (listRef.current) observer.observe(listRef.current);
     return () => observer.disconnect();
   }, [scrollRef, items.length]);
 

--- a/crates/tidebreak-desktop/ui/src/code/delivery/filters.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/filters.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { commaList, humanize, toggleValue } from "./helpers";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 export function PullRequestFilters({
   repositories,
@@ -64,7 +64,7 @@ export function PullRequestFilters({
       </PopoverTrigger>
       <PopoverContent
         align="end"
-        className="w-[22rem] max-w-[calc(100vw-24px)] p-3"
+        className="max-h-[min(720px,calc(100vh-32px))] w-[22rem] max-w-[calc(100vw-24px)] overflow-auto p-3"
       >
         <FilterSection title="Repositories">
           <RepositoryCheckboxes
@@ -524,13 +524,30 @@ function AdvancedTextFilter({
   placeholder: string;
   onChange: (value: string[]) => void;
 }) {
+  const committed = value.join(", ");
+  const [draft, setDraft] = useState(committed);
+  useEffect(() => {
+    setDraft(committed);
+  }, [committed]);
+
+  function commit() {
+    onChange(commaList(draft));
+  }
+
   return (
     <div className="mb-3 flex flex-col gap-1.5">
       <Label className="text-xs text-muted-foreground">{label}</Label>
       <Input
-        value={value.join(", ")}
+        value={draft}
         placeholder={placeholder}
-        onChange={(event) => onChange(commaList(event.target.value))}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commit}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            commit();
+          }
+        }}
       />
     </div>
   );

--- a/crates/tidebreak-desktop/ui/src/code/delivery/helpers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/helpers.ts
@@ -12,6 +12,7 @@ import type {
   CodeGitHubRepositoryRef,
   CodeGitHubRepositoryTarget,
 } from "../../api/types";
+import type { StatusTone } from "../statusTone";
 import type { PrBuiltInView, PullRequestGrouping } from "./views";
 import {
   groupedPullRequestRows,
@@ -37,10 +38,8 @@ export function runBucket(
   return "skipped";
 }
 
-export function runTone(
-  value: string,
-): "success" | "critical" | "warning" | "muted" {
-  if (value === "success") return "success";
+export function runTone(value: string): StatusTone {
+  if (value === "success") return "ready";
   if (
     value === "failure" ||
     value === "timed_out" ||
@@ -51,9 +50,9 @@ export function runTone(
     return "critical";
   }
   if (value === "queued" || value === "in_progress" || value === "pending") {
-    return "warning";
+    return "pending";
   }
-  return "muted";
+  return "neutral";
 }
 
 export function selectedRepositoryTargets(

--- a/crates/tidebreak-desktop/ui/src/code/delivery/status.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/status.tsx
@@ -17,6 +17,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { humanize, runTone } from "./helpers";
 import { relativeTime } from "../PullRequestDetail";
+import { STATUS_CHIP, STATUS_TEXT } from "../statusTone";
 
 /**
  * How many rows there are, how old they are, and a way to reread them.
@@ -221,13 +222,7 @@ export function RunStatusBadge({ item }: { item: CodeDeliveryRunSummary }) {
     <span
       className={cn(
         "rounded-md px-2 py-1 text-xs font-medium",
-        tone === "success" &&
-          "bg-success-background text-success-foreground-muted",
-        tone === "critical" &&
-          "bg-critical-background text-critical-foreground-muted",
-        tone === "warning" &&
-          "bg-warning-background text-warning-foreground-muted",
-        tone === "muted" && "bg-muted text-muted-foreground",
+        STATUS_CHIP[tone],
       )}
     >
       {humanize(value)}
@@ -238,15 +233,7 @@ export function RunStatusBadge({ item }: { item: CodeDeliveryRunSummary }) {
 export function RunStateText({ value }: { value: string }) {
   const tone = runTone(value);
   return (
-    <span
-      className={cn(
-        "text-xs font-medium",
-        tone === "success" && "text-success",
-        tone === "critical" && "text-critical",
-        tone === "warning" && "text-warning",
-        tone === "muted" && "text-muted-foreground",
-      )}
-    >
+    <span className={cn("text-xs font-medium", STATUS_TEXT[tone])}>
       {humanize(value)}
     </span>
   );

--- a/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestQuery.ts
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/usePullRequestQuery.ts
@@ -152,6 +152,7 @@ export function usePullRequestQuery({
     setError(null);
     try {
       if (selectedRepositories.length === 0) {
+        if (!append) setItems([]);
         setNextCursor(undefined);
         setErrors([]);
         return;

--- a/crates/tidebreak-desktop/ui/src/code/workspace/layout.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/layout.tsx
@@ -98,8 +98,6 @@ export function nameTerminals(
   return unchanged ? (current as Record<string, string>) : kept;
 }
 
-/** Native child webviews must yield whenever a portaled app surface overlaps them. */
-
 function shortcutHint(id: ShellShortcutAction, command: boolean): string {
   const def = SHELL_SHORTCUTS.find((item) => item.id === id);
   return def ? shortcutKeycaps(def, command).join("") : "";

--- a/crates/tidebreak-desktop/ui/src/code/workspace/subagents.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/subagents.tsx
@@ -41,9 +41,6 @@ export function subagentSummaryFromTranscript(
 
 function toolDetailSubject(
   detail: Extract<CodeTranscriptItem, { kind: "tool" }>["detail"],
-): string;
-function toolDetailSubject(
-  detail: Extract<CodeTranscriptItem, { kind: "tool" }>["detail"],
 ): string {
   switch (detail.kind) {
     case "command":

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useBrowserTabs.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useBrowserTabs.test.ts
@@ -205,23 +205,6 @@ describe("agent browser lifecycle", () => {
     });
   });
 
-  it("ignores activation events that would select an agent preview", () => {
-    const layout = withBrowser(
-      openCodeEditor(EMPTY, { type: "file", path: "app.tsx" }),
-      "agent-1",
-    );
-    const { setLayout } = setup({ ...layout, activeIndex: 0 });
-    const listener = mocks.subscribe.mock.calls.at(-1)![0];
-    act(() =>
-      listener({
-        type: "agent_activate_requested",
-        workspaceId: "ws-1",
-        browserId: "agent-1",
-      }),
-    );
-    expect(setLayout).not.toHaveBeenCalled();
-  });
-
   it("discovers tabs opened while another route was showing without selecting them", async () => {
     mocks.list.mockResolvedValueOnce([
       {

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.test.ts
@@ -173,6 +173,23 @@ describe("useWorkspaceSessions", () => {
     ]);
   });
 
+  it("restores a closed conversation tab when it is selected again", async () => {
+    const { result } = setup([main, sibling]);
+    await waitFor(() => expect(result.current.session?.id).toBe("sess-main"));
+    act(() => result.current.selectConversation("sess-sibling"));
+    act(() => result.current.closeConversation("sess-sibling"));
+    expect(result.current.conversationTabs.map((tab) => tab.id)).toEqual([
+      "sess-main",
+    ]);
+
+    act(() => result.current.selectConversation("sess-sibling"));
+    expect(result.current.session?.id).toBe("sess-sibling");
+    expect(result.current.conversationTabs.map((tab) => tab.id)).toEqual([
+      "sess-main",
+      "sess-sibling",
+    ]);
+  });
+
   it("reports a load failure and retries on request", async () => {
     const { result, client } = setup([main], undefined, {
       failFirstLoad: true,

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
@@ -444,6 +444,12 @@ export function useWorkspaceSessions({
     }
     setDraftAgent(false);
     setActiveSessionId(sessionId);
+    setClosedConversationIds((current) => {
+      if (!current.has(sessionId)) return current;
+      const next = new Set(current);
+      next.delete(sessionId);
+      return next;
+    });
     openWorkspaceTask(
       sessionId === conversations[0]?.id ? undefined : sessionId,
     );

--- a/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Browser.stories.tsx
@@ -46,7 +46,8 @@ type BrowserScenario =
   | "profile-reset-confirmation"
   | "profile-resetting"
   | "profile-reset-reconstructing"
-  | "profile-reset-failure";
+  | "profile-reset-failure"
+  | "address-error";
 
 const inspectEngine: NonNullable<BrowserHostSnapshot["engine"]> = {
   name: "wk_webview",
@@ -272,7 +273,11 @@ function BrowserStory({
         <BrowserToolbar
           session={session}
           address={address}
-          addressError={null}
+          addressError={
+            scenario === "address-error"
+              ? "Only HTTP and HTTPS addresses can open here"
+              : null
+          }
           canGoBack={session.historyIndex > 0}
           canGoForward={false}
           controller={controller}
@@ -780,6 +785,10 @@ export const SlowPage: Story = { args: { scenario: "slow" } };
 
 export const Failure: Story = {
   args: { scenario: "failure" },
+};
+
+export const AddressError: Story = {
+  args: { scenario: "address-error" },
 };
 
 export const PopupBlocked: Story = { args: { scenario: "popup" } };

--- a/crates/tidebreak-desktop/ui/src/stories/CodeAnalytics.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/CodeAnalytics.stories.tsx
@@ -455,7 +455,5 @@ export const CollapsedMacRail: Story = {
 
 export const NarrowWidth: Story = {
   args: { scenario: "gateway" },
-  parameters: {
-    viewport: { defaultViewport: "tablet" },
-  },
+  globals: { viewport: { value: "conversation", isRotated: false } },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -694,7 +694,7 @@ export const ArchiveEmpty: Story = {
 };
 
 export const NarrowPullRequestDetail: Story = {
-  parameters: { viewport: { defaultViewport: "compact" } },
+  globals: { viewport: { value: "compact", isRotated: false } },
 };
 
 /**

--- a/crates/tidebreak-desktop/ui/src/stories/FoldersView.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/FoldersView.stories.tsx
@@ -189,5 +189,5 @@ type Story = StoryObj<typeof meta>;
 export const FutureChatAccess: Story = {};
 
 export const FutureChatAccessCompact: Story = {
-  parameters: { viewport: { defaultViewport: "compact" } },
+  globals: { viewport: { value: "compact", isRotated: false } },
 };

--- a/crates/tidebreak-desktop/ui/src/stories/Plugins.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/Plugins.stories.tsx
@@ -228,7 +228,7 @@ export const ImportResults: Story = {
 
 export const ImportResultsCompact: Story = {
   render: () => <ImportResultsStory />,
-  parameters: { viewport: { defaultViewport: "compact" } },
+  globals: { viewport: { value: "compact", isRotated: false } },
 };
 
 export const LoadFailure: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/SettingsAdvanced.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SettingsAdvanced.stories.tsx
@@ -172,7 +172,7 @@ export const ConnectedAppsMcpImportSummary: Story = {
 
 export const ConnectedAppsMcpImportSummaryCompact: Story = {
   args: { panel: "connected-apps", state: "empty" },
-  parameters: { viewport: { defaultViewport: "compact" } },
+  globals: { viewport: { value: "compact", isRotated: false } },
 };
 
 export const ConnectedAppsFailure: Story = {

--- a/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/TurnReviewCard.stories.tsx
@@ -114,7 +114,7 @@ export const CodexRevokedRefreshToken: Story = {
 
 export const CodexRevokedRefreshTokenCompact: Story = {
   render: renderCodexRevokedTokenTranscript,
-  parameters: { viewport: { defaultViewport: "compact" } },
+  globals: { viewport: { value: "compact", isRotated: false } },
 };
 
 /**


### PR DESCRIPTION
1. `AdvancedTextFilter` now holds a local draft and commits on blur/Enter so trailing commas and additional values survive typing; no delivery filter tests cover this component, so none added.
2. `selectConversation` removes the id from `closedConversationIds` so a closed tab returns when reselected; `useWorkspaceSessions.test.ts` asserts close then reselect restores the tab.
3. `VirtualRows` also observes `listRef` so a banner above the list re-measures `scrollMargin`.
4. Browser `stop()` only sets loadState to ready/idle when `runHostCommand("stop")` succeeds.
5. Empty repository selection in `usePullRequestQuery` now clears `items`, matching `RunsSurface`.
6. `browserSecurity` and `browserDisplayAddress` catch invalid URLs and fall back like the other entry points in that file.
7. Removed unused `agent_activate_requested` from `BrowserHostEvent` (and the workspace test that only existed to ignore it).
8. Converted Storybook viewport stories to `globals.viewport`; `CodeAnalytics` NarrowWidth uses `conversation` (nearest defined viewport to the undefined `tablet`).
9. Added `AddressError` story so the critical notice and input ring render.
10. Replaced `LoaderCircle className="animate-spin"` with `Spinner` on the named delivery and browser sites.
11. PR filter popover uses the same max-height and overflow as run filters.
12. Custom viewport width commits on blur; comment now matches the `customWidth` effect dependency.
13. Cruft: deleted the no-op `toolDetailSubject` overload; deleted unread `surfaceRef` on `CodeBrowserTab`; deleted the two extra `foregroundBrowserScope` tests; deleted the orphan layout comment; `SaveViewDialog` clears `name` on cancel/close; dropped dead `enabled`/`onEnabledChange` on manual repository rows.
14. `RunStatusBadge`/`RunStateText` import `STATUS_CHIP`/`STATUS_TEXT`; `queued`/`in_progress` use the pending tone.

Skipped
- Item 1 extra test: no delivery filter tests exist for `AdvancedTextFilter`.
- Item 13 `BrowserController` collapse: `kind === "agent"` is discriminated in `BrowserToolbar` and stories (`Extract<BrowserController, { kind: "agent" }>`), so the union is not identical in use.
- Item 13 `CodeBrowserTab.tsx:1379`: that line is `BrowserFallback`'s wrapper div, not an unused `surfaceRef` (the unread ref was only at line 165 / the viewport wrapper).

Checks (crates/tidebreak-desktop/ui)
- `pnpm exec biome format --write src` — Formatted 925 files in 1449ms. Fixed 2 files.
- `pnpm exec biome format src` — Checked 925 files in 1387ms. No fixes applied.
- `pnpm lint` — Checked 925 files in 1705ms. No fixes applied.
- `pnpm test` — Test Files 286 passed (286); Tests 2519 passed (2519)
- `pnpm build` — ✓ built in 7.66s
- `pnpm storybook:build` — Storybook build completed successfully