### PR TITLE
chore: delete dead code and fix stale references from the code-mode audit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,11 @@ cargo build --workspace
 scripts/clean-worktree-artifacts.sh
 scripts/clean-worktree-artifacts.sh --worktree ../finished-task --yes
 
+# Wipe this machine's debug-app profile so the next `scripts/dev.sh` run
+# starts from empty stores. Does not touch an installed release profile.
+scripts/wipe-dev.sh
+scripts/wipe-dev.sh --yes
+
 # Formatting, lints, and tests (what CI runs)
 cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings

--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -390,6 +390,14 @@ pub fn supported_caps_summary(caps: &HarnessCaps) -> String {
         ("reasoning", caps.reasoning_levels),
         ("file_events", caps.native_file_change_events),
         ("interrupt", caps.native_interrupt),
+        ("image_input", caps.image_input),
+        ("slash_commands", caps.slash_commands),
+        ("durable_parks", caps.durable_parks),
+        ("user_questions", caps.user_questions),
+        ("standing_grants", caps.standing_grants),
+        ("mid_turn_resume", caps.mid_turn_resume),
+        ("transcript", caps.transcript),
+        ("memory_loopback", caps.memory_loopback),
     ];
     let supported: Vec<&str> = flags
         .into_iter()

--- a/crates/tidebreak-code-execution/src/daytona.rs
+++ b/crates/tidebreak-code-execution/src/daytona.rs
@@ -275,7 +275,7 @@ impl DaytonaExecutionProvider {
     ///
     /// An escape hatch, not the normal path: absent an override the provider
     /// registers and uses the official documents snapshot itself (see
-    /// [`Self::documents_snapshot_name`]). An override disables that entirely —
+    /// [`DOCUMENTS_SNAPSHOT`]). An override disables that entirely —
     /// no auto-registration and no fallback, so a snapshot name that does not
     /// exist in the account stays a visible sandbox-creation error rather than
     /// quietly becoming Daytona's default.
@@ -374,17 +374,6 @@ impl DaytonaExecutionProvider {
             .ok_or_else(|| {
                 ExecError::Unavailable("Daytona sandbox disappeared while it was starting".into())
             })
-    }
-
-    /// The name of the snapshot the official Tidebreak documents image is
-    /// registered under in the caller's own Daytona organization.
-    ///
-    /// Daytona has no cross-organization public snapshots, so a key that has
-    /// never seen Tidebreak has nothing to point at. The provider closes that
-    /// gap itself rather than asking the user to register an image by hand.
-    #[must_use]
-    pub fn documents_snapshot_name() -> &'static str {
-        DOCUMENTS_SNAPSHOT
     }
 
     /// Decide which snapshot the next sandbox is created from.

--- a/crates/tidebreak-code-execution/src/docker.rs
+++ b/crates/tidebreak-code-execution/src/docker.rs
@@ -343,6 +343,7 @@ impl DockerExecutionProvider {
     }
 
     /// Run containers on a different Docker-CLI-compatible binary (`podman`).
