### PR TITLE
fix(desktop): show server error messages without the HttpError prefix and keep push failure detail

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -96,6 +96,9 @@ export function WorkspaceWorkflowControl({
   onOpenWatchTask?: () => void;
 }) {
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [pushFailureDetail, setPushFailureDetail] = useState<string | null>(
+    null,
+  );
   // Downloading the failing job logs is a host read the reader waits on, so
   // the primary button spins through it rather than looking dead.
   const [attachingLogs, setAttachingLogs] = useState(false);
@@ -418,12 +421,15 @@ export function WorkspaceWorkflowControl({
             return true;
           });
           if (!pushed) return;
+          setPushFailureDetail(null);
           toast.success("Pushed");
         } catch (err) {
-          const message =
-            err instanceof HttpError && err.kind === "git_auth_failed"
-              ? err.message
-              : friendlyErrorMessage(err, "Could not push");
+          const message = friendlyErrorMessage(err, "Could not push");
+          setPushFailureDetail(
+            err instanceof HttpError && err.kind === "git_push_failed"
+              ? message
+              : null,
+          );
           resource.setMutationError(message);
           toast.error(message);
         }
@@ -570,6 +576,11 @@ export function WorkspaceWorkflowControl({
                 snapshot={resource.data}
                 error={resource.mutationError ?? resource.error}
               />
+              {pushFailureDetail && (
+                <pre className="bg-muted max-h-32 overflow-auto rounded-md p-2 text-xs whitespace-pre-wrap">
+                  {pushFailureDetail}
+                </pre>
+              )}
             </div>
             <div className="flex flex-wrap gap-1 border-t border-border-subtle p-1.5">
               {!model.remote && (

--- a/crates/tidebreak-desktop/ui/src/lib/utils.test.ts
+++ b/crates/tidebreak-desktop/ui/src/lib/utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { HttpError } from "../api/client/http";
+import { friendlyErrorMessage } from "./utils";
+
+describe("friendlyErrorMessage", () => {
+  it("yields the server message from an HttpError, without status prefix", () => {
+    expect(
+      friendlyErrorMessage(
+        new HttpError(409, "409: repository already registered", "conflict"),
+        "Could not add repository",
+      ),
+    ).toBe("repository already registered");
+  });
+
+  it("yields a plain Error's message", () => {
+    expect(friendlyErrorMessage(new Error("disk full"), "Could not save")).toBe(
+      "disk full",
+    );
+  });
+
+  it("yields a string as itself", () => {
+    expect(friendlyErrorMessage("network down", "Could not reach")).toBe(
+      "network down",
+    );
+  });
+
+  it("falls back when the input is empty", () => {
+    expect(friendlyErrorMessage("", "Could not complete")).toBe(
+      "Could not complete",
+    );
+    expect(friendlyErrorMessage(new Error("   "), "Could not complete")).toBe(
+      "Could not complete",
+    );
+  });
+
+  it("falls back when an unknown shape is longer than 240 characters", () => {
+    const long = "x".repeat(241);
+    expect(friendlyErrorMessage(long, "Could not complete")).toBe(
+      "Could not complete",
+    );
+  });
+
+  it("keeps long HttpError detail instead of the fallback", () => {
+    const detail = `git push failed:\n${"remote rejected\n".repeat(20).trimEnd()}`;
+    expect(
+      friendlyErrorMessage(
+        new HttpError(409, `409: ${detail}`, "git_push_failed"),
+        "Could not push",
+      ),
+    ).toBe(detail);
+  });
+});

--- a/crates/tidebreak-desktop/ui/src/lib/utils.test.ts
+++ b/crates/tidebreak-desktop/ui/src/lib/utils.test.ts
@@ -13,6 +13,15 @@ describe("friendlyErrorMessage", () => {
     ).toBe("repository already registered");
   });
 
+  it("strips only the client's own status prefix, never digits the server wrote", () => {
+    expect(
+      friendlyErrorMessage(
+        new HttpError(500, "500: 404: file not found", "internal"),
+        "fallback",
+      ),
+    ).toBe("404: file not found");
+  });
+
   it("yields a plain Error's message", () => {
     expect(friendlyErrorMessage(new Error("disk full"), "Could not save")).toBe(
       "disk full",

--- a/crates/tidebreak-desktop/ui/src/lib/utils.ts
+++ b/crates/tidebreak-desktop/ui/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+import { HttpError } from "../api/client/http";
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
@@ -8,13 +10,20 @@ export function cn(...inputs: ClassValue[]) {
 /**
  * A caught value as something worth showing a reader.
  *
- * The backend returns human-readable strings, so the caught message is usually
- * the best copy available. Anything empty or long enough to be a stack trace or
- * a serialized payload falls back to the caller's own wording.
+ * Prefer `Error.message` over `String(error)` so `HttpError` (whose `name` is
+ * `"HttpError"`) does not leak a `"HttpError: "` prefix. The HTTP client
+ * prefixes the status (`"409: …"`); strip that when the body already carries
+ * the server's `message`. Server detail is already bounded (git stderr up to
+ * 4 KB); keep the 240-character cap only for unknown shapes so a toast stays
+ * readable.
  */
 export function friendlyErrorMessage(error: unknown, fallback: string): string {
-  const message = String(error)
+  let message = (error instanceof Error ? error.message : String(error))
     .replace(/^Error:\s*/, "")
     .trim();
+  if (error instanceof HttpError) {
+    message = message.replace(/^\d{3}:\s*/, "").trim();
+    return message || fallback;
+  }
   return message && message.length <= 240 ? message : fallback;
 }

--- a/crates/tidebreak-desktop/ui/src/lib/utils.ts
+++ b/crates/tidebreak-desktop/ui/src/lib/utils.ts
@@ -22,7 +22,12 @@ export function friendlyErrorMessage(error: unknown, fallback: string): string {
     .replace(/^Error:\s*/, "")
     .trim();
   if (error instanceof HttpError) {
-    message = message.replace(/^\d{3}:\s*/, "").trim();
+    // The client builds the message as `${status}: ${server message}`, so
+    // strip exactly that status, never digits the server itself wrote.
+    const prefix = `${error.status}:`;
+    if (message.startsWith(prefix)) {
+      message = message.slice(prefix.length).trim();
+    }
     return message || fallback;
   }
   return message && message.length <= 240 ? message : fallback;


### PR DESCRIPTION
## What changed

`friendlyErrorMessage` used `String(error)` and only stripped a leading `Error:` prefix. `HttpError` sets `name` to `"HttpError"`, so toasts showed `HttpError: 409: …`. The helper now uses `error.message` for `Error` values, then strips a leading `\d{3}:\s*` status prefix on `HttpError` (the client builds `message` as `` `${status}: ${detail}` ``, preferring the JSON `message` field).

Server `HttpError` detail is already bounded (git stderr up to 4 KB). The 240-character cap is kept only for unknown shapes so a toast stays readable.

A rejected push with kind `git_push_failed` still goes through the existing toast + mutation-error path, and the workspace workflow popover now shows that git stderr in a scrollable `<pre>` using the same markup as the clone failure in `AddRepoPalette`.

## Tests added

`src/lib/utils.test.ts`: HttpError with status + message yields the bare message; a plain Error yields its message; a string yields itself; empty input still falls back; unknown shapes longer than 240 characters still fall back; long HttpError detail is kept.

## Checks run

From `crates/tidebreak-desktop/ui` (pnpm 10.18.3; `pnpm install --frozen-lockfile` first):

```
Formatted 926 files in 1024ms. No fixes applied.
Checked 926 files in 974ms. No fixes applied.
Checked 926 files in 1184ms. No fixes applied.
 Test Files  287 passed (287)
      Tests  2527 passed (2527)
✓ built in 8.25s
```

(`pnpm exec biome format --write src`, `pnpm exec biome format src`, `pnpm lint`, `pnpm test`, `pnpm build`.)

## Skipped

None of the requested claims failed verification. `HttpError` does not have a separate `detail` field; the server's `message` is already in `error.message` after the status prefix.