### PR TITLE
fix(code): keep pull-request live-tier checks when a read did not load them

### DIFF
--- a/crates/tidebreak-code-delivery/src/lib.rs
+++ b/crates/tidebreak-code-delivery/src/lib.rs
@@ -41,8 +41,8 @@ use tidebreak_core::{
     CodePullRequestAttribution, CodePullRequestDiscovery, CodePullRequestFact, CodePullRequestId,
     CodePullRequestRelation, CodePullRequestState, CodeRepo, CodeWorkflowRunFact,
     CodeWorkflowRunId, CodeWorkspace, CodeWorkspaceStatus, OwnerId, PullRequestCheck,
-    PullRequestCheckBucket, PullRequestComment, PullRequestCommentKind, PullRequestDigest, RepoId,
-    WorkspaceId,
+    PullRequestCheckBucket, PullRequestCheckCounts, PullRequestComment, PullRequestCommentKind,
+    PullRequestDigest, RepoId, WorkspaceId,
 };
 
 mod api;

--- a/crates/tidebreak-code-delivery/src/pull_requests.rs
+++ b/crates/tidebreak-code-delivery/src/pull_requests.rs
@@ -50,6 +50,11 @@ pub(super) struct PullRequestObservation {
     /// Stored facts folded onto the page are not host observations: the
     /// persist pass must not treat them as a fresh confirm.
     pub(super) from_host: bool,
+    /// True when the read loaded the check rollup. A list read for every
+    /// state skips `statusCheckRollup`, so its empty check list means
+    /// "not asked", not "none": the live-tier write must not clear the
+    /// checks the conditional fetcher wrote.
+    pub(super) checks_loaded: bool,
 }
 
 impl PullRequestObservation {
@@ -991,6 +996,7 @@ pub(super) fn observation_from_fact(
         head_repository: None,
         host_stack: None,
         from_host: false,
+        checks_loaded,
     }
 }
 
@@ -1224,6 +1230,7 @@ pub(super) fn parse_pull_request(
         head_repository: parse_head_repository(repository, value),
         host_stack: None,
         from_host: true,
+        checks_loaded,
     })
 }
 
