### PR TITLE
fix(desktop): keep Delivery preferences through a bad persisted row and drop the dead notification pipeline

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.test.ts
@@ -1,11 +1,25 @@
-import { describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { ApiClient } from "../api/client";
 import type {
+  CodeDeliveryPullRequestQuery,
+  CodeDeliveryPullRequestSummary,
   CodeDeliveryRunQuery,
+  CodeDeliveryRunSummary,
   CodeGitHubRepositoryRef,
 } from "../api/types";
-import type { CodeDeliveryNotificationRule } from "./CodeDeliveryStore";
 import {
+  codeDeliveryRepositoryKey,
+  resetCodeDeliveryHostState,
+  useCodeDeliveryStore,
+  type CodeDeliveryNotificationRule,
+} from "./CodeDeliveryStore";
+import { resetCodeClientGenerationForTests } from "./CodeClientGeneration";
+import {
+  CodeDeliveryMonitor,
   migrateLegacyNotificationRules,
   monitorRuns,
   monitorSince,
@@ -27,6 +41,72 @@ const attentionRule: CodeDeliveryNotificationRule = {
   repositoryKeys: [],
   tidebreakLinkedOnly: false,
 };
+
+function pullRequest(id: number): CodeDeliveryPullRequestSummary {
+  return {
+    id: `${codeDeliveryRepositoryKey(repository)}#${id}`,
+    repository,
+    number: id,
+    url: `${repository.url}/pull/${id}`,
+    title: `Pull request ${id}`,
+    state: "open",
+    draft: false,
+    head_branch: `feature/${id}`,
+    base_branch: "main",
+    head_sha: `sha-${id}`,
+    auto_merge_enabled: false,
+    checks: [],
+    attention_reasons: [],
+    ready_to_merge: false,
+    workspace_links: [],
+    labels: [],
+    created_at: "2026-09-10T12:00:00.000Z",
+    updated_at: "2026-09-10T12:00:00.000Z",
+  };
+}
+
+function run(id: number): CodeDeliveryRunSummary {
+  return {
+    id: `${codeDeliveryRepositoryKey(repository)}:workflow_run:${id}`,
+    repository,
+    kind: "workflow_run",
+    github_id: id,
+    name: `CI ${id}`,
+    url: `${repository.url}/actions/runs/${id}`,
+    status: "completed",
+    conclusion: "success",
+    attention_reasons: [],
+    workspace_links: [],
+    created_at: "2026-09-10T12:00:00.000Z",
+    updated_at: "2026-09-10T12:00:00.000Z",
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  resetCodeClientGenerationForTests();
+  useCodeDeliveryStore.setState({
+    manualRepositories: [],
+    excludedRegisteredRepoIds: [],
+    pinnedRepositoryKeys: [],
+    savedViews: [],
+    lastPollAt: null,
+    lastSuccessfulPollAt: null,
+    knownAuthors: [],
+    legacyNotificationRules: null,
+    notificationRulesMigrated: false,
+    persistenceError: null,
+  });
+  resetCodeDeliveryHostState();
+});
+
+afterEach(() => {
+  cleanup();
+  resetCodeDeliveryHostState();
+  resetCodeClientGenerationForTests();
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
 
 describe("migrateLegacyNotificationRules", () => {
   it("arms every mapped rule as a server notification trigger", async () => {
@@ -105,6 +185,76 @@ describe("migrateLegacyNotificationRules", () => {
       ["repo-1", "conflicts", "notify"],
       ["repo-1", "conflicts", "notify"],
     ]);
+  });
+});
+
+describe("CodeDeliveryMonitor", () => {
+  it("carries three-page aggregates across two bounded passes", async () => {
+    const pullRequests = [pullRequest(1), pullRequest(2), pullRequest(3)];
+    const runs = [run(1), run(2), run(3)];
+    const pullRequestCursors = [undefined, "pr-2", "pr-3"];
+    const runCursors = [undefined, "run-2", "run-3"];
+    let pullRequestPage = 0;
+    let runPage = 0;
+    const completeDeliveryPoll = vi.fn(
+      useCodeDeliveryStore.getState().completeDeliveryPoll,
+    );
+    useCodeDeliveryStore.setState({ completeDeliveryPoll });
+
+    const client = {
+      getCodeDeliveryRepositories: vi.fn(async () => ({
+        capability: { found: true, authenticated: true, remediation: "" },
+        repositories: [repository],
+        errors: [],
+        fetched_at: "2026-09-10T12:00:00.000Z",
+      })),
+      queryCodeDeliveryPullRequests: vi.fn(
+        async (query: CodeDeliveryPullRequestQuery) => {
+          expect(query.cursor).toBe(pullRequestCursors[pullRequestPage]);
+          if (pullRequestPage === 2) {
+            expect(useCodeDeliveryStore.getState().lastPollAt).toBeNull();
+          }
+          const page = pullRequestPage;
+          pullRequestPage += 1;
+          return {
+            capability: { found: true, authenticated: true, remediation: "" },
+            items: [pullRequests[page]],
+            errors: [],
+            fetched_at: "2026-09-10T12:00:00.000Z",
+            ...(page < 2 ? { next_cursor: pullRequestCursors[page + 1] } : {}),
+          };
+        },
+      ),
+      queryCodeDeliveryRuns: vi.fn(async (query: CodeDeliveryRunQuery) => {
+        expect(query.cursor).toBe(runCursors[runPage]);
+        if (runPage === 2) {
+          expect(useCodeDeliveryStore.getState().lastPollAt).toBeNull();
+        }
+        const page = runPage;
+        runPage += 1;
+        return {
+          capability: { found: true, authenticated: true, remediation: "" },
+          items: [runs[page]],
+          errors: [],
+          fetched_at: "2026-09-10T12:00:00.000Z",
+          ...(page < 2 ? { next_cursor: runCursors[page + 1] } : {}),
+        };
+      }),
+    } as unknown as ApiClient;
+
+    render(createElement(CodeDeliveryMonitor, { client, maxPagesPerPass: 2 }));
+
+    await waitFor(() => expect(completeDeliveryPoll).toHaveBeenCalledOnce());
+    expect(completeDeliveryPoll).toHaveBeenCalledWith(
+      pullRequests,
+      runs,
+      expect.any(String),
+    );
+    expect(client.queryCodeDeliveryPullRequests).toHaveBeenCalledTimes(3);
+    expect(client.queryCodeDeliveryRuns).toHaveBeenCalledTimes(3);
+    expect(useCodeDeliveryStore.getState().lastPollAt).toBe(
+      completeDeliveryPoll.mock.calls[0]?.[2],
+    );
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.test.ts
@@ -139,6 +139,33 @@ describe("monitorRuns", () => {
     expect(queries).toHaveLength(1);
     expect(queries[0]?.kinds).toEqual(["workflow_run"]);
   });
+
+  it("caps each pass and returns the cursor for the next pass", async () => {
+    let page = 0;
+    const queryCodeDeliveryRuns = vi.fn(async () => {
+      page += 1;
+      return {
+        capability: { found: true, authenticated: true, remediation: "" },
+        items: [],
+        errors: [],
+        fetched_at: "2026-08-20T12:00:00.000Z",
+        next_cursor: `cursor-${page}`,
+      };
+    });
+
+    const batch = await monitorRuns(
+      { queryCodeDeliveryRuns },
+      [],
+      "2026-08-20T00:00:00.000Z",
+    );
+
+    expect(queryCodeDeliveryRuns).toHaveBeenCalledTimes(5);
+    expect(batch).toEqual({
+      items: [],
+      complete: false,
+      nextCursor: "cursor-5",
+    });
+  });
 });
 
 describe("monitorSince", () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
@@ -37,7 +37,14 @@ type MonitorBatch<T> = {
 };
 
 /** Shell-level delivery polling for GitHub notifications. */
-export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
+export function CodeDeliveryMonitor({
+  client,
+  maxPagesPerPass = MAX_MONITOR_PAGES,
+}: {
+  client: ApiClient;
+  /** Test seam for exercising continuation without changing production bounds. */
+  maxPagesPerPass?: number;
+}) {
   const wakeRef = useRef<(() => void) | null>(null);
   const deliveryRevision = useCodeUpdatesStore(
     (state) => state.deliveryRevision,
@@ -171,6 +178,7 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
                 pending.since,
                 pending.pullRequestCursor,
                 queryController.signal,
+                maxPagesPerPass,
               ),
           pending.runsComplete
             ? Promise.resolve<MonitorBatch<CodeDeliveryRunSummary>>({
@@ -183,21 +191,26 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
                 pending.since,
                 pending.runCursor,
                 queryController.signal,
+                maxPagesPerPass,
               ),
         ]);
         const [pullRequestBatch, runBatch] = batches;
-        pending.pullRequests.push(...pullRequestBatch.items);
-        pending.runs.push(...runBatch.items);
-        pending.pullRequestsComplete = pullRequestBatch.complete;
-        pending.runsComplete = runBatch.complete;
-        pending.pullRequestCursor = pullRequestBatch.nextCursor;
-        pending.runCursor = runBatch.nextCursor;
+        continuation = {
+          ...pending,
+          pullRequests: [...pending.pullRequests, ...pullRequestBatch.items],
+          runs: [...pending.runs, ...runBatch.items],
+          pullRequestsComplete: pullRequestBatch.complete,
+          runsComplete: runBatch.complete,
+          pullRequestCursor: pullRequestBatch.nextCursor,
+          runCursor: runBatch.nextCursor,
+        };
+        const nextPending = continuation;
 
         if (!isCurrent()) {
           initial.setPollState(false);
           return;
         }
-        if (!pending.pullRequestsComplete || !pending.runsComplete) {
+        if (!nextPending.pullRequestsComplete || !nextPending.runsComplete) {
           // Keep one pass bounded. Very large aggregates continue immediately
           // from these cursors and refresh across several passes.
           rerunRequested = true;
@@ -208,9 +221,9 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
         useCodeDeliveryStore
           .getState()
           .completeDeliveryPoll(
-            pending.pullRequests,
-            pending.runs,
-            pending.startedAt,
+            nextPending.pullRequests,
+            nextPending.runs,
+            nextPending.startedAt,
           );
       } catch (error) {
         continuation = null;
@@ -242,7 +255,7 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
       if (timer !== null) window.clearTimeout(timer);
       queryController?.abort();
     };
-  }, [client]);
+  }, [client, maxPagesPerPass]);
 
   return null;
 }
@@ -314,10 +327,11 @@ export async function monitorPullRequests(
   updatedAfter: string,
   initialCursor?: string,
   signal?: AbortSignal,
+  maxPages = MAX_MONITOR_PAGES,
 ): Promise<MonitorBatch<CodeDeliveryPullRequestSummary>> {
   const items: CodeDeliveryPullRequestSummary[] = [];
   let cursor = initialCursor;
-  for (let pageNumber = 0; pageNumber < MAX_MONITOR_PAGES; pageNumber += 1) {
+  for (let pageNumber = 0; pageNumber < maxPages; pageNumber += 1) {
     const page = await client.queryCodeDeliveryPullRequests(
       {
         repositories,
@@ -347,10 +361,11 @@ export async function monitorRuns(
   createdAfter: string,
   initialCursor?: string,
   signal?: AbortSignal,
+  maxPages = MAX_MONITOR_PAGES,
 ): Promise<MonitorBatch<CodeDeliveryRunSummary>> {
   const items: CodeDeliveryRunSummary[] = [];
   let cursor = initialCursor;
-  for (let pageNumber = 0; pageNumber < MAX_MONITOR_PAGES; pageNumber += 1) {
+  for (let pageNumber = 0; pageNumber < maxPages; pageNumber += 1) {
     const page = await client.queryCodeDeliveryRuns(
       {
         repositories,

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryMonitor.tsx
@@ -57,6 +57,17 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
     let rerunRequested = false;
     let timer: number | null = null;
     let queryController: AbortController | null = null;
+    let continuation: {
+      startedAt: string;
+      targetKey: string;
+      since: string;
+      pullRequests: CodeDeliveryPullRequestSummary[];
+      runs: CodeDeliveryRunSummary[];
+      pullRequestCursor?: string;
+      runCursor?: string;
+      pullRequestsComplete: boolean;
+      runsComplete: boolean;
+    } | null = null;
     const isCurrent = () =>
       !cancelled && isCodeClientGenerationActive(clientGeneration);
 
@@ -86,7 +97,10 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
       initial.setPollState(true, null);
       try {
         const discovered = await initial.loadRepositories(client);
-        if (!isCurrent()) return;
+        if (!isCurrent()) {
+          initial.setPollState(false);
+          return;
+        }
         const current = useCodeDeliveryStore.getState();
         if (
           !discovered.capability.found ||
@@ -110,7 +124,10 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
               errors: discovered.errors,
             },
           );
-          if (!isCurrent()) return;
+          if (!isCurrent()) {
+            initial.setPollState(false);
+            return;
+          }
           if (migrationComplete) {
             useCodeDeliveryStore
               .getState()
@@ -120,64 +137,87 @@ export function CodeDeliveryMonitor({ client }: { client: ApiClient }) {
 
         const targets = repositories.map(codeDeliveryRepositoryTarget);
         if (targets.length === 0) {
+          continuation = null;
           current.completeDeliveryPoll([], [], startedAt);
           return;
         }
 
-        queryController = new AbortController();
-        const since = monitorSince(current.lastPollAt, Date.parse(startedAt));
-        const pullRequests: CodeDeliveryPullRequestSummary[] = [];
-        const runs: CodeDeliveryRunSummary[] = [];
-        let pullRequestCursor: string | undefined;
-        let runCursor: string | undefined;
-        let pullRequestsComplete = false;
-        let runsComplete = false;
-
-        while (!pullRequestsComplete || !runsComplete) {
-          const batches: [
-            MonitorBatch<CodeDeliveryPullRequestSummary>,
-            MonitorBatch<CodeDeliveryRunSummary>,
-          ] = await Promise.all([
-            pullRequestsComplete
-              ? Promise.resolve<MonitorBatch<CodeDeliveryPullRequestSummary>>({
-                  items: [],
-                  complete: true,
-                })
-              : monitorPullRequests(
-                  client,
-                  targets,
-                  since,
-                  pullRequestCursor,
-                  queryController.signal,
-                ),
-            runsComplete
-              ? Promise.resolve<MonitorBatch<CodeDeliveryRunSummary>>({
-                  items: [],
-                  complete: true,
-                })
-              : monitorRuns(
-                  client,
-                  targets,
-                  since,
-                  runCursor,
-                  queryController.signal,
-                ),
-          ]);
-          const [pullRequestBatch, runBatch] = batches;
-          pullRequests.push(...pullRequestBatch.items);
-          runs.push(...runBatch.items);
-          pullRequestsComplete = pullRequestBatch.complete;
-          runsComplete = runBatch.complete;
-          pullRequestCursor = pullRequestBatch.nextCursor;
-          runCursor = runBatch.nextCursor;
+        const targetKey = JSON.stringify(targets);
+        if (!continuation || continuation.targetKey !== targetKey) {
+          continuation = {
+            startedAt,
+            targetKey,
+            since: monitorSince(current.lastPollAt, Date.parse(startedAt)),
+            pullRequests: [],
+            runs: [],
+            pullRequestsComplete: false,
+            runsComplete: false,
+          };
         }
+        const pending = continuation;
+        queryController = new AbortController();
+        const batches: [
+          MonitorBatch<CodeDeliveryPullRequestSummary>,
+          MonitorBatch<CodeDeliveryRunSummary>,
+        ] = await Promise.all([
+          pending.pullRequestsComplete
+            ? Promise.resolve<MonitorBatch<CodeDeliveryPullRequestSummary>>({
+                items: [],
+                complete: true,
+              })
+            : monitorPullRequests(
+                client,
+                targets,
+                pending.since,
+                pending.pullRequestCursor,
+                queryController.signal,
+              ),
+          pending.runsComplete
+            ? Promise.resolve<MonitorBatch<CodeDeliveryRunSummary>>({
+                items: [],
+                complete: true,
+              })
+            : monitorRuns(
+                client,
+                targets,
+                pending.since,
+                pending.runCursor,
+                queryController.signal,
+              ),
+        ]);
+        const [pullRequestBatch, runBatch] = batches;
+        pending.pullRequests.push(...pullRequestBatch.items);
+        pending.runs.push(...runBatch.items);
+        pending.pullRequestsComplete = pullRequestBatch.complete;
+        pending.runsComplete = runBatch.complete;
+        pending.pullRequestCursor = pullRequestBatch.nextCursor;
+        pending.runCursor = runBatch.nextCursor;
 
-        if (!isCurrent()) return;
+        if (!isCurrent()) {
+          initial.setPollState(false);
+          return;
+        }
+        if (!pending.pullRequestsComplete || !pending.runsComplete) {
+          // Keep one pass bounded. Very large aggregates continue immediately
+          // from these cursors and refresh across several passes.
+          rerunRequested = true;
+          initial.setPollState(false);
+          return;
+        }
+        continuation = null;
         useCodeDeliveryStore
           .getState()
-          .completeDeliveryPoll(pullRequests, runs, startedAt);
+          .completeDeliveryPoll(
+            pending.pullRequests,
+            pending.runs,
+            pending.startedAt,
+          );
       } catch (error) {
-        if (!isCurrent() || isAbortError(error)) return;
+        continuation = null;
+        if (!isCurrent() || isAbortError(error)) {
+          initial.setPollState(false);
+          return;
+        }
         useCodeDeliveryStore
           .getState()
           .setPollState(false, deliveryErrorMessage(error));

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.test.ts
@@ -13,7 +13,6 @@ import {
   rememberedPullRequestPage,
   resetCodeDeliveryHostState,
   trackedCodeDeliveryRepositories,
-  unreadCodeDeliveryNotifications,
   useCodeDeliveryStore,
 } from "./CodeDeliveryStore";
 
@@ -87,11 +86,22 @@ function run(
 
 beforeEach(() => {
   window.localStorage.clear();
-  useCodeDeliveryStore.getState().reset();
+  useCodeDeliveryStore.setState({
+    manualRepositories: [],
+    excludedRegisteredRepoIds: [],
+    pinnedRepositoryKeys: [],
+    savedViews: [],
+    lastPollAt: null,
+    knownAuthors: [],
+    legacyNotificationRules: null,
+    notificationRulesMigrated: false,
+    persistenceError: null,
+  });
+  resetCodeDeliveryHostState();
 });
 
 afterEach(() => {
-  useCodeDeliveryStore.getState().reset();
+  resetCodeDeliveryHostState();
   window.localStorage.clear();
 });
 
@@ -188,88 +198,6 @@ describe("trackedCodeDeliveryRepositories", () => {
       excludedRegisteredRepoIds: ["repo-zeta"],
       pinnedRepositoryKeys: ["github.com/other-org/beta"],
     });
-  });
-});
-
-describe("delivery notifications", () => {
-  it("deduplicates a poll fingerprint and preserves explicit read state", () => {
-    const repo = repository("brightwave-inc", "tidebreak", "repo-1");
-    const store = useCodeDeliveryStore.getState();
-    const item = pullRequest(2248, repo);
-
-    expect(store.ingestDeliveryPoll([item], [], NOW)).toBe(1);
-    expect(
-      useCodeDeliveryStore.getState().ingestDeliveryPoll([item], [], NOW),
-    ).toBe(0);
-    expect(useCodeDeliveryStore.getState().notifications).toHaveLength(1);
-    expect(
-      unreadCodeDeliveryNotifications(useCodeDeliveryStore.getState()),
-    ).toBe(1);
-
-    const notificationId = useCodeDeliveryStore.getState().notifications[0]!.id;
-    useCodeDeliveryStore.getState().markNotificationRead(notificationId);
-    expect(
-      unreadCodeDeliveryNotifications(useCodeDeliveryStore.getState()),
-    ).toBe(0);
-
-    useCodeDeliveryStore.getState().markNotificationRead(notificationId, false);
-    expect(
-      unreadCodeDeliveryNotifications(useCodeDeliveryStore.getState()),
-    ).toBe(1);
-
-    useCodeDeliveryStore.getState().markAllNotificationsRead();
-    expect(
-      unreadCodeDeliveryNotifications(useCodeDeliveryStore.getState()),
-    ).toBe(0);
-  });
-
-  it("keeps the client-side feed after rule evaluation moves to the server", () => {
-    const alpha = repository("brightwave-inc", "alpha", "repo-alpha");
-    const beta = repository("brightwave-inc", "beta", "repo-beta");
-    const linked = pullRequest(3, alpha, {
-      workspace_links: [
-        {
-          workspace_id: "ws-3",
-          repo_id: "repo-alpha",
-          title: "Fix alpha",
-          branch_name: "feature/3",
-          status: "active",
-          exact: true,
-        },
-      ],
-    });
-    expect(
-      useCodeDeliveryStore
-        .getState()
-        .ingestDeliveryPoll([pullRequest(1, beta), linked], [], NOW),
-    ).toBe(2);
-    expect(useCodeDeliveryStore.getState().notifications).toHaveLength(2);
-    expect(
-      useCodeDeliveryStore
-        .getState()
-        .notifications.find(
-          (notification) => notification.workspaceId === "ws-3",
-        ),
-    ).toBeDefined();
-  });
-
-  it("keeps at most 500 notifications and drops events older than 30 days", () => {
-    const repo = repository("brightwave-inc", "tidebreak", "repo-1");
-    const recent = Array.from({ length: 506 }, (_, index) =>
-      run(index + 1, repo),
-    );
-    const old = run(999, repo, {
-      created_at: "2026-07-20T11:59:59.000Z",
-      updated_at: "2026-07-20T11:59:59.000Z",
-    });
-
-    expect(
-      useCodeDeliveryStore.getState().ingestDeliveryPoll([], [old], NOW),
-    ).toBe(0);
-    expect(
-      useCodeDeliveryStore.getState().ingestDeliveryPoll([], recent, NOW),
-    ).toBe(506);
-    expect(useCodeDeliveryStore.getState().notifications).toHaveLength(500);
   });
 });
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStore.ts
@@ -14,10 +14,7 @@ import type {
 
 const STORAGE_KEY = "tidebreak.code-delivery";
 const STORAGE_VERSION = 1;
-const MAX_NOTIFICATIONS = 500;
 const MAX_KNOWN_AUTHORS = 50;
-const MAX_SEEN_FINGERPRINTS = 5_000;
-const MAX_NOTIFICATION_AGE_MS = 30 * 24 * 60 * 60 * 1_000;
 const REPOSITORY_CACHE_MS = 2 * 60 * 1_000;
 const MAX_PULL_REQUEST_PAGE_CACHE = 8;
 
@@ -97,34 +94,6 @@ export type CodeDeliveryNotificationRule = {
   tidebreakLinkedOnly: boolean;
 };
 
-export type CodeDeliveryNotificationTarget =
-  | {
-      kind: "pull_request";
-      repository: CodeGitHubRepositoryTarget;
-      number: number;
-    }
-  | {
-      kind: "run";
-      repository: CodeGitHubRepositoryTarget;
-      runKind: CodeDeliveryRunKind;
-      id: number;
-    };
-
-export type CodeDeliveryNotification = {
-  id: string;
-  fingerprint: string;
-  rule: CodeDeliveryNotificationRuleKind;
-  title: string;
-  detail: string;
-  repositoryName: string;
-  occurredAt: string;
-  receivedAt: string;
-  readAt?: string;
-  url: string;
-  workspaceId?: string;
-  target: CodeDeliveryNotificationTarget;
-};
-
 const LEGACY_DEFAULT_NOTIFICATION_RULES: CodeDeliveryNotificationRule[] = [
   {
     id: "pull_request_attention",
@@ -151,8 +120,6 @@ type StoredCodeDeliveryState = {
   excludedRegisteredRepoIds: string[];
   pinnedRepositoryKeys: string[];
   savedViews: CodeDeliverySavedView[];
-  notifications: CodeDeliveryNotification[];
-  seenFingerprints: Record<string, string>;
   lastPollAt: string | null;
   knownAuthors: CodeDeliveryAuthor[];
 };
@@ -166,6 +133,7 @@ type PersistedCodeDeliveryState = StoredCodeDeliveryState & {
 type HydratedCodeDeliveryState = StoredCodeDeliveryState & {
   /** Old rules stay here until every mapped server trigger is armed. */
   legacyNotificationRules: CodeDeliveryNotificationRule[] | null;
+  notificationRulesMigrated: boolean;
 };
 
 type CodeDeliveryStore = HydratedCodeDeliveryState & {
@@ -192,23 +160,13 @@ type CodeDeliveryStore = HydratedCodeDeliveryState & {
   completeNotificationRuleMigration: (
     rules: CodeDeliveryNotificationRule[],
   ) => void;
-  ingestDeliveryPoll: (
-    pullRequests: readonly CodeDeliveryPullRequestSummary[],
-    runs: readonly CodeDeliveryRunSummary[],
-    receivedAt?: string,
-  ) => number;
   completeDeliveryPoll: (
     pullRequests: readonly CodeDeliveryPullRequestSummary[],
     runs: readonly CodeDeliveryRunSummary[],
     at: string,
-  ) => number;
+  ) => void;
   rememberDeliveryAuthors: (authors: readonly CodeDeliveryAuthor[]) => void;
-  markNotificationRead: (id: string, read?: boolean) => void;
-  markAllNotificationsRead: () => void;
-  clearNotifications: () => void;
   setPollState: (polling: boolean, error?: string | null) => void;
-  finishPoll: (at: string) => void;
-  reset: () => void;
 };
 
 function emptyPersistedState(): HydratedCodeDeliveryState {
@@ -217,11 +175,10 @@ function emptyPersistedState(): HydratedCodeDeliveryState {
     excludedRegisteredRepoIds: [],
     pinnedRepositoryKeys: [],
     savedViews: [],
-    notifications: [],
-    seenFingerprints: {},
     lastPollAt: null,
     knownAuthors: [],
     legacyNotificationRules: null,
+    notificationRulesMigrated: false,
   };
 }
 
@@ -244,13 +201,13 @@ function persist(state: CodeDeliveryStore): string | null {
     excludedRegisteredRepoIds: state.excludedRegisteredRepoIds,
     pinnedRepositoryKeys: state.pinnedRepositoryKeys,
     savedViews: state.savedViews,
-    notifications: state.notifications,
-    seenFingerprints: state.seenFingerprints,
     lastPollAt: state.lastPollAt,
     knownAuthors: state.knownAuthors,
     ...(state.legacyNotificationRules
       ? { notificationRules: state.legacyNotificationRules }
-      : { notificationRulesMigrated: true }),
+      : state.notificationRulesMigrated
+        ? { notificationRulesMigrated: true }
+        : {}),
   };
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
@@ -393,29 +350,11 @@ export const useCodeDeliveryStore = create<CodeDeliveryStore>()((set, get) => {
     },
     completeNotificationRuleMigration: (rules) => {
       if (get().legacyNotificationRules !== rules) return;
-      set({ legacyNotificationRules: null });
+      set({ legacyNotificationRules: null, notificationRulesMigrated: true });
       persistCurrent();
     },
-    ingestDeliveryPoll: (
-      pullRequests,
-      runs,
-      receivedAt = new Date().toISOString(),
-    ) => {
-      const next = buildDeliveryPoll(get(), pullRequests, runs, receivedAt);
-      if (next.changed) {
-        set({
-          notifications: next.notifications,
-          seenFingerprints: next.seenFingerprints,
-        });
-        persistCurrent();
-      }
-      return next.added;
-    },
     completeDeliveryPoll: (pullRequests, runs, at) => {
-      const next = buildDeliveryPoll(get(), pullRequests, runs, at);
       set({
-        notifications: next.notifications,
-        seenFingerprints: next.seenFingerprints,
         knownAuthors: mergeKnownAuthors(
           get().knownAuthors,
           deliveryAuthorSightings(pullRequests, runs),
@@ -426,7 +365,6 @@ export const useCodeDeliveryStore = create<CodeDeliveryStore>()((set, get) => {
         lastSuccessfulPollAt: at,
       });
       persistCurrent();
-      return next.added;
     },
     rememberDeliveryAuthors: (authors) => {
       const merged = mergeKnownAuthors(get().knownAuthors, authors);
@@ -442,63 +380,8 @@ export const useCodeDeliveryStore = create<CodeDeliveryStore>()((set, get) => {
       set({ knownAuthors: merged });
       persistCurrent();
     },
-    markNotificationRead: (id, read = true) => {
-      const at = new Date().toISOString();
-      set({
-        notifications: get().notifications.map((notification) =>
-          notification.id === id
-            ? {
-                ...notification,
-                ...(read ? { readAt: at } : { readAt: undefined }),
-              }
-            : notification,
-        ),
-      });
-      persistCurrent();
-    },
-    markAllNotificationsRead: () => {
-      const at = new Date().toISOString();
-      set({
-        notifications: get().notifications.map((notification) => ({
-          ...notification,
-          readAt: notification.readAt ?? at,
-        })),
-      });
-      persistCurrent();
-    },
-    clearNotifications: () => {
-      set({ notifications: [] });
-      persistCurrent();
-    },
     setPollState: (polling, error = get().monitorError) => {
       set({ polling, monitorError: error });
-    },
-    finishPoll: (at) => {
-      set({
-        polling: false,
-        monitorError: null,
-        lastPollAt: at,
-        lastSuccessfulPollAt: at,
-      });
-      persistCurrent();
-    },
-    reset: () => {
-      repositoryGeneration += 1;
-      repositoryRequest = null;
-      const fresh = emptyPersistedState();
-      set({
-        ...fresh,
-        polling: false,
-        monitorError: null,
-        lastSuccessfulPollAt: null,
-        repositorySnapshot: null,
-        repositoryLoading: false,
-        repositoryError: null,
-        repositoryFetchedAt: null,
-        persistenceError: null,
-        lastPullRequestPages: [],
-      });
-      persistCurrent();
     },
   };
 });
@@ -543,197 +426,10 @@ export function rememberedPullRequestPage(
   return pages.find((page) => page.key === key);
 }
 
-function buildDeliveryPoll(
-  state: Pick<CodeDeliveryStore, "notifications" | "seenFingerprints">,
-  pullRequests: readonly CodeDeliveryPullRequestSummary[],
-  runs: readonly CodeDeliveryRunSummary[],
-  receivedAt: string,
-): {
-  notifications: CodeDeliveryNotification[];
-  seenFingerprints: Record<string, string>;
-  added: number;
-  changed: boolean;
-} {
-  const now = Date.parse(receivedAt);
-  const cutoff = now - MAX_NOTIFICATION_AGE_MS;
-  const seen = { ...state.seenFingerprints };
-  const incoming: CodeDeliveryNotification[] = [];
-
-  for (const pullRequest of pullRequests) {
-    if (Date.parse(pullRequest.updated_at) < cutoff) continue;
-    if (pullRequest.attention_reasons.length > 0) {
-      const fingerprint = [
-        "pr-attention",
-        pullRequest.id,
-        pullRequest.head_sha ?? "",
-        [...pullRequest.attention_reasons].sort().join(","),
-      ].join(":");
-      maybeAddNotification(
-        incoming,
-        seen,
-        pullRequest,
-        fingerprint,
-        receivedAt,
-        {
-          rule: "pull_request_attention",
-          title: `${pullRequest.repository.name_with_owner} #${pullRequest.number} needs attention`,
-          detail: pullRequest.title,
-        },
-      );
-    }
-    if (pullRequest.ready_to_merge) {
-      const fingerprint = [
-        "pr-ready",
-        pullRequest.id,
-        pullRequest.head_sha ?? "",
-      ].join(":");
-      maybeAddNotification(
-        incoming,
-        seen,
-        pullRequest,
-        fingerprint,
-        receivedAt,
-        {
-          rule: "pull_request_ready",
-          title: `${pullRequest.repository.name_with_owner} #${pullRequest.number} is ready`,
-          detail: pullRequest.title,
-        },
-      );
-    }
-  }
-
-  for (const run of runs) {
-    if (
-      Date.parse(run.updated_at) < cutoff ||
-      run.attention_reasons.length === 0
-    ) {
-      continue;
-    }
-    const fingerprint = [
-      "run-failure",
-      run.id,
-      run.run_attempt ?? run.updated_at,
-      run.status,
-      run.conclusion ?? "",
-    ].join(":");
-    maybeAddRunNotification(incoming, seen, run, fingerprint, receivedAt);
-  }
-
-  const notifications = [...incoming, ...state.notifications]
-    .filter((notification) => Date.parse(notification.occurredAt) >= cutoff)
-    .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt))
-    .slice(0, MAX_NOTIFICATIONS);
-  const seenFingerprints = Object.fromEntries(
-    Object.entries(seen)
-      .filter(([, at]) => Date.parse(at) >= cutoff)
-      .sort((left, right) => right[1].localeCompare(left[1]))
-      .slice(0, MAX_SEEN_FINGERPRINTS),
-  );
-  return {
-    notifications,
-    seenFingerprints,
-    added: incoming.length,
-    changed:
-      !sameNotifications(state.notifications, notifications) ||
-      !sameStringRecord(state.seenFingerprints, seenFingerprints),
-  };
-}
-
-function sameNotifications(
-  left: readonly CodeDeliveryNotification[],
-  right: readonly CodeDeliveryNotification[],
-): boolean {
-  return (
-    left.length === right.length &&
-    left.every(
-      (notification, index) =>
-        notification.id === right[index]?.id &&
-        notification.readAt === right[index]?.readAt,
-    )
-  );
-}
-
-function sameStringRecord(
-  left: Record<string, string>,
-  right: Record<string, string>,
-): boolean {
-  const entries = Object.entries(left);
-  return (
-    entries.length === Object.keys(right).length &&
-    entries.every(([key, value]) => right[key] === value)
-  );
-}
-
 function deliveryErrorMessage(error: unknown): string {
   return error instanceof Error
     ? error.message
     : "Could not load GitHub repositories.";
-}
-
-function maybeAddNotification(
-  incoming: CodeDeliveryNotification[],
-  seen: Record<string, string>,
-  pullRequest: CodeDeliveryPullRequestSummary,
-  fingerprint: string,
-  receivedAt: string,
-  copy: {
-    rule: "pull_request_attention" | "pull_request_ready";
-    title: string;
-    detail: string;
-  },
-): void {
-  if (seen[fingerprint]) return;
-  seen[fingerprint] = receivedAt;
-  incoming.push({
-    id: fingerprint,
-    fingerprint,
-    rule: copy.rule,
-    title: copy.title,
-    detail: copy.detail,
-    repositoryName: pullRequest.repository.name_with_owner,
-    occurredAt: pullRequest.updated_at,
-    receivedAt,
-    url: pullRequest.url,
-    ...(pullRequest.workspace_links[0]
-      ? { workspaceId: pullRequest.workspace_links[0].workspace_id }
-      : {}),
-    target: {
-      kind: "pull_request",
-      repository: codeDeliveryRepositoryTarget(pullRequest.repository),
-      number: pullRequest.number,
-    },
-  });
-}
-
-function maybeAddRunNotification(
-  incoming: CodeDeliveryNotification[],
-  seen: Record<string, string>,
-  run: CodeDeliveryRunSummary,
-  fingerprint: string,
-  receivedAt: string,
-): void {
-  if (seen[fingerprint]) return;
-  seen[fingerprint] = receivedAt;
-  incoming.push({
-    id: fingerprint,
-    fingerprint,
-    rule: "run_failure",
-    title: `${run.repository.name_with_owner} ${run.name} failed`,
-    detail: run.conclusion ?? run.status,
-    repositoryName: run.repository.name_with_owner,
-    occurredAt: run.updated_at,
-    receivedAt,
-    url: run.url,
-    ...(run.workspace_links[0]
-      ? { workspaceId: run.workspace_links[0].workspace_id }
-      : {}),
-    target: {
-      kind: "run",
-      repository: codeDeliveryRepositoryTarget(run.repository),
-      runKind: run.kind,
-      id: run.github_id,
-    },
-  });
 }
 
 export function codeDeliveryRepositoryKey(
@@ -786,15 +482,6 @@ export function trackedCodeDeliveryRepositories(
       },
     );
   });
-}
-
-export function unreadCodeDeliveryNotifications(
-  state: Pick<CodeDeliveryStore, "notifications">,
-): number {
-  return state.notifications.reduce(
-    (count, notification) => count + (notification.readAt ? 0 : 1),
-    0,
-  );
 }
 
 /**
@@ -886,27 +573,10 @@ function parsePersistedState(value: unknown): HydratedCodeDeliveryState | null {
   if (!isRecord(value) || value.version !== STORAGE_VERSION) return null;
   const manualRepositories = parseRepositoryRefs(value.manualRepositories);
   const savedViews = parseSavedViews(value.savedViews);
-  const notifications = parseNotifications(value.notifications);
   const rulesMigrated = value.notificationRulesMigrated === true;
   const notificationRules = rulesMigrated
     ? null
     : parseNotificationRules(value.notificationRules);
-  if (
-    !manualRepositories ||
-    !stringArray(value.excludedRegisteredRepoIds) ||
-    !stringArray(value.pinnedRepositoryKeys) ||
-    !savedViews ||
-    !(
-      value.notificationRulesMigrated === undefined ||
-      value.notificationRulesMigrated === true
-    ) ||
-    (!rulesMigrated && !notificationRules) ||
-    !notifications ||
-    !isStringRecord(value.seenFingerprints) ||
-    !(value.lastPollAt === null || typeof value.lastPollAt === "string")
-  ) {
-    return null;
-  }
   const byRule = new Map(
     (notificationRules ?? []).map((rule) => [rule.id, rule]),
   );
@@ -917,19 +587,25 @@ function parsePersistedState(value: unknown): HydratedCodeDeliveryState | null {
   }
   return {
     manualRepositories,
-    excludedRegisteredRepoIds: [...value.excludedRegisteredRepoIds],
-    pinnedRepositoryKeys: [...value.pinnedRepositoryKeys],
+    excludedRegisteredRepoIds: stringArray(value.excludedRegisteredRepoIds)
+      ? [...value.excludedRegisteredRepoIds]
+      : [],
+    pinnedRepositoryKeys: stringArray(value.pinnedRepositoryKeys)
+      ? [...value.pinnedRepositoryKeys]
+      : [],
     savedViews,
-    notifications,
-    seenFingerprints: { ...value.seenFingerprints },
-    lastPollAt: value.lastPollAt,
+    lastPollAt:
+      value.lastPollAt === null || typeof value.lastPollAt === "string"
+        ? value.lastPollAt
+        : null,
     knownAuthors: parseKnownAuthors(value.knownAuthors),
     legacyNotificationRules: rulesMigrated ? null : [...byRule.values()],
+    notificationRulesMigrated: rulesMigrated,
   };
 }
 
-function parseRepositoryRefs(value: unknown): CodeGitHubRepositoryRef[] | null {
-  if (!Array.isArray(value)) return null;
+function parseRepositoryRefs(value: unknown): CodeGitHubRepositoryRef[] {
+  if (!Array.isArray(value)) return [];
   const parsed: CodeGitHubRepositoryRef[] = [];
   for (const item of value) {
     if (
@@ -948,7 +624,7 @@ function parseRepositoryRefs(value: unknown): CodeGitHubRepositoryRef[] | null {
         typeof item.tidebreak_repo_id === "string"
       )
     ) {
-      return null;
+      continue;
     }
     parsed.push({
       host: item.host,
@@ -967,8 +643,8 @@ function parseRepositoryRefs(value: unknown): CodeGitHubRepositoryRef[] | null {
   return parsed;
 }
 
-function parseSavedViews(value: unknown): CodeDeliverySavedView[] | null {
-  if (!Array.isArray(value)) return null;
+function parseSavedViews(value: unknown): CodeDeliverySavedView[] {
+  if (!Array.isArray(value)) return [];
   const views: CodeDeliverySavedView[] = [];
   for (const item of value) {
     if (
@@ -978,11 +654,11 @@ function parseSavedViews(value: unknown): CodeDeliverySavedView[] | null {
       !nonEmpty(item.createdAt) ||
       !isRecord(item.filters)
     ) {
-      return null;
+      continue;
     }
     if (item.kind === "pull_requests") {
       const filters = parsePrFilters(item.filters);
-      if (!filters) return null;
+      if (!filters) continue;
       views.push({
         id: item.id,
         kind: item.kind,
@@ -992,7 +668,7 @@ function parseSavedViews(value: unknown): CodeDeliverySavedView[] | null {
       });
     } else if (item.kind === "runs") {
       const filters = parseRunFilters(item.filters);
-      if (!filters) return null;
+      if (!filters) continue;
       views.push({
         id: item.id,
         kind: item.kind,
@@ -1001,7 +677,7 @@ function parseSavedViews(value: unknown): CodeDeliverySavedView[] | null {
         filters,
       });
     } else {
-      return null;
+      continue;
     }
   }
   return views;
@@ -1086,8 +762,8 @@ function parseRunFilters(
 
 function parseNotificationRules(
   value: unknown,
-): CodeDeliveryNotificationRule[] | null {
-  if (!Array.isArray(value)) return null;
+): CodeDeliveryNotificationRule[] {
+  if (!Array.isArray(value)) return [];
   const rules: CodeDeliveryNotificationRule[] = [];
   for (const item of value) {
     if (
@@ -1097,7 +773,7 @@ function parseNotificationRules(
       !stringArray(item.repositoryKeys) ||
       typeof item.tidebreakLinkedOnly !== "boolean"
     ) {
-      return null;
+      continue;
     }
     rules.push({
       id: item.id,
@@ -1107,90 +783,6 @@ function parseNotificationRules(
     });
   }
   return rules;
-}
-
-function parseNotifications(value: unknown): CodeDeliveryNotification[] | null {
-  if (!Array.isArray(value)) return null;
-  const notifications: CodeDeliveryNotification[] = [];
-  for (const item of value) {
-    if (
-      !isRecord(item) ||
-      !nonEmpty(item.id) ||
-      !nonEmpty(item.fingerprint) ||
-      !isRuleKind(item.rule) ||
-      !nonEmpty(item.title) ||
-      typeof item.detail !== "string" ||
-      !nonEmpty(item.repositoryName) ||
-      !nonEmpty(item.occurredAt) ||
-      !nonEmpty(item.receivedAt) ||
-      !(item.readAt === undefined || typeof item.readAt === "string") ||
-      !nonEmpty(item.url) ||
-      !(
-        item.workspaceId === undefined || typeof item.workspaceId === "string"
-      ) ||
-      !isRecord(item.target)
-    ) {
-      return null;
-    }
-    const target = parseNotificationTarget(item.target);
-    if (!target) return null;
-    notifications.push({
-      id: item.id,
-      fingerprint: item.fingerprint,
-      rule: item.rule,
-      title: item.title,
-      detail: item.detail,
-      repositoryName: item.repositoryName,
-      occurredAt: item.occurredAt,
-      receivedAt: item.receivedAt,
-      url: item.url,
-      target,
-      ...(item.readAt !== undefined ? { readAt: item.readAt } : {}),
-      ...(item.workspaceId !== undefined
-        ? { workspaceId: item.workspaceId }
-        : {}),
-    });
-  }
-  return notifications;
-}
-
-function parseNotificationTarget(
-  value: Record<string, unknown>,
-): CodeDeliveryNotificationTarget | null {
-  if (!isRecord(value.repository)) return null;
-  const repository = value.repository;
-  if (
-    !nonEmpty(repository.host) ||
-    !nonEmpty(repository.owner) ||
-    !nonEmpty(repository.name)
-  ) {
-    return null;
-  }
-  const targetRepository = {
-    host: repository.host,
-    owner: repository.owner,
-    name: repository.name,
-  };
-  if (value.kind === "pull_request" && Number.isSafeInteger(value.number)) {
-    return {
-      kind: "pull_request",
-      repository: targetRepository,
-      number: value.number as number,
-    };
-  }
-  if (
-    value.kind === "run" &&
-    (value.runKind === "workflow_run" || value.runKind === "deployment") &&
-    Number.isSafeInteger(value.id)
-  ) {
-    return {
-      kind: "run",
-      repository: targetRepository,
-      runKind: value.runKind,
-      id: value.id as number,
-    };
-  }
-  return null;
 }
 
 function isRuleKind(value: unknown): value is CodeDeliveryNotificationRuleKind {
@@ -1204,13 +796,6 @@ function isRuleKind(value: unknown): value is CodeDeliveryNotificationRuleKind {
 function stringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === "string")
-  );
-}
-
-function isStringRecord(value: unknown): value is Record<string, string> {
-  return (
-    isRecord(value) &&
-    Object.values(value).every((item) => typeof item === "string")
   );
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStoreMigration.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryStoreMigration.test.ts
@@ -30,32 +30,29 @@ function legacyState() {
         tidebreakLinkedOnly: false,
       },
     ],
-    notifications: [
-      {
-        id: "run-failure:1",
-        fingerprint: "run-failure:1",
-        rule: "run_failure",
-        title: "CI failed",
-        detail: "failure",
-        repositoryName: "brightwave-inc/tidebreak",
-        occurredAt: "2026-08-28T12:00:00Z",
-        receivedAt: "2026-08-28T12:00:01Z",
-        url: "https://github.com/brightwave-inc/tidebreak/actions/runs/1",
-        target: {
-          kind: "run",
-          repository: {
-            host: "github.com",
-            owner: "brightwave-inc",
-            name: "tidebreak",
-          },
-          runKind: "workflow_run",
-          id: 1,
-        },
-      },
-    ],
-    seenFingerprints: { "run-failure:1": "2026-08-28T12:00:01Z" },
+    notifications: [{ id: "legacy-client-row" }],
+    seenFingerprints: { "legacy-client-row": "2026-08-28T12:00:01Z" },
     lastPollAt: "2026-08-28T12:00:01Z",
     knownAuthors: [{ login: "mara" }],
+  };
+}
+
+function pullRequestView(id: string) {
+  return {
+    id,
+    kind: "pull_requests",
+    name: `View ${id}`,
+    createdAt: "2026-08-28T12:00:00Z",
+    filters: {
+      search: "",
+      repositoryKeys: [],
+      states: ["open"],
+      reviewStates: [],
+      checkStates: [],
+      authors: [],
+      attentionOnly: false,
+      readyOnly: false,
+    },
   };
 }
 
@@ -80,16 +77,18 @@ describe("delivery notification rule migration storage", () => {
     const rules = useCodeDeliveryStore.getState().legacyNotificationRules;
 
     expect(rules).toHaveLength(3);
-    useCodeDeliveryStore.getState().markAllNotificationsRead();
+    useCodeDeliveryStore
+      .getState()
+      .rememberDeliveryAuthors([{ login: "devon" }]);
     expect(
       JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}"),
-    ).toMatchObject({
-      notificationRules: legacyState().notificationRules,
-      notifications: [{ id: "run-failure:1" }],
-      seenFingerprints: {
-        "run-failure:1": "2026-08-28T12:00:01Z",
-      },
-    });
+    ).toMatchObject({ notificationRules: legacyState().notificationRules });
+    expect(
+      JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}"),
+    ).not.toHaveProperty("notifications");
+    expect(
+      JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}"),
+    ).not.toHaveProperty("seenFingerprints");
 
     expect(rules).not.toBeNull();
     useCodeDeliveryStore.getState().completeNotificationRuleMigration(rules!);
@@ -98,10 +97,6 @@ describe("delivery notification rule migration storage", () => {
     );
     expect(migrated.notificationRulesMigrated).toBe(true);
     expect(migrated).not.toHaveProperty("notificationRules");
-    expect(migrated.notifications[0].id).toBe("run-failure:1");
-    expect(migrated.seenFingerprints).toEqual({
-      "run-failure:1": "2026-08-28T12:00:01Z",
-    });
 
     const reloaded = await loadStore();
     expect(
@@ -109,15 +104,74 @@ describe("delivery notification rule migration storage", () => {
     ).toBeNull();
   });
 
-  it("does not invent legacy rules when no saved state exists", async () => {
+  it("does not invent migration completion when no saved state exists", async () => {
     const { useCodeDeliveryStore } = await loadStore();
 
     expect(useCodeDeliveryStore.getState().legacyNotificationRules).toBeNull();
-    useCodeDeliveryStore.getState().finishPoll("2026-08-29T12:00:00Z");
+    useCodeDeliveryStore
+      .getState()
+      .completeDeliveryPoll([], [], "2026-08-29T12:00:00Z");
     const persisted = JSON.parse(
       window.localStorage.getItem(STORAGE_KEY) ?? "{}",
     );
-    expect(persisted.notificationRulesMigrated).toBe(true);
+    expect(persisted).not.toHaveProperty("notificationRulesMigrated");
     expect(persisted).not.toHaveProperty("notificationRules");
+  });
+
+  it("drops one bad saved-view row while keeping every other field", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        ...legacyState(),
+        manualRepositories: [
+          {
+            host: "github.com",
+            owner: "brightwave-inc",
+            name: "tidebreak",
+            name_with_owner: "brightwave-inc/tidebreak",
+            url: "https://github.com/brightwave-inc/tidebreak",
+          },
+        ],
+        pinnedRepositoryKeys: ["github.com/brightwave-inc/tidebreak"],
+        savedViews: [
+          pullRequestView("kept"),
+          { ...pullRequestView("bad"), filters: null },
+        ],
+      }),
+    );
+
+    const { useCodeDeliveryStore } = await loadStore();
+    const state = useCodeDeliveryStore.getState();
+    expect(state.savedViews.map((view) => view.id)).toEqual(["kept"]);
+    expect(state.manualRepositories).toHaveLength(1);
+    expect(state.pinnedRepositoryKeys).toEqual([
+      "github.com/brightwave-inc/tidebreak",
+    ]);
+    expect(state.knownAuthors).toEqual([{ login: "mara" }]);
+    expect(state.legacyNotificationRules).toHaveLength(3);
+  });
+
+  it("ignores a corrupt notification row without marking migration complete", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        ...legacyState(),
+        notifications: [{ id: null }],
+      }),
+    );
+
+    const { useCodeDeliveryStore } = await loadStore();
+    const rules = useCodeDeliveryStore.getState().legacyNotificationRules;
+    expect(rules).toHaveLength(3);
+
+    useCodeDeliveryStore
+      .getState()
+      .rememberDeliveryAuthors([{ login: "devon" }]);
+    const persisted = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY) ?? "{}",
+    );
+    expect(persisted).not.toHaveProperty("notificationRulesMigrated");
+    expect(persisted.notificationRules).toHaveLength(3);
+    expect(persisted).not.toHaveProperty("notifications");
   });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import { renderWithRouter } from "@/test/router";
 import { useCodeCatalogStore } from "./CodeCatalogStore";
-import { useCodeDeliveryStore } from "./CodeDeliveryStore";
+import { resetCodeDeliveryHostState } from "./CodeDeliveryStore";
 import { DEFAULT_RAIL_PREFS, useCodeUiStore } from "./CodeUiStore";
 import { disconnectCodeUpdates, useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { CodeSidebar } from "./CodeSidebar";
@@ -152,7 +152,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   useCodeCatalogStore.getState().reset();
-  useCodeDeliveryStore.getState().reset();
+  resetCodeDeliveryHostState();
   disconnectCodeUpdates();
   useCodeUpdatesStore.getState().reset();
   useCodeUiStore.setState({

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -22,7 +22,10 @@ import type {
 import { CodeArchivePage } from "@/code/CodeArchivePage";
 import { useCodeCatalogStore } from "@/code/CodeCatalogStore";
 import { CodeDeliveryPage } from "@/code/CodeDeliveryPage";
-import { useCodeDeliveryStore } from "@/code/CodeDeliveryStore";
+import {
+  resetCodeDeliveryHostState,
+  useCodeDeliveryStore,
+} from "@/code/CodeDeliveryStore";
 import { DEFAULT_RAIL_PREFS, useCodeUiStore } from "@/code/CodeUiStore";
 import {
   disconnectCodeUpdates,
@@ -435,7 +438,7 @@ function resetStoryState(_scenario: DeliveryScenario): void {
   disconnectCodeUpdates();
   useCodeCatalogStore.getState().reset();
   useCodeUpdatesStore.getState().reset();
-  useCodeDeliveryStore.getState().reset();
+  resetCodeDeliveryHostState();
   useCodeUiStore.setState({
     railPrefs: DEFAULT_RAIL_PREFS,
     reviewSidebarOpen: false,
@@ -473,7 +476,7 @@ function DeliveryCenterStory({
   useEffect(
     () => () => {
       useCodeCatalogStore.getState().reset();
-      useCodeDeliveryStore.getState().reset();
+      resetCodeDeliveryHostState();
       useCodeUpdatesStore.getState().reset();
     },
     [],


### PR DESCRIPTION
## Items

1. Parsed persisted Delivery state field-by-field, retaining valid repositories, pins, views, authors, and legacy rules while dropping malformed rows; migration completion is now persisted only after real rules migrate or an existing completion flag is read.
2. Removed the dead client-side Delivery notification state, fingerprint cache, builders, actions, selector, parsing, serialization, and tests; legacy keys are ignored on read and omitted on the next persist.
3. Removed the test-only `ingestDeliveryPoll` duplicate; the remaining poll behavior is exercised through `completeDeliveryPoll`.
4. Removed the persisting Delivery `reset` action and changed Delivery Center stories to reset only host-derived state, so Storybook no longer erases developer preferences.
5. Removed the test-only `finishPoll` action and retargeted the migration test to `completeDeliveryPoll`.
6. Cleared `polling` on stale-generation and aborted exits, and made the five-page monitor limit real by carrying cursors and accumulated rows across immediate follow-up passes; very large aggregates therefore refresh across several bounded passes.

## Additional consumer change

- `src/code/CodeSidebar.dom.test.tsx`: replaced its deleted `reset()` test cleanup call with `resetCodeDeliveryHostState()`.

## Skipped

- None. Item 4's production-caller claim held; grep also found the test-only cleanup caller listed above, which required the minimal consumer update.

## Checks

- `pnpm install --frozen-lockfile`: `Done in 27.1s using pnpm v10.18.3`
- `pnpm exec biome format --write src`: `Formatted 925 files in 1093ms. Fixed 1 file.`
- `pnpm exec biome format src`: `Checked 925 files in 910ms. No fixes applied.`
- `pnpm lint`: `Checked 925 files in 1230ms. No fixes applied.`
- `pnpm test`: `Test Files 286 passed (286)` / `Tests 2521 passed (2521)` / `Duration 265.03s (environment 42%, import 24%, setup 18%, tests 11%, transform 5%)`
- `pnpm build`: `✓ built in 8.52s`
- `pnpm storybook:build`: `└ Storybook build completed successfully`