+    #[cfg(test)]
     #[must_use]
     pub fn with_binary(mut self, binary: impl Into<String>) -> Self {
         self.binary = binary.into();
@@ -397,6 +398,7 @@ impl DockerExecutionProvider {
     /// default has — see [`Self::verifies_image_integrity`] — and an image
     /// without the document tooling degrades the document skills to whatever
     /// it happens to contain.
+    #[cfg(test)]
     #[must_use]
     pub fn with_image(mut self, image: impl Into<String>) -> Self {
         self.image = image.into();

--- a/crates/tidebreak-code-execution/src/package_cache.rs
+++ b/crates/tidebreak-code-execution/src/package_cache.rs
@@ -638,13 +638,6 @@ impl SharedPackageCache {
         })
     }
 
-    /// Derive the wheel cache key for one supported local interpreter.
-    pub async fn runtime_key(python: &Path) -> Option<String> {
-        Self::python_runtime(python)
-            .await
-            .map(|runtime| runtime.key)
-    }
-
     /// Host-side acquisition: download the exactly pinned requirements (and
     /// their transitive closure) as wheels with the host's own pip, then
     /// verify and promote them.

--- a/crates/tidebreak-code-execution/src/sandbox_image.rs
+++ b/crates/tidebreak-code-execution/src/sandbox_image.rs
@@ -10,9 +10,10 @@
 //!
 //! The pin is rewritten by the job in
 //! `.github/workflows/publish-sandbox-image.yml` after every image publish,
-//! alongside `PUBLISHED_IMAGE_DIGEST` in `tidebreak-server`'s `sandbox_docker`
-//! and the E2B template definition. That job matches on the constant names
-//! below, so renaming one means editing the workflow in the same change.
+//! alongside `PUBLISHED_IMAGE_DIGEST` in `tidebreak-sandbox-runtime`'s
+//! `docker` module and the E2B template definition. That job matches on the
+//! constant names below, so renaming one means editing the workflow in the
+//! same change.
 
 /// The official documents image, pinned by manifest-list digest. A
 /// `repository@sha256:…` ref is content-addressed: the runtime resolves

--- a/crates/tidebreak-code-remote/src/wire.rs
+++ b/crates/tidebreak-code-remote/src/wire.rs
@@ -151,7 +151,10 @@ impl SandboxState {
     }
 }
 
-/// Current state of one sandbox, reduced to the fields this server acts on.
+/// Current state of one sandbox as the gateway returns it.
+///
+/// The driver reads only `spend_microusd`. The other fields exist so
+/// deserialization pins the gateway response shape for the contract test.
 #[derive(Clone, Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct SandboxStatus {