@@ -1525,24 +1532,28 @@ pub(super) fn workspace_links(
 /// the same shape a workspace read stores, so the live tier and its
 /// write-through take one path no matter who observed the pull request.
 pub fn digest_from_summary(item: &CodeDeliveryPullRequestSummary) -> PullRequestDigest {
+    let checks: Vec<PullRequestCheck> = item
+        .checks
+        .iter()
+        .map(|check| PullRequestCheck {
+            name: check.name.clone(),
+            bucket: check.bucket,
+            detail: check.detail.clone(),
+            url: check.url.clone(),
+        })
+        .collect();
+    // The summary and counts are derived the same way the conditional
+    // fetcher derives them, so the two live-tier writers agree on every
+    // field and an unchanged rollup reads as unchanged.
+    let counts = PullRequestCheckCounts::from_checks(&checks);
     PullRequestDigest {
         number: item.number,
         url: Some(item.url.clone()),
         state: item.state.clone(),
         title: Some(item.title.clone()),
-        checks_summary: None,
-        check_counts: None,
-        checks: Some(
-            item.checks
-                .iter()
-                .map(|check| PullRequestCheck {
-                    name: check.name.clone(),
-                    bucket: check.bucket,
-                    detail: check.detail.clone(),
-                    url: check.url.clone(),
-                })
-                .collect(),
-        ),
+        checks_summary: Some(counts.summary_line()),
+        check_counts: Some(counts),
+        checks: Some(checks),
         draft: Some(item.draft),
         // `state` alone cannot separate merged from closed on every host
         // response, which is why the summary carries `merged_at`.
@@ -1643,6 +1654,7 @@ pub(super) async fn persist_and_augment_pull_request_facts(
             .collect();
         for &index in indices {
             let from_host = items[index].from_host;
+            let checks_loaded = items[index].checks_loaded;
             let item = &mut items[index].summary;
             if item.in_merge_queue.is_none() {
                 item.in_merge_queue = known_queue.get(&item.number).copied();
@@ -1682,8 +1694,15 @@ pub(super) async fn persist_and_augment_pull_request_facts(
             // row's live tier and fan real change out to every workspace
             // holding the pull request (decision 66). One list read per
             // repository is what keeps every surface fresh.
+            let mut digest = digest_from_summary(item);
+            if !checks_loaded {
+                // Not asked, so not known: `None` keeps the row's checks.
+                digest.checks_summary = None;
+                digest.check_counts = None;
+                digest.checks = None;
+            }
             runtime
-                .record_pull_request_live_state(owner, None, &digest_from_summary(item))
+                .record_pull_request_live_state(owner, None, &digest)
                 .await;
             // Keep this pass's fact set current for later durable reads.
             match repo_facts

--- a/crates/tidebreak-code-delivery/src/tests.rs
+++ b/crates/tidebreak-code-delivery/src/tests.rs
@@ -1009,3 +1009,48 @@ fn cursors_are_bounded_offsets() {
     assert_eq!(page, vec![3]);
     assert_eq!(next, None);
 }
+
+#[test]
+fn a_list_read_without_a_rollup_does_not_claim_to_know_the_checks() {
+    // The reconcile sweep lists every state, and that plan skips
+    // `statusCheckRollup`. Its empty check list means "not asked": the
+    // observation says so, and the live-tier digest carries `None` so the
+    // write keeps the rollup the conditional fetcher stored.
+    let without = serde_json::json!({
+        "number": 2801,
+        "title": "Sweep read",
+        "state": "OPEN",
+        "url": "https://github.com/brightwave-inc/tidebreak/pull/2801",
+        "headRefName": "thet/sweep",
+        "baseRefName": "main"
+    });
+    let parsed = parse_pull_request(&repository_ref(), &without, &[]).unwrap();
+    assert!(!parsed.checks_loaded);
+    assert!(parsed.summary.checks.is_empty());
+
+    let with = serde_json::json!({
+        "number": 2801,
+        "title": "Sweep read",
+        "state": "OPEN",
+        "url": "https://github.com/brightwave-inc/tidebreak/pull/2801",
+        "headRefName": "thet/sweep",
+        "baseRefName": "main",
+        "statusCheckRollup": []
+    });
+    let parsed = parse_pull_request(&repository_ref(), &with, &[]).unwrap();
+    assert!(parsed.checks_loaded, "an empty rollup was still loaded");
+
+    // Both live-tier writers derive the summary and counts from the same
+    // check list, so an unchanged rollup compares equal whoever wrote it.
+    let digest = digest_from_summary(&parsed.summary);
+    assert_eq!(digest.checks.as_ref().map(Vec::len), Some(0));
+    assert_eq!(
+        digest.checks_summary.as_deref(),
+        Some(
+            PullRequestCheckCounts::from_checks(&[])
+                .summary_line()
+                .as_str()
+        )
+    );
+    assert!(digest.check_counts.is_some());
+}

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -1127,7 +1127,9 @@ pub struct CodePullRequestFact {
 pub struct CodePullRequestLiveState {
     /// One-line checks summary, as the digest carries it.
     pub checks_summary: Option<String>,
-    /// Individual checks, when the host reported any.
+    /// Individual checks. `Some` when the read loaded the check rollup
+    /// (empty when the host reported none); `None` when it did not load
+    /// checks at all, which a write treats as "keep what the row has".
     pub checks: Option<Vec<PullRequestCheck>>,
     /// Lowercased host review decision.
     pub review_decision: Option<String>,

--- a/crates/tidebreak-core/src/db/ops/code/pull_request.rs
+++ b/crates/tidebreak-core/src/db/ops/code/pull_request.rs
@@ -128,10 +128,18 @@ pub async fn get_pull_request_fact(
 
 /// Write the live tier onto one observed pull request (decision 66).
 ///
-/// Returns the row id and whether any live field actually moved —
-/// `observed_at` alone never counts, so callers broadcast real change and
-/// nothing else. `Ok(None)` when no fact row exists for the identity: the
-/// live tier decorates decision-62 observations, it never mints them.
+/// Returns the row id, whether any live field actually moved, and the tier
+/// as stored after the write. `observed_at` alone never counts as change, so
+/// callers broadcast real change and nothing else. `Ok(None)` when no fact
+/// row exists for the identity: the live tier decorates decision-62
+/// observations, it never mints them.
+///
+/// A read that did not load checks carries `checks: None`, and that keeps
+/// the row's check list and summary: the reconcile sweep lists pull requests
+/// without their check rollup, and stamping that absence over a rollup the
+/// conditional fetcher wrote would blind the watch and the check triggers
+/// for the length of the sweep interval. A read that loaded checks and found
+/// none carries `Some(vec![])`, which clears them.
 pub async fn set_pull_request_live_state(
     store: &DbStore,
     owner: &OwnerId,
@@ -140,22 +148,26 @@ pub async fn set_pull_request_live_state(
     repo_name: &str,
     number: u64,
     live: &CodePullRequestLiveState,
-) -> Result<Option<(CodePullRequestId, bool)>> {
+) -> Result<Option<(CodePullRequestId, bool, CodePullRequestLiveState)>> {
     let number = i64::try_from(number)
         .map_err(|_| AgentError::Store(format!("pull request number {number} overflows")))?;
     let Some(row) = find_fact_row(store, owner, host, repo_owner, repo_name, number).await? else {
         return Ok(None);
     };
-    let checks_json = match &live.checks {
-        Some(checks) => Some(serde_json::to_string(checks).map_err(|err| {
-            AgentError::Store(format!(
-                "pull request {} live checks are unwritable: {err}",
-                row.id
-            ))
-        })?),
-        None => None,
+    let (checks_summary, checks_json) = match &live.checks {
+        Some(checks) => (
+            live.checks_summary.clone(),
+            Some(serde_json::to_string(checks).map_err(|err| {
+                AgentError::Store(format!(
+                    "pull request {} live checks are unwritable: {err}",
+                    row.id
+                ))
+            })?),
+        ),
+        // The read did not load checks: keep what the row already knows.
+        None => (row.checks_summary.clone(), row.checks.clone()),
     };
-    let changed = row.checks_summary != live.checks_summary
+    let changed = row.checks_summary != checks_summary
         || row.checks != checks_json
         || row.review_decision != live.review_decision
         || row.mergeable != live.mergeable
@@ -163,8 +175,17 @@ pub async fn set_pull_request_live_state(
         || row.auto_merge_enabled != live.auto_merge_enabled
         || row.in_merge_queue != live.in_merge_queue;
     let id = CodePullRequestId(row.id);
+    let stored_checks = match checks_json.as_deref() {
+        Some(raw) => Some(serde_json::from_str(raw).map_err(|err| {
+            AgentError::Store(format!(
+                "pull request {} live checks are unreadable: {err}",
+                row.id
+            ))
+        })?),
+        None => None,
+    };
     let mut model: entities::code_pull_request::ActiveModel = row.into();
-    model.checks_summary = Set(live.checks_summary.clone());
+    model.checks_summary = Set(checks_summary.clone());
     model.checks = Set(checks_json);
     model.review_decision = Set(live.review_decision.clone());
     model.mergeable = Set(live.mergeable.clone());
@@ -173,7 +194,12 @@ pub async fn set_pull_request_live_state(
     model.in_merge_queue = Set(live.in_merge_queue);
     model.live_observed_at = Set(Some(live.observed_at));
     model.update(&store.conn).await.map_err(store_err)?;
-    Ok(Some((id, changed)))
+    let stored = CodePullRequestLiveState {
+        checks_summary,
+        checks: stored_checks,
+        ..live.clone()
+    };
+    Ok(Some((id, changed, stored)))
 }
 
 /// One observed pull request plus the transport hints the conditional

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4190,19 +4190,61 @@ async fn pull_request_facts_upsert_claim_and_promote() {
         in_merge_queue: Some(false),
         observed_at: later,
     };
-    let (live_id, changed) =
+    let (live_id, changed, _) =
         set_pull_request_live_state(&store, &owner, "github.com", "acme", "tools", 412, &live)
             .await
             .unwrap()
             .unwrap();
     assert_eq!(live_id, id);
     assert!(changed);
-    let (_, changed_again) =
+    let (_, changed_again, _) =
         set_pull_request_live_state(&store, &owner, "github.com", "acme", "tools", 412, &live)
             .await
             .unwrap()
             .unwrap();
     assert!(!changed_again, "observed_at alone is not change");
+    // A read that never loaded checks (`checks: None`) keeps the row's
+    // rollup and does not count as change; one that loaded and found none
+    // (`Some(vec![])`) clears it.
+    let unloaded = CodePullRequestLiveState {
+        checks_summary: None,
+        checks: None,
+        ..live.clone()
+    };
+    let (_, changed_unloaded, stored_unloaded) = set_pull_request_live_state(
+        &store,
+        &owner,
+        "github.com",
+        "acme",
+        "tools",
+        412,
+        &unloaded,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(!changed_unloaded, "an unloaded rollup is not a change");
+    assert_eq!(stored_unloaded.checks.as_ref().map(Vec::len), Some(1));
+    assert_eq!(
+        stored_unloaded.checks_summary.as_deref(),
+        Some("8 passing, 1 pending, 0 failing")
+    );
+    let cleared = CodePullRequestLiveState {
+        checks_summary: Some("0 passing, 0 pending, 0 failing".into()),
+        checks: Some(Vec::new()),
+        ..live.clone()
+    };
+    let (_, changed_cleared, stored_cleared) =
+        set_pull_request_live_state(&store, &owner, "github.com", "acme", "tools", 412, &cleared)
+            .await
+            .unwrap()
+            .unwrap();
+    assert!(changed_cleared, "a loaded empty rollup clears the row");
+    assert_eq!(stored_cleared.checks.as_ref().map(Vec::len), Some(0));
+    set_pull_request_live_state(&store, &owner, "github.com", "acme", "tools", 412, &live)
+        .await
+        .unwrap()
+        .unwrap();
     let stored = get_pull_request_fact(&store, &owner, "github.com", "acme", "tools", 412)
         .await
         .unwrap()

--- a/crates/tidebreak-server/src/code/pr_fetch.rs
+++ b/crates/tidebreak-server/src/code/pr_fetch.rs
@@ -511,7 +511,9 @@ pub(crate) fn digest_from_parts(
         title: pull.title.clone(),
         checks_summary: Some(counts.summary_line()),
         check_counts: Some(counts),
-        checks: (!checks.is_empty()).then(|| checks.to_vec()),
+        // The fetcher always loads the rollup, so an empty list is a fact
+        // ("no checks") and clears the row, unlike a read that never asked.
+        checks: Some(checks.to_vec()),
         draft: pull.draft,
         merged: Some(pull.state == "merged"),
         review_decision,

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -1225,7 +1225,7 @@ impl CodeRuntime {
             return;
         }
         let live = tidebreak_core::CodePullRequestLiveState::from_digest(digest, Utc::now());
-        let changed = match tidebreak_core::db::code::set_pull_request_live_state(
+        let (changed, stored) = match tidebreak_core::db::code::set_pull_request_live_state(
             &self.db,
             owner,
             &host,
@@ -1236,7 +1236,7 @@ impl CodeRuntime {
         )
         .await
         {
-            Ok(Some((_, changed))) => changed,
+            Ok(Some((_, changed, stored))) => (changed, stored),
             // No fact row yet: the detector or the reconcile sweep mints it,
             // and the next digest change lands on it.
             Ok(None) => return,
@@ -1248,6 +1248,18 @@ impl CodeRuntime {
         if !changed {
             return;
         }
+        // A read that did not load checks writes through the checks the row
+        // kept, not its own absence: the workspace column mirrors the tier.
+        let mut digest = digest.clone();
+        if digest.checks.is_none() {
+            digest.checks_summary = stored.checks_summary;
+            digest.check_counts = stored
+                .checks
+                .as_deref()
+                .map(tidebreak_core::PullRequestCheckCounts::from_checks);
+            digest.checks = stored.checks;
+        }
+        let digest = &digest;
         // One delivery nudge per real change (decision 66): the delivery
         // page and notification monitor re-read on receipt instead of on
         // their own timers.


### PR DESCRIPTION
## What

The pull-request live tier (decision 66) has two writers: the conditional fetcher, which always loads the check rollup, and the delivery-crate reconcile sweep, which lists every state and so never asks for `statusCheckRollup`. The sweep's digest still wrote `checks: Some([])` over the row on every pass, and `set_pull_request_live_state` is a full replace.

Consequences on `main`:

- A failing pull request read as having no failing or pending checks for the length of the sweep interval. The watch loop parked with "a repository requirement is outstanding" or finished as ready, and `checks_failed` triggers never fired while the tier was fresh.
- The sweep wrote `checks_summary: None` where the fetcher wrote `Some(summary)`, so every write compared as a change and rebroadcast every workspace digest and the delivery nudge on each tick.

## How

- `PullRequestObservation` records `checks_loaded`. The persist pass blanks the three check fields on a digest whose read did not load checks.
- `CodePullRequestLiveState.checks: None` now means "not loaded". `set_pull_request_live_state` keeps the row's checks and summary for it, and returns the tier as stored.
- The fetcher writes `Some(vec![])` for a loaded empty rollup, so a real "no checks" still clears the row.
- `digest_from_summary` derives `checks_summary` and `check_counts` from the check list the same way the fetcher does.
- The write-through to sibling workspaces mirrors the stored tier, not the writer's absence.

## Checks

- `cargo test -p tidebreak-core --locked pull_request_facts_upsert_claim_and_promote`: 1 passed (extended with the unloaded and cleared cases).
- `cargo test -p tidebreak-code-delivery --locked`: 30 passed (one new test).
- `cargo test -p tidebreak-server-core --locked pr_fetch` / `workspace_delivery` / `reconcile`: 14 / 6 / 12 passed.
- `cargo clippy -p tidebreak-core -p tidebreak-code-delivery -p tidebreak-server-core --all-targets --locked -- -D warnings`: clean.

Not changed here: the hosted REST forge path hardcodes `reviewDecision: null` and so clears `review_decision` on the same sweep. That needs a REST-side derivation and is filed separately.