### PR TITLE
docs: correct execution, agent-run, deliverables, and crate docs against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,10 @@ issue.
 
 Install [rustup](https://rustup.rs/) for the pinned Rust toolchain, Node.js 22,
 [pnpm](https://pnpm.io), the
-[Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/), the Tauri
-CLI, and CMake for the local voice engine:
+[Tauri 2 prerequisites](https://v2.tauri.app/start/prerequisites/), and the Tauri
+CLI. Local voice transcription runs in a separately published `tidebreak-whisper`
+helper the desktop downloads on demand, so building the desktop app does not
+require CMake:
 
 ```sh
 cargo install tauri-cli --version "^2"

--- a/crates/tidebreak-core/src/chrome_connection.rs
+++ b/crates/tidebreak-core/src/chrome_connection.rs
@@ -35,7 +35,7 @@ pub fn chrome_connection_tool_specs() -> Vec<ToolSpec> {
     vec![
         ToolSpec::for_args::<ChromeConnectArgs>(
             CHROME_CONNECT_TOOL,
-            "Request a Chrome connection for this coding session. Use managed to start Chrome in the background with a temporary isolated profile for app testing. New tabs preserve focus; chrome_activate_tab explicitly brings a tab forward. Use existing only when the task needs the user's signed-in Chrome profile. The native host asks permission; existing Chrome also asks the user to approve remote debugging. The host discovers the local endpoint. After connection, use chrome_* tools. A stopped connection resumes only after fresh native consent.",
+            "Request a Chrome connection for this coding session. Use managed to start Chrome in the background with a temporary isolated profile for app testing. New tabs preserve focus. Use existing only when the task needs the user's signed-in Chrome profile. The native host asks permission; existing Chrome also asks the user to approve remote debugging. The host discovers the local endpoint. After connection, use chrome_* tools. A stopped connection resumes only after fresh native consent.",
         ),
         ToolSpec::for_args::<ChromeConnectionEmptyArgs>(
             CHROME_DISCONNECT_TOOL,

--- a/crates/tidebreak-desktop/ui/DESIGN.md
+++ b/crates/tidebreak-desktop/ui/DESIGN.md
@@ -176,9 +176,9 @@ control sits below the label and spans the full width, because selects,
 text inputs, and editors read badly squeezed against the right edge.
 
 Save each field when its value changes. Do not add Save or Cancel buttons.
-Use a `Switch` for binary toggles and a `Select` for short lists. Use
-`ValidatedInput` (or an async validation pattern) for text that must be
-checked, such as a workspace URL.
+Use a `Switch` for binary toggles and a `Select` for short lists. Use an
+async validation pattern for text that must be checked, such as a workspace
+URL.
 
 ### Cards and rows
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,10 @@ an accepted boundary.
   vocabulary, foreground and sandbox surfaces, and reliability rules.
 - [Code execution](code-execution.md) — the provider-neutral `exec` contract,
   network policy, workspaces, local backends, and managed backends.
+- [Computer use](computer-use.md) — screen capture, app control, and Chrome
+  debugger input for coding sessions.
+- [Code browser integration](code-browser-integration.md) — how coding sessions
+  share a browser channel with the host.
 - [Execution providers and sandbox-resident runs](sandbox-providers.md) — the
   parked design for detached runs, credential separation, admission, and the
   sandbox-agent protocol.
@@ -86,5 +90,10 @@ an accepted boundary.
 
 - [What comes after v1](deferred.md) — canonical home for intentionally parked
   product scope and the conditions that would bring it forward.
+
+## Spikes
+
+- [Reverse-RPC findings](spikes/reverse-rpc-findings.md) — superseded spike;
+  the shipping contract is `tidebreak-sandbox-protocol`.
 
 For API-level documentation, run `cargo doc --open`.

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -58,7 +58,7 @@ differ:
 | --- | --- |
 | Responds directly in the chat | Works on one delegated task |
 | Final assistant text completes a turn | An explicit result submission completes the run |
-| Uses conversation-facing tools | Uses a small fixed sandbox tool surface over a bounded checkpoint budget; has no shared conversation context |
+| Uses conversation-facing tools | Uses a small fixed sandbox tool surface under a model-step check-in cadence (`DEFAULT_SANDBOX_AGENT_CHECKIN_STEPS`, default 100); has no shared conversation context |
 | Usually short-lived work | May park and resume over a longer period |
 | Streams answer content | Publishes bounded progress and a final result |
 
@@ -166,24 +166,27 @@ answer/cancel races cannot produce two results. See
 ## Sandbox and host-access boundary
 
 A background agent cannot access projects, general host folders, the general
-network, or the parent conversation. Its narrow exceptions share one bounded
-tool-call budget: commands in its own execution workspace, a checkpointed
-public web search, a typed folder-access proposal that grants no access, or—only
-in the embedded desktop—one exact file named by its immutable admission. A run
-may spend that budget over several checkpoints; the worker replays the whole
-resolved chain on every claim, which is why the count is capped. The read tool
-takes no arguments. A native executor revalidates the current chat attachment
-immediately before the host broker performs a bounded UTF-8 read, persists
-private no-replay recovery state, and publishes only bounded content or a
-neutral failure. Headless workers never advertise the read. Sandboxes do not
-receive foreground spawn/wait or broker transport contracts, and absolute paths
-never cross into provider context. See
-[Host access and connected folders](host-access.md).
+network, or the parent conversation. Its narrow tools are commands in its own
+execution workspace, a checkpointed public web search, a typed folder-access
+proposal that grants no access, `update_task_plan`, `done`, or—only in the
+embedded desktop—one exact file named by its immutable admission. The run's
+one policy bound is a check-in cadence, not a row budget: each step is one
+model completion over the replayed checkpoint chain
+(`DEFAULT_SANDBOX_AGENT_CHECKIN_STEPS`, default 100, user-configurable).
+Reaching the cadence is not a failure: tools are withdrawn two steps early and
+the run submits what it has. The read tool takes no arguments. A native
+executor revalidates the current chat attachment immediately before the host
+broker performs a bounded UTF-8 read, persists private no-replay recovery
+state, and publishes only bounded content or a neutral failure. Headless
+workers never advertise the read. Sandboxes do not receive foreground
+spawn/wait or broker transport contracts, and absolute paths never cross into
+provider context. See [Host access and connected folders](host-access.md).
 
 Execution is how a background run produces anything the user keeps. Its
 workspace is named by the run, not the conversation, so siblings delegated in
-one message never share a filesystem; it starts empty and holds nothing but what
-the run's own earlier commands wrote. The request carries no folder authority
+one message never share a filesystem. Document skills are staged first under
+`<scratch>/.tidebreak/skills/`; after that the workspace holds only what the
+run's own earlier commands wrote. The request carries no folder authority
 and stages no host paths — delegation already bypasses the conversation's
 approval gate, so this path must not be the one that hands a delegated agent the
 user's files. The one thing the parent conversation contributes is its network
@@ -208,18 +211,6 @@ back on its next step. Each call replaces the whole list, and the plan is keyed
 by the run rather than by the chat — four siblings delegated in one message are
 working four different tasks, and a chat-keyed row would have them overwriting
 each other and the conversation's own plan.
-
-Plan rows are budgeted apart from the rest. A run is told to keep its checklist
-current as steps finish, which is a call after most real steps; charged to the
-same tool allowance, bookkeeping would starve the commands and searches the task
-is actually for, and the run would exhaust itself describing work it never got
-to do. So the allowance above bounds work rows, and plan rows get their own
-smaller cap — enough revisions to narrate one delegated task, few enough to
-bound a model that does nothing else. Each budget withdraws its own tools when
-it runs out, and the durable store enforces the same split, so the advertised
-surface and the bound the transaction applies cannot disagree. Model steps are
-unaffected: every checkpoint still costs the completion that makes it and the
-completion that reads its result.
 
 When a run calls `done` with steps still open, the host hands that call back
 once with the open steps named, the same way it answers a terminal tool that
@@ -253,15 +244,12 @@ worker advances them under its own lease — so the delegation is the only place
 in the chat where the reader could speak about what the child does. Classing it
 below the authority it hands out would state the opposite.
 
-Declaring the class is not the same as gating on it. The gate parks a *pending
-server tool call* on a durable approval receipt, and a spawn has no such
-record: its tool call is written already completed, inside the same transaction
-that admits the child. So the class today decides advertisement — a plan turn
-never sees the pair — and not admission. The consequence worth naming: in a
-chat where a foreground `web_search` would stop and ask, the same egress
-performed by a delegated child does not. Closing that requires a durable
-pending-spawn checkpoint the reader can answer, which is its own change
-(issue #1477), not a flag.
+A gated spawn parks and asks. `gate_sandbox_spawn` first accepts an ordinary
+pending server row and parks on that, exactly like any other Sensitive call;
+the child is admitted only after the decision commits. In `Allow` mode, or
+when a standing grant already covers this spawn, the ungated path still
+writes the tool call completed in the same transaction that admits the child.
+An interrupted decision leaves the row pending and no child is admitted.
 
 ## Bounded scheduling
 
@@ -305,14 +293,17 @@ and a short summary, and the receipt records the outputs the scan already
 published under those names alongside the summary. Naming a file the run never
 wrote fails the completion like any other malformed one, bounded by the run's own
 attempt budget; a run that genuinely produced nothing submits nothing. Final text
-remains the receipt for a model that simply stops without submitting. The only
-current non-text outcome is a validated folder-consent proposal. It carries no
-host path, root identity, broker grant, or client-call identity; it only tells
-the foreground parent to decide whether the existing foreground consent tool is
-appropriate. The receipt, `completed` state, and one parent inbox entry commit
-together, so an ambiguous worker retry can recover its original result but
-cannot overwrite or double-deliver it. Each inbox entry advances through a
-fenced lifecycle: `pending -> consumed`, with a stable resume token proving the
+remains the receipt for a model that simply stops without submitting. Other
+typed outcomes are a validated folder-consent proposal (no host path, root
+identity, broker grant, or client-call identity — it only tells the foreground
+parent to decide whether the existing consent tool is appropriate),
+`Cancelled`, and `CheckIn`. Check-in is not terminal: the run sits in
+`NeedsInput` until a resume deletes that receipt so the result slot is free
+for the outcome it eventually produces. The receipt, terminal or paused state,
+and one parent inbox entry commit together, so an ambiguous worker retry can
+recover its original result but cannot overwrite or double-deliver it. Each
+inbox entry advances through a fenced lifecycle:
+`pending -> claimed -> consumed`, with a stable resume token proving the
 consumer, or `cancelled` when the parent retires the delivery. The ordered wait
 consumes all named entries in one transaction only after the matching
 foreground checkpoint exists. A result that arrives first remains pending; it
@@ -340,10 +331,12 @@ always durable state transitions, never process-local notifications.
 
 The authenticated local API exposes `GET /chats/{id}/agent-runs` for a
 chat-scoped snapshot of its foreground coordinator and any sandbox children.
-It is a read model, not a scheduler control surface: clients use it to render
-queued, running, waiting, failed, and completed work, while workers continue to
-advance runs solely through fenced store transitions. A missing chat returns
-`404`, rather than revealing whether an unrelated run identifier exists.
+Clients use it to render queued, running, waiting, failed, and completed work.
+Cancel, resume, and steer are separate POST routes on the same run
+(`…/cancel`, `…/resume`, `…/steer`); the foreground also drives resume and
+cancel as the `resume_agent` and `cancel_agent` tools. Workers still advance
+runs through fenced store transitions. A missing chat returns `404`, rather
+than revealing whether an unrelated run identifier exists.
 The response is deliberately renderer-safe: worker lease tokens, delegated
 input, raw failure details, and scheduler bookkeeping never cross this API
 boundary. A bounded failure code may be included for display and recovery
@@ -354,9 +347,10 @@ renderer correlation key, not a provider call identity or scheduler control.
 
 When an agent has a live, supported tool checkpoint, the snapshot may also
 contain a small `activity` object. Its values are a deliberately admitted,
-fixed display vocabulary—for example, sandbox `exec` and `web_search`, or foreground
-`list_connected_folders`, `list_folder`, and `read_connected_file`, each with
-`waiting` or `running` status. It is not a tool trace: queries, tool arguments,
+fixed display vocabulary—for example, sandbox `exec`, `web_search`, and
+`update_task_plan`, or foreground `list_connected_folders`, `list_folder`,
+`read_connected_file`, `read_delegated_file`, and `import_connected_file`,
+each with `waiting` or `running` status. It is not a tool trace: queries, tool arguments,
 results, folder/root identities, relative paths, filenames, host paths, grants,
 provider identifiers, executor leases, and raw failures remain server-side.
 New tools are invisible to the renderer until they receive their own safe
@@ -382,7 +376,7 @@ and are outside the host-field non-disclosure guarantee.
 
 A settled `exec` step's output tail is the one deliberate exception to the rule
 that stored results stay server-side. A sandbox command runs in a private,
-initially-empty workspace containing only what the run itself staged, so what it
+initially-empty workspace containing staged skills and then only what the run itself wrote, so what it
 printed is the command's own text rather than host- or user-derived content, and
 without it a failed background command is unreadable. The tail is bounded to
 2,000 characters, carried only for terminal steps, and taken from the whole
@@ -461,39 +455,3 @@ The agent hierarchy preserves the runtime's existing rules:
 
 Until a tool satisfies the side-effect receipt contract, Tidebreak continues to
 fail conservatively after an ambiguous execution rather than replay it.
-
-## Delivery sequence
-
-The implementation is intentionally incremental:
-
-1. Add the durable `AgentRun` hierarchy, atomic foreground ownership, and
-   depth-one constraints. *(Shipped.)*
-2. Add the bounded sandbox scheduler and lease lifecycle. *(Shipped.)*
-3. Add idempotent cancellation and immutable fenced result submission.
-   *(Shipped.)*
-4. Add the parent inbox and atomic child-result delivery. *(Shipped.)*
-5. Generalize client execution into the shared continuation model.
-6. Persist shared model/tool step boundaries and side-effect receipts.
-7. Atomically join durable inbox consumption with a parent turn checkpoint and
-   durable `resuming` wake signal. *(Shipped.)*
-8. Run isolated sandbox tasks with no shared conversation context, over the
-   durable lease/result boundary. *(Shipped.)*
-9. Prove the bounded foreground-only spawn path with atomic child admission,
-   sandbox wake-up, immutable delivery, and parent resume. *(Shipped.)*
-10. Add the one-call sandbox `web_search` checkpoint, host executor, and
-    receipt-backed model resume. *(Shipped.)*
-11. Let a sandbox relay a typed folder-consent proposal to its foreground
-    parent, without host access or a picker. *(Shipped.)*
-12. Add fenced read-only tools to the foreground turn for roots its chat already
-    attached. *(Shipped.)*
-13. Add desktop surfaces for queued, running, waiting, failed, and completed
-   background work, including exact sandbox stop controls. *(Shipped.)*
-14. Persist the non-blocking spawn checkpoint and ordered wait receipts.
-    *(Shipped.)*
-15. Activate non-blocking spawn and ordered multi-agent waits together.
-    *(Shipped.)*
-16. Add the desktop-only, argument-free read of one exact file immutably
-    delegated at spawn, with native claim/revalidation, broker authorization,
-    revocation fencing, and crash-safe no-replay recovery. *(Shipped.)*
-17. Add richer context lifecycle, parallel-safe tool groups, and further
-    orchestration only after these recovery boundaries are proven.

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -17,7 +17,7 @@ The authenticated local API owns provider selection and timeout policy:
 | Route | Purpose |
 | --- | --- |
 | `GET /code-execution` | Return the selected provider, timeout, provider-enforcement disclosure, and host readiness |
-| `PUT /code-execution` | Select a fixed provider or disable execution and update the bounded timeout |
+| `PUT /code-execution` | Select a fixed provider or disable execution, and update the bounded timeout, egress policy, E2B template, or Daytona snapshot |
 | `GET /code-execution/credentials` | Read readiness for the fixed E2B and Daytona key slots |
 | `PUT /code-execution/credentials/{e2b\|daytona}` | Store that provider's API key in its fixed host-secret slot |
 | `DELETE /code-execution/credentials/{e2b\|daytona}` | Remove only that provider's saved API key |
@@ -29,13 +29,20 @@ The initial state is:
   "provider": "local",
   "timeout_ms": 60000,
   "available": true,
-  "has_credential": false
+  "has_credential": false,
+  "providers": [],
+  "egress": {
+    "policy": { "mode": "open" },
+    "enforcement": []
+  },
+  "detached_admission": []
 }
 ```
 
-`available` reports whether the selected native confinement primitive exists on
-the current host. The example above is the supported macOS state; it is false
-when execution is disabled or unsupported.
+`available` reports the selected provider's own availability test: local asks
+the adapter's platform probe, Docker asks whether a runtime answers, and the
+managed providers are available exactly when their credential slot is filled.
+It is false when execution is disabled or that test fails.
 Timeouts must be between 1 and 120 seconds; the default is 60 seconds, enough headroom for a cold package install that pulls compiled wheels. Sending `{"provider": null}`
 disables execution; sending `{"provider": "local"}` enables the local adapter.
 `e2b` and `daytona` select the managed adapters, which become available once
@@ -51,8 +58,9 @@ independently. Local execution needs no credential and has no slot to report.
 ### Per-chat network policy
 
 Every chat persists one provider-neutral code-execution policy. It defaults to
-`off`, is selected beside the composer, and is read again immediately before
-each command:
+`open`. A new chat seeds from the owner's last explicit choice at the same
+routes; a brand-new install with no sticky state keeps open. The policy is
+selected beside the composer and is read again immediately before each command:
 
 ```json
 { "mode": "off" }
@@ -68,8 +76,8 @@ each command:
 Custom hosts are exact DNS names: wildcard patterns and address literals are
 rejected, entries are lowercased and deduplicated before persistence, and the
 list is bounded. `package_managers` expands to a fixed, reviewable registry
-class (PyPI, npm, crates.io, Maven, Go, NuGet, RubyGems, and Packagist
-endpoints). The model cannot author or widen the policy.
+class (PyPI, npm, crates.io, Maven, Gradle Plugin Portal, Go, NuGet, RubyGems,
+and Packagist endpoints). The model cannot author or widen the policy.
 
 The local adapter starts an execution-scoped HTTP CONNECT broker on
 `127.0.0.1` for every non-`off` command. Seatbelt admits outbound TCP to that
@@ -256,9 +264,19 @@ On macOS, the configured server intersects the chat's product attachment IDs
 with the host broker's live read and write grants immediately before each
 `exec` invocation. The local adapter rejects missing roots and roots presented
 as symlinks, canonicalizes every path, and adds one narrow Seatbelt `subpath`
-read allowance per readable root. A write allowance is added only when the
-live grant is write-scoped. The profile's existing network denial and broad
-user-data read denials remain in place.
+read allowance per readable root.
+
+Writable grants do not write the user's real folder during the command. Each
+writable root is copied into a per-turn overlay under `.exec-overlays` in the
+chat scratch tree; the sandbox profile makes that copy the only writable
+location. The overlay *is* the tree the command sees, so every filesystem
+operation works as it would against the real folder. On APFS the copy is a
+`clonefile`. At the end of the turn, the overlay is compared against the
+digest manifest recorded when it was made. Untouched files are left alone;
+changed files are written back; files the overlay deleted are deleted from the
+folder too. Each write-back keeps an undo snapshot of the prior bytes when they
+fit the snapshot ceiling. A folder that cannot be staged is downgraded to
+read-only for that turn rather than restoring direct writes.
 
 Folder paths and access modes are listed in the foreground operating context so
 the model can address them without inventing paths. That list is bounded and is
@@ -297,11 +315,12 @@ tools. Local execution reports a
 concise command error when the host lacks Python or an underlying renderer; it
 does not download tooling or use an unconfined fallback.
 
-The local backend warms its verified wheel cache one exact requirement set at
-a time. A successful set, or one pip proves has no compatible distribution for
-the fixed interpreter, is remembered for the process lifetime so later execs
-do not repeat the same deterministic resolution and warning. Network, timeout,
-and process-launch failures remain retryable, and any changed exact pin set
+The host runs `pip download` (wheels only) into a hash-verified, host-owned
+cache and mounts that cache read-only as `$TIDEBREAK_PACKAGE_CACHE`. Population
+is host-side over host TLS; nothing a sandbox wrote is promoted. The resolved
+requirement set is persisted to `populated-pins.json` so later execs reuse the
+same deterministic resolution across process restarts. Network, timeout, and
+process-launch failures remain retryable, and any changed exact pin set
 receives one fresh attempt.
 
 Beyond the helpers, the sandbox image carries the runtimes a document run may
@@ -344,10 +363,13 @@ The initial adapter is deliberately fail-closed and macOS-first:
 
 - `/usr/bin/sandbox-exec` applies a generated Seatbelt profile;
 - network is denied;
-- writes are allowed only below the exact canonical private chat scratch;
+- writes are allowed only below the exact canonical private chat scratch, the
+  per-chat env home, write overlays, and `/dev/null`;
 - sensitive user, application, configuration, temporary, and volume paths are
   denied for reads, while system executables and runtime libraries remain
   usable;
+- when the chat policy is not `off`, Seatbelt also admits one loopback TCP
+  pinhole to the execution-scoped CONNECT broker;
 - the parent environment is cleared; only fixed `HOME`, `TMPDIR`, and `PATH`
   values are supplied, with `HOME` and `TMPDIR` pointing at a writable per-chat
   directory outside the model-visible scratch so interpreter caches never
@@ -363,8 +385,8 @@ The initial adapter is deliberately fail-closed and macOS-first:
 An absolute path beneath a host area that the local profile denies is reported
 as `sandbox_path_denied`, not as a missing workspace file. Direct path
 arguments are rejected before the process starts. When a shell or interpreter
-embeds the path in a script, a failed Seatbelt access is annotated in the
-bounded stderr result while preserving the original diagnostic. The message
+embeds the path in a script, a failed Seatbelt access replaces stdout and
+stderr wholesale with a sandbox-denial message. The message
 names the path, identifies the permitted model-visible roots (the private chat
 workspace plus any currently connected folders), and tells the caller to
 attach or copy the file into scratch or connect its containing folder before

--- a/docs/computer-use.md
+++ b/docs/computer-use.md
@@ -83,7 +83,7 @@ a normal result. Stop and disconnect also clear the emulation. If setup or clean
 fails, the operation refuses further input instead of bringing the tab forward.
 
 Input supports nested, scaled, and rotated frames. Perspective-transformed frames
-return an unsupported-geometry result before input. `chrome_activate_tab`
+refuse with an error before input. `chrome_activate_tab`
 refuses because it changes your selected tab. Disconnecting a managed browser
 closes it and removes its temporary profile. Disconnecting an existing browser leaves it open.
 

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -8,17 +8,28 @@ libraries.
 
 ```
       clients            tidebreak-desktop   tidebreak-cli
-                               │                 │
-                               └────── tidebreak-server
-                                            │
-      libraries          tidebreak-mcp
-                         tidebreak-router
-                         tidebreak-host-broker  tidebreak-code-execution
-                         tidebreak-egress       tidebreak-sandbox-protocol
+                         tidebreak-sandbox-agent
+                         tidebreak-supervised-agent
+                               │
+                         tidebreak-server (crate tidebreak-server-api)
+                               │
+                         tidebreak-server-core (crate tidebreak-server)
+                               │
+      libraries          tidebreak-mcp            tidebreak-harness
+                         tidebreak-router         tidebreak-code-remote
+                         tidebreak-host-broker    tidebreak-code-delivery
+                         tidebreak-code-execution tidebreak-sandbox-runtime
+                         tidebreak-egress         tidebreak-sandbox-protocol
+                         tidebreak-gateway-runtime
+                         tidebreak-worker-runtime
+                         tidebreak-managed-node
+                         tidebreak-shell-policy
                                             │
       the seam                         tidebreak-core
 
 ```
+
+`tidebreak-whisper` is its own Cargo workspace, excluded from the root one.
 
 **Status legend:** 🟢 built/in active development · 🟡 partial baseline · ⚪ stub.
 
@@ -40,7 +51,7 @@ Major surfaces present today:
 
 | Module | What it is |
 | --- | --- |
-| `id` | Typed identifiers (`ChatId`, `TurnId`, `CallId`, …) — newtypes so the compiler stops you mixing them up. |
+| `id` | Typed identifiers (`SessionId`, `TurnId`, `CallId`, …) — newtypes so the compiler stops you mixing them up. |
 | `error` | The crate-wide `AgentError` + `Result`. |
 | `model` | Persisted chats, projects, documents, jobs, tool executions, leases, and lifecycle state. |
 | `tool` | The tool contract (`Tool`, `ToolSpec`, `ToolOutput`, `ToolCtx`, `ApprovalClass`). |
@@ -149,6 +160,110 @@ See [Code execution](code-execution.md).
 
 **Depends on:** `tidebreak-core`, `tidebreak-egress`.
 
+## `tidebreak-code-remote` — remote sandbox control 🟢
+
+The client side of the confining environment's sandbox runtime API. Decision
+0079 split remote execution in two: the workload half is
+`tidebreak-supervised-agent`; this crate is Tidebreak asking that environment
+to provision, watch, steer, and stop the sandbox a remote session's engine
+runs in. Tidebreak never dials into the pod. The pinned contract is
+`/api/v1/runtime/...` on the gateway (spawn, status, sequenced events, inbox
+messages, cancel).
+
+**Depends on:** `tidebreak-core`.
+
+## `tidebreak-code-delivery` — GitHub delivery 🟢
+
+Install-wide GitHub delivery reads and guarded user actions. The database
+remains the source of truth for registered repositories, Tidebreak
+workspaces, and attributed pull-request facts. Workflow run summaries persist
+as `code_workflow_run` rows; deployments stay live GitHub observations in a
+short in-memory cache.
+
+**Depends on:** `tidebreak-core`.
+
+## `tidebreak-sandbox-agent` — in-container sandbox agent 🟡
+
+The sandbox-resident side of the sandbox-provider design: a container image
+running Tidebreak's agent loop with a closed, sandbox-resident tool registry,
+behind `tidebreak-sandbox-protocol`. The supervisor owns the transport
+listener; the agent loop drives model inference back to the host over reverse
+RPC so no model credential lives in the container; a separate egress proxy
+enforces the run's compiled network policy.
+
+**Depends on:** `tidebreak-sandbox-protocol`, `tidebreak-core`.
+
+## `tidebreak-sandbox-runtime` — sandboxed background-agent execution 🟢
+
+Owns in-process sandbox runs, container-hosted runs, Docker lifecycle,
+detached-admission checks, exact-attempt cancellation, and the durable
+reverse-operation log. The embedding server supplies model routing, live
+settings, event publication, and tool catalogs through narrow traits.
+
+**Depends on:** `tidebreak-core`, `tidebreak-sandbox-protocol`.
+
+## `tidebreak-worker-runtime` — durable worker pacing 🟢
+
+Shared pacing and retry contracts for durable workers (lanes and retry).
+
+**Depends on:** nothing in the workspace.
+
+## `tidebreak-supervised-agent` — externally supervised agent 🟡
+
+An externally supervised sandbox — a controlled execution environment that
+Tidebreak does not provision — starts this agent, owns the durable event
+stream, and exposes a control endpoint. The agent initiates outbound polls to
+that endpoint, drives an engine CLI through `tidebreak-harness`, and reports
+lifecycle events outward. It runs no listener, accepts no attach, and keeps
+no durable state of its own.
+
+**Depends on:** `tidebreak-harness`, `tidebreak-core`.
+
+## `tidebreak-managed-node` — managed Node runtime contract 🟢
+
+Shared verification contract for Tidebreak's managed Node runtime. The
+desktop owns downloading and unpacking Node. Consumers only trust the
+resulting directory when its marker names the exact artifact pinned for the
+current platform and both required entrypoints are present.
+
+**Depends on:** nothing in the workspace.
+
+## `tidebreak-gateway-runtime` — model-gateway session 🟢
+
+Model-gateway connection, session, catalog, and relay runtime. The embedding
+server supplies managed policy, model persistence, pairing, and MCP
+configuration through narrow traits. The runtime owns the network session,
+authority fence, sign-in lifecycle, catalog refresh, endpoint entitlements,
+and shared-app relay.
+
+**Depends on:** `tidebreak-core`, `tidebreak-router`.
+
+## `tidebreak-shell-policy` — shell command analysis 🟢
+
+Deterministic safety analysis for shell commands. Given a raw command and
+standing allow/deny rules, it decides whether the command may run without
+asking, must be put to a human, or is structurally unsafe. The crate is
+pure: no process is spawned and no filesystem is touched.
+
+**Depends on:** nothing Tidebreak-specific beyond the parser.
+
+## `tidebreak-harness` — external engine events 🟢
+
+Protocol translation from an external agent engine into one normalized event
+vocabulary. Nothing in this crate's traits assumes the engine is a coding
+agent. Orchestration, persistence, and UI consume only `tidebreak_core::Event`;
+this crate emits the unpersisted sibling `HarnessEvent`.
+
+**Depends on:** `tidebreak-core`.
+
+## `tidebreak-whisper` — on-demand transcription helper 🟢
+
+One-shot whisper.cpp transcription helper. The desktop spawns this binary per
+transcription instead of linking whisper.cpp. It is excluded from the root
+workspace and published separately.
+
+**Depends on:** whisper.cpp (its own workspace).
+
 ## `tidebreak-egress` — egress policy decisions 🟢
 
 The dependency-free decision layer from
@@ -202,12 +317,21 @@ local run instructions.
 
 **Depends on:** `tidebreak-core`, `tidebreak-host-broker`, `tidebreak-server` (+ Tauri).
 
-## `tidebreak-server` — local API and workers 🟢
+## `tidebreak-server-api` — HTTP and WebSocket routes 🟢
 
-The authenticated loopback HTTP/WebSocket surface shared by desktop and
-headless clients. It owns route orchestration and the durable document,
-retirement, and audit workers while core state transitions remain in
-`tidebreak-core`.
+Package name `tidebreak-server`. Tidebreak's in-process HTTP and WebSocket
+route surface. Desktop and CLI depend on this crate; it re-exports workers
+and tools from `tidebreak-server-core`.
+
+**Depends on:** `tidebreak-server-core`.
+
+## `tidebreak-server` — local API workers 🟢
+
+Directory `crates/tidebreak-server`, package name `tidebreak-server-core`.
+The authenticated loopback workers shared by desktop and headless clients.
+It owns the durable document, retirement, and audit workers while core state
+transitions remain in `tidebreak-core`. HTTP routes live in
+`tidebreak-server-api`, not here.
 
 Two former standalone crates now live here as modules, because the server
 was their only consumer:

--- a/docs/decisions/0013-computer-use-screen-capture-and-app-control.md
+++ b/docs/decisions/0013-computer-use-screen-capture-and-app-control.md
@@ -4,8 +4,11 @@
 - Date: 2026-08-12
 - Owners: desktop / agent core
 - Related: [`docs/deferred.md`](../deferred.md) (browser surface), permission
-  modes and approval classes in `openwave-core/src/approval.rs`, host
-  capability grants in `openwave-host-broker/src/capability.rs`
+  modes and approval classes in `crates/tidebreak-core/src/approval.rs`, host
+  capability grants in `crates/tidebreak-host-broker/src/capability.rs`
+- Amended by: [`0095-computer-use-for-coding-harnesses.md`](0095-computer-use-for-coding-harnesses.md)
+  — the foreground-only, development-app blocklist, and screenshot-redaction
+  limits; the rest of this record stands
 
 ## Context
 

--- a/docs/decisions/0073-agent-mcp-drives-chat-over-attach.md
+++ b/docs/decisions/0073-agent-mcp-drives-chat-over-attach.md
@@ -104,7 +104,7 @@ is the wrong face for long-running follow.
 
 ## Validation
 
-`crates/tidebreak-cli/tests/agent_mcp.rs` speaks MCP over the real binary
+`crates/tidebreak-cli/src/agent_mcp/` speaks MCP over the real binary
 against `tidebreak serve` with the scripted provider: a turn completes with
 assistant text; an exec approval returns `needs_approval` and `chat_decide`
 settles it; `chat_events` returns frames after a cursor; a short timeout

--- a/docs/decisions/0074-agent-mcp-drives-code-mode.md
+++ b/docs/decisions/0074-agent-mcp-drives-code-mode.md
@@ -93,7 +93,7 @@ the headless loop.
 
 ## Validation
 
-`crates/tidebreak-cli/tests/agent_mcp_code.rs` speaks MCP over the real binary
+`crates/tidebreak-cli/src/agent_mcp/code.rs` speaks MCP over the real binary
 against `tidebreak serve` with the feature-gated scripted harness: repo →
 workspace → session → `code_run_turn` completes with assistant text; a
 scripted approval returns `needs_approval` and `code_decide` settles it; a

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -27,17 +27,17 @@ symlinks rather than following them.
 
 ## Closed first-slice contract
 
-- Curated text formats — Markdown, plain text, CSV, JSON, HTML, and recognized
-  source-code or text-configuration filenames — publish as text outputs; any
-  other extension publishes as a binary artifact with a media type derived from
-  its extension, bounded at 16 MiB.
+- Curated text formats — Markdown, plain text, CSV, JSON, HTML, charts
+  (`*.chart.json`), and recognized source-code or text-configuration filenames
+  — publish as text outputs; any other extension publishes as a binary artifact
+  with a media type derived from its extension, bounded at 16 MiB.
 - Filenames are one portable ASCII component, at most 120 characters.
 - Content is valid UTF-8, non-empty, and at most 512 KiB.
 - The catalog returns the newest 100 valid output files.
 - Text previews return at most 100,000 Unicode characters. Export always uses
   the complete file.
 - Formats with an inline viewer — spreadsheets and CSV (Univer), Word documents
-  (docx-preview), PDFs, and images — load the revision's complete bytes and
+  (`@extend-ai/react-docx`), PDFs, and images — load the revision's complete bytes and
   reuse the same engines as source documents.
 - Markdown previews use the same safe renderer as assistant messages: raw HTML,
   local-file links, executable URL schemes, and remote image loads are not
@@ -92,9 +92,7 @@ identical content returns the original record, so an ambiguous store response
 can be retried without creating a second output or a second revision; reusing
 one with different content is rejected.
 
-This layer is what the exec `output/` scan writes into. Files created before
-the record existed under the legacy `artifacts/` directory predate the record
-and are not adopted into it.
+This layer is what the exec `output/` scan writes into.
 
 ## Accepting binary workspace artifacts
 
@@ -184,7 +182,7 @@ person can move back.
 ## Deliberate limits
 
 An export is a synchronous user action, so it is not automatically retried and
-does not yet have a durable export receipt. Writing directly into connected
-folders remains a later slice. That addition should preserve the same rule: the
-model names a logical output, while a person or narrowly scoped capability
-chooses where host data is written.
+does not yet have a durable export receipt. Publishing an existing output into
+an attached folder uses `write_output_to_connected_folder`: the model names the
+output by filename, and the trusted client writes only into a root the user
+already connected.

--- a/docs/spikes/reverse-rpc-findings.md
+++ b/docs/spikes/reverse-rpc-findings.md
@@ -1,3 +1,5 @@
+Superseded by `tidebreak-sandbox-protocol` (`reverse.rs` and `oplog.rs`); kept as historical spike notes.
+
 # Reverse-RPC callback channel — spike findings
 
 Spike for [sandbox-providers.md](../sandbox-providers.md) step 5, issue #821. The


### PR DESCRIPTION
Align maintainer docs with the shipping code.

- 1. Network policy defaults to `open` and seeds from the owner's last explicit `POST /chats` choice (`NetworkPolicy` `#[default] Open`; sticky defaults in `projects_chats.rs`).
- 2. Local exec writes land in a per-turn `.exec-overlays` copy with a manifest apply and undo snapshot (overlay module; `open_write_overlay` in provider.rs).
- 3. Seatbelt write set, env home, overlays, `/dev/null`, and broker pinhole; host `pip download` into `$TIDEBREAK_PACKAGE_CACHE` with `populated-pins.json`; PUT `/code-execution` accepts egress/template/snapshot; `available` is the selected provider's probe; package-manager class includes `plugins.gradle.org`; Seatbelt denial replaces stdout/stderr wholesale.
- 4. Spawn gate parks and asks (`gate_sandbox_spawn`, #1564); check-in cadence `DEFAULT_SANDBOX_AGENT_CHECKIN_STEPS` (#1858); result payloads include Cancelled and CheckIn/`NeedsInput` (#1879); inbox `pending -> claimed -> consumed`; deleted completed delivery sequence; skills staged under `<scratch>/.tidebreak/skills/`; cancel/resume/steer routes plus `resume_agent`/`cancel_agent`; sandbox tools include `update_task_plan` and `done`; activity kinds include UpdateTaskPlan, ReadDelegatedFile, ImportConnectedFile.
- 5. `write_output_to_connected_folder` shipped (#677, by-filename #1324); Word viewer is `@extend-ai/react-docx`; dropped legacy `artifacts/` scan; chart deliverable type (`*.chart.json`).
- 6. Documented the missing crates from each `lib.rs`; routes live in `tidebreak-server-api` (package `tidebreak-server`) while `crates/tidebreak-server` is package `tidebreak-server-core`; dropped `ChatId`.
- 7. README no longer requires CMake for the desktop build (whisper helper excluded, #3093).
- 8. Indexed `computer-use.md` and `code-browser-integration.md`.
- 9. Perspective frames refuse with a plain error string, not an unsupported-geometry result.
- 10. Decision 0013 Amended by 0095; renamed openwave paths; 0073/0074 validation paths now point at `crates/tidebreak-cli/src/agent_mcp/`.
- 11. Reverse-RPC spike banner plus Spikes index; shipping contract is `tidebreak-sandbox-protocol`.
- 12. Removed non-existent `ValidatedInput` from DESIGN.md.
- 13. Dropped `chrome_activate_tab explicitly brings a tab forward` from the chrome_connect spec string (tool excluded; calls return `independent_input_unavailable`).

## Skipped

None. Every listed claim held against the current tree.

## Checks

- `cargo fmt --all --check`
- `cargo test -p tidebreak-core --locked chrome_connection` (2 passed)
- No workflow job reads `docs/` (documentation-site lane builds `docs-site`).