--- a/crates/tidebreak-core/src/code/caps.rs
+++ b/crates/tidebreak-core/src/code/caps.rs
@@ -115,12 +115,9 @@ pub struct HarnessCaps {
     pub standing_grants: CapLevel,
     /// The engine can resume a turn that was interrupted mid-model-call.
     ///
-    /// Boot recovery skips pid-less sessions that declare this, so a
-    /// restart does not close an in-flight internal turn as interrupted.
-    /// Update-quiesce uses the same flag: `Supported` aborts and hands the
-    /// lease back; `Unsupported` waits for a turn boundary (decision 0080).
-    /// External harnesses declare `Unsupported` — no engine can resume a
-    /// harness turn.
+    /// Declared so the doctor surface can report it. Boot recovery and
+    /// update-quiesce key on [`crate::HarnessKind::Internal`] today, not
+    /// this flag. External harnesses declare `Unsupported`.
     pub mid_turn_resume: CapLevel,
     /// The engine stores a provider transcript (`message` rows) the host
     /// can read. `GET /chats/{id}/messages` refuses on a session whose

--- a/crates/tidebreak-core/src/code/external_input.rs
+++ b/crates/tidebreak-core/src/code/external_input.rs
@@ -35,7 +35,13 @@ impl ExternalThreadContext {
     /// Validate before allocating the rendered quote envelope.
     pub fn validate(&self) -> Result<(), &'static str> {
         if self.messages.len() > Self::MAX_MESSAGES {
-            return Err("Thread context may contain at most 20 messages.");
+            return Err(Box::leak(
+                format!(
+                    "Thread context may contain at most {} messages.",
+                    Self::MAX_MESSAGES
+                )
+                .into_boxed_str(),
+            ));
         }
         let mut bytes = 0_usize;
         for message in &self.messages {
@@ -55,7 +61,13 @@ impl ExternalThreadContext {
                 .saturating_add(message.timestamp.len())
                 .saturating_add(message.text.len());
             if bytes > Self::MAX_BYTES {
-                return Err("Thread context may contain at most 16 KiB of text.");
+                return Err(Box::leak(
+                    format!(
+                        "Thread context may contain at most {} KiB of text.",
+                        Self::MAX_BYTES / 1024
+                    )
+                    .into_boxed_str(),
+                ));
             }
         }
         Ok(())

--- a/crates/tidebreak-core/src/code/external_input.rs
+++ b/crates/tidebreak-core/src/code/external_input.rs
@@ -33,14 +33,11 @@ impl ExternalThreadContext {
     pub const MAX_BYTES: usize = 16_384;
 
     /// Validate before allocating the rendered quote envelope.
-    pub fn validate(&self) -> Result<(), &'static str> {
+    pub fn validate(&self) -> Result<(), String> {
         if self.messages.len() > Self::MAX_MESSAGES {
-            return Err(Box::leak(
-                format!(
-                    "Thread context may contain at most {} messages.",
-                    Self::MAX_MESSAGES
-                )
-                .into_boxed_str(),
+            return Err(format!(
+                "Thread context may contain at most {} messages.",
+                Self::MAX_MESSAGES
             ));
         }
         let mut bytes = 0_usize;
@@ -54,19 +51,16 @@ impl ExternalThreadContext {
                     .iter()
                     .any(|value| value.contains('\0'))
             {
-                return Err("Each context message needs a bounded author, timestamp, and nonempty text without NUL characters.");
+                return Err("Each context message needs a bounded author, timestamp, and nonempty text without NUL characters.".into());
             }
             bytes = bytes
                 .saturating_add(message.author.len())
                 .saturating_add(message.timestamp.len())
                 .saturating_add(message.text.len());
             if bytes > Self::MAX_BYTES {
-                return Err(Box::leak(
-                    format!(
-                        "Thread context may contain at most {} KiB of text.",
-                        Self::MAX_BYTES / 1024
-                    )
-                    .into_boxed_str(),
+                return Err(format!(
+                    "Thread context may contain at most {} KiB of text.",
+                    Self::MAX_BYTES / 1024
                 ));
             }
         }

--- a/crates/tidebreak-core/src/db/ops/code/confirm.rs
+++ b/crates/tidebreak-core/src/db/ops/code/confirm.rs
@@ -1,4 +1,7 @@
-//! The repository scope an administrator approves for each channel.
+//! Channel repository-confirm rows kept for older clients.
+//!
+//! Decision 0096 removed the administrator repository-scope gate. These
+//! rows no longer authorize anything.
 
 use sea_orm::sea_query::{Expr, ExprTrait, Func};
 use sea_orm::{

--- a/crates/tidebreak-core/src/db/ops/code/external_event.rs
+++ b/crates/tidebreak-core/src/db/ops/code/external_event.rs
@@ -131,7 +131,7 @@ pub async fn record_external_message(
     .await
     .map_err(|error| match error {
         ExternalMessageIntakeError::Store(error) => error,
-        ExternalMessageIntakeError::Context { message, .. } => AgentError::Store(message.into()),
+        ExternalMessageIntakeError::Context { message, .. } => AgentError::Store(message),
     })
 }
 
@@ -144,7 +144,7 @@ pub enum ExternalMessageIntakeError {
         /// Machine-readable refusal.
         kind: &'static str,
         /// Client-safe explanation.
-        message: &'static str,
+        message: String,
     },
     /// Persistence or serialization failed.
     #[error(transparent)]
@@ -223,7 +223,8 @@ pub async fn record_external_message_with_context(
         if has_turn || has_event || !existing.is_empty() {
             return Err(ExternalMessageIntakeError::Context {
                 kind: "context_first_turn_only",
-                message: "Thread context is accepted only on the first message of a session.",
+                message: "Thread context is accepted only on the first message of a session."
+                    .into(),
             });
         }
         let binding = entities::code_external_binding::Entity::find_by_id(context.binding_id.0)
@@ -236,7 +237,7 @@ pub async fn record_external_message_with_context(
         let Some(binding) = binding else {
             return Err(ExternalMessageIntakeError::Context {
                 kind: "context_binding_mismatch",
-                message: "The context binding must belong to this session and grant.",
+                message: "The context binding must belong to this session and grant.".into(),
             });
         };
         entities::code_external_binding::ActiveModel {

--- a/crates/tidebreak-desktop/ui/package.json
+++ b/crates/tidebreak-desktop/ui/package.json
@@ -12,9 +12,7 @@
     "format": "biome format --write src",
     "lint": "biome lint src",
     "before-tauri-dev": "node ../scripts/prepare-sidecar.mjs && vite",
-    "before-tauri-build": "node ../scripts/prepare-sidecar.mjs --release && tsc && node --max-old-space-size=6144 node_modules/vite/bin/vite.js build",
-    "preview": "vite preview",
-    "tauri": "cargo tauri"
+    "before-tauri-build": "node ../scripts/prepare-sidecar.mjs --release && tsc && node --max-old-space-size=6144 node_modules/vite/bin/vite.js build"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2751,12 +2751,9 @@ standing_grants: CapLevel,
 /**
  * The engine can resume a turn that was interrupted mid-model-call.
  *
- * Boot recovery skips pid-less sessions that declare this, so a
- * restart does not close an in-flight internal turn as interrupted.
- * Update-quiesce uses the same flag: `Supported` aborts and hands the
- * lease back; `Unsupported` waits for a turn boundary (decision 0080).
- * External harnesses declare `Unsupported` — no engine can resume a
- * harness turn.
+ * Declared so the doctor surface can report it. Boot recovery and
+ * update-quiesce key on [`crate::HarnessKind::Internal`] today, not
+ * this flag. External harnesses declare `Unsupported`.
  */
 mid_turn_resume: CapLevel,
 /**

--- a/crates/tidebreak-sandbox-protocol/src/oplog.rs
+++ b/crates/tidebreak-sandbox-protocol/src/oplog.rs
@@ -16,8 +16,8 @@
 //!
 //! # Storage and retention
 //!
-//! This crate's in-memory store is **not** crash-safe; production uses the
-//! durable adapter in `tidebreak-server`. The shared contract is:
+//! This crate's in-memory store is **not** crash-safe; production uses
+//! `DurableOperationStore` in `tidebreak-sandbox-runtime`. The shared contract is:
 //!
 //! 1. A durable store persists the
 //!    `Claimed -> Recorded / Failed` transition on the run, committed
@@ -108,7 +108,7 @@ pub enum StoreError {
 /// The durable-storage seam for the reverse-RPC operation log.
 ///
 /// A production implementation persists these transitions transactionally on
-/// the run (see the module-level TODO). The trait is intentionally small: claim
+/// the run. The trait is intentionally small: claim
 /// an identity, record its terminal outcome, read it back, and evict it once it
 /// can no longer be re-issued.
 pub trait OperationStore: Send + Sync {

--- a/crates/tidebreak-sandbox-runtime/src/container_run/tests.rs
+++ b/crates/tidebreak-sandbox-runtime/src/container_run/tests.rs
@@ -145,16 +145,6 @@ impl ScriptedProvider {
         }
     }
 
-    /// The same provider, but stalling `delay` before answering each completion,
-    /// so a drive spans several lease periods.
-    #[allow(dead_code)]
-    fn slow(completions: Vec<String>, delay: Duration) -> Self {
-        Self {
-            delay,
-            ..Self::new(completions)
-        }
-    }
-
     fn first_prompt(&self) -> String {
         self.prompts
             .lock()

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -990,7 +990,7 @@ impl CodeRuntime {
         .await
         .map_err(|error| match error {
             tidebreak_core::db::code::ExternalMessageIntakeError::Context { kind, message } => {
-                ServerError::bad_request_kind(kind, message)
+                ServerError::bad_request_kind(kind, &message)
             }
             tidebreak_core::db::code::ExternalMessageIntakeError::Store(error) => error.into(),
         })?;

--- a/docs/decisions/0052-harness-subagents-as-child-rows.md
+++ b/docs/decisions/0052-harness-subagents-as-child-rows.md
@@ -3,7 +3,7 @@
 - Status: Accepted
 - Date: 2026-08-20
 - Owners: code mode
-- Related: [`0031-code-mode-harness-adapters.md`](0031-code-mode-harness-adapters.md),
+- Related: [`0031-harness-adapter-boundary.md`](0031-harness-adapter-boundary.md),
   [`0035-code-mode-wire-contract.md`](0035-code-mode-wire-contract.md),
   [`0050-watch-and-fix-is-a-durable-task.md`](0050-watch-and-fix-is-a-durable-task.md)
 

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2751,12 +2751,9 @@ standing_grants: CapLevel,
 /**
  * The engine can resume a turn that was interrupted mid-model-call.
  *
- * Boot recovery skips pid-less sessions that declare this, so a
- * restart does not close an in-flight internal turn as interrupted.
- * Update-quiesce uses the same flag: `Supported` aborts and hands the
- * lease back; `Unsupported` waits for a turn boundary (decision 0080).
- * External harnesses declare `Unsupported` — no engine can resume a
- * harness turn.
+ * Declared so the doctor surface can report it. Boot recovery and
+ * update-quiesce key on [`crate::HarnessKind::Internal`] today, not
+ * this flag. External harnesses declare `Unsupported`.
  */
 mid_turn_resume: CapLevel,
 /**


### PR DESCRIPTION
## What changed

Verified each code-mode audit claim against the tree, then applied the ones that held:

- Deleted unused `ScriptedProvider::slow` and `PackageCache::runtime_key`.
- Deleted `DaytonaProvider::documents_snapshot_name` and pointed the remaining rustdoc at `DOCUMENTS_SNAPSHOT`.
- Moved Docker `with_binary` / `with_image` under `#[cfg(test)]` (only the crate's test module called them).
- Corrected docs for the documents image digest location, the durable operation store (`DurableOperationStore` in `tidebreak-sandbox-runtime`), ADR 0052's related link to `0031-harness-adapter-boundary.md`, `SandboxStatus` (driver uses `spend_microusd`; other fields pin the gateway contract), `mid_turn_resume` (doctor surface; recovery keys on engine kind), and channel repository-confirm rows (kept for older clients per decision 0096; authorize nothing).
- Documented `scripts/wipe-dev.sh` in CONTRIBUTING.md next to the other local scripts.
- Removed unused `preview` and `tauri` scripts from the desktop UI `package.json`.
- Included the remaining `HarnessCaps` flags in `supported_caps_summary` in struct field order.
- Thread-context refusal strings now format `MAX_MESSAGES` and `MAX_BYTES` instead of duplicating the numbers in prose.

## Skipped

None. Every listed claim matched the code after workspace search.

## Checks

- `cargo fmt --all --check` (exit 0)
- `python3 scripts/adr.py check` — `ADR check: 96 decisions, 0001 through 0096, manifest synchronized`
- `cargo clippy -p tidebreak-sandbox-runtime -p tidebreak-code-execution -p tidebreak-sandbox-protocol -p tidebreak-code-remote -p tidebreak-cli -p tidebreak-core --all-targets --locked -- -D warnings` — `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 5m 02s`
- `cargo test -p tidebreak-cli --locked api::code` — `test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 129 filtered out`
- `cargo test -p tidebreak-core --locked external_input` — `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 920 filtered out`
- `cd crates/tidebreak-desktop/ui && pnpm install --frozen-lockfile && pnpm exec biome format src && pnpm lint` — biome `Checked 925 files in 1146ms. No fixes applied.` then lint `Checked 925 files in 1153ms. No fixes applied.`

This PR is ready for review. CI and Shipright were not run here.