### PR TITLE
fix(harness): decode stream chunks at line boundaries and close adapter gaps from the audit

### DIFF
--- a/crates/tidebreak-harness/src/budget.rs
+++ b/crates/tidebreak-harness/src/budget.rs
@@ -2,6 +2,8 @@
 //!
 //! Parsing is O(new bytes). Overflow is counted, never silently dropped.
 
+use std::borrow::Cow;
+
 /// Default chunk size for one read from an engine pipe.
 pub const DEFAULT_CHUNK_SIZE: usize = 8_192;
 /// Default number of chunks processed before yielding.
@@ -42,7 +44,7 @@ pub struct BudgetTick {
 /// Partial-line buffer with a hard cap. Overflow is counted.
 #[derive(Debug, Default)]
 pub struct StreamLineBuffer {
-    pending: String,
+    pending: Vec<u8>,
     /// Whether the line currently being buffered has already hit the cap, so
     /// the rest of it is dropped until its newline arrives.
     overflowing: bool,
@@ -57,20 +59,19 @@ impl StreamLineBuffer {
         Self::default()
     }
 
-    /// Push `bytes` (lossy UTF-8) and take any complete lines.
+    /// Push `bytes` and take complete lines, decoding only at line boundaries.
     ///
     /// A line longer than `budget.max_partial_line` is emitted truncated at
     /// its cap once its newline arrives, and the bytes beyond the cap are
     /// counted as overflow. The stream keeps flowing either way: one oversized
     /// line must never stop later lines from being delivered.
     pub fn push(&mut self, bytes: &[u8], budget: StreamBudget) -> BudgetTick {
-        let incoming = String::from_utf8_lossy(bytes);
-        let mut rest: &str = incoming.as_ref();
+        let mut rest = bytes;
         let mut lines = Vec::new();
         let mut overflow_chunks = 0;
 
         while !rest.is_empty() {
-            let (segment, tail) = match rest.find('\n') {
+            let (segment, tail) = match rest.iter().position(|byte| *byte == b'\n') {
                 Some(idx) => (&rest[..idx], Some(&rest[idx + 1..])),
                 None => (rest, None),
             };
@@ -83,27 +84,31 @@ impl StreamLineBuffer {
             } else {
                 let room = budget.max_partial_line.saturating_sub(self.pending.len());
                 if segment.len() > room {
-                    let end = crate::text::floor_char_boundary(segment, room);
-                    self.pending.push_str(&segment[..end]);
+                    self.pending.extend_from_slice(&segment[..room]);
+                    if let Err(error) = std::str::from_utf8(&self.pending) {
+                        if error.error_len().is_none() {
+                            self.pending.truncate(error.valid_up_to());
+                        }
+                    }
                     self.overflowing = true;
                     overflow_chunks += 1;
                     self.overflow_chunks += 1;
                 } else {
-                    self.pending.push_str(segment);
+                    self.pending.extend_from_slice(segment);
                 }
             }
 
             match tail {
                 Some(tail) => {
                     let mut line = std::mem::take(&mut self.pending);
-                    if line.ends_with('\r') {
+                    if line.ends_with(b"\r") {
                         line.pop();
                     }
-                    lines.push(line);
+                    lines.push(String::from_utf8_lossy(&line).into_owned());
                     self.overflowing = false;
                     rest = tail;
                 }
-                None => rest = "",
+                None => rest = b"",
             }
         }
 
@@ -115,8 +120,8 @@ impl StreamLineBuffer {
 
     /// Remaining partial line, if any.
     #[must_use]
-    pub fn pending(&self) -> &str {
-        &self.pending
+    pub fn pending(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(&self.pending)
     }
 }
 
@@ -133,6 +138,18 @@ mod tests {
         let tick = buf.push(b"ee\n", StreamBudget::default());
         assert_eq!(tick.lines, ["three"]);
         assert!(buf.pending().is_empty());
+    }
+
+    #[test]
+    fn decodes_a_character_split_across_chunks_at_the_line_boundary() {
+        let mut buf = StreamLineBuffer::new();
+        let emoji = "🙂".as_bytes();
+        assert!(buf
+            .push(&emoji[..2], StreamBudget::default())
+            .lines
+            .is_empty());
+        let tick = buf.push(&[emoji[2], emoji[3], b'\n'], StreamBudget::default());
+        assert_eq!(tick.lines, ["🙂"]);
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/child.rs
+++ b/crates/tidebreak-harness/src/child.rs
@@ -520,9 +520,16 @@ impl ProcessTreeChild {
             };
             let mut guard = ProcessGroupGuard::new(Some(process_group));
             guard.signal(libc::SIGINT)?;
-            sleep(grace).await;
-            guard.kill()?;
-            let status = self.child_mut().wait().await;
+            let status = tokio::select! {
+                status = self.child_mut().wait() => {
+                    guard.kill()?;
+                    status
+                },
+                () = sleep(grace) => {
+                    guard.kill()?;
+                    self.child_mut().wait().await
+                }
+            };
             if status.is_ok() {
                 unregister_spawned_process(self.process_id, &self.process_identity);
                 guard.disarm();
@@ -1446,20 +1453,18 @@ wait
     }
 
     #[tokio::test]
-    async fn cancelling_interrupt_still_escalates_and_closes_descendant_pipes() {
+    async fn interrupt_returns_when_the_leader_exits_before_the_grace_period() {
         let (mut child, mut stdout) = spawn_shell_tree().await;
 
-        let cancelled = timeout(
-            Duration::from_millis(10),
+        let status = timeout(
+            Duration::from_secs(1),
             child.interrupt(Duration::from_secs(5)),
         )
-        .await;
-        assert!(cancelled.is_err(), "interrupt unexpectedly completed");
+        .await
+        .expect("interrupt waited for the full grace period")
+        .unwrap();
+        assert!(!status.success());
         assert_pipe_reaches_eof(&mut stdout).await;
-        timeout(ASSERTION_TIMEOUT, child.wait())
-            .await
-            .expect("cancelled interrupt left the root running")
-            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/tidebreak-harness/src/claude/mod.rs
+++ b/crates/tidebreak-harness/src/claude/mod.rs
@@ -34,8 +34,8 @@ impl ClaudeCodeAdapter {
     }
 }
 
-/// The ladder `claude --effort` takes on the pinned 2.1.234, plus the rung the
-/// engine's own picker appends above it.
+/// The ladder `claude --effort` takes on the pinned Claude Code version, plus
+/// the rung the engine's own picker appends above it.
 ///
 /// `--effort` itself accepts `low, medium, high, xhigh, max`. `Ultra` is
 /// ultracode, which Claude Code presents as the top of the same slider even
@@ -218,13 +218,15 @@ impl HarnessAdapter for ClaudeCodeAdapter {
             resume: CapLevel::Supported,
             streaming_deltas: CapLevel::Supported,
             // Permission flags are documented on the 2.1 line. The product
-            // pins 2.1.234 and offers every mode that pin can honor.
+            // pins the current Claude Code version and offers every mode that
+            // pin can honor.
             structured_approvals: CapLevel::Supported,
             mid_turn_steering: CapLevel::Unknown,
             plan_mode: CapLevel::Supported,
             auto_mode: CapLevel::Supported,
             allow_mode: CapLevel::Supported,
-            // `--effort` is documented on the pinned 2.1.234 `--help`.
+            // `--effort` is documented on the pinned Claude Code version
+            // `--help`.
             reasoning_levels: CapLevel::Supported,
             native_file_change_events: CapLevel::Unknown,
             native_interrupt: CapLevel::Supported,
@@ -253,7 +255,7 @@ impl HarnessAdapter for ClaudeCodeAdapter {
     }
 
     fn reasoning_efforts(&self, probe: &HarnessProbe) -> Vec<ReasoningEffort> {
-        // The ladder reads off the pinned 2.1.234 `--help`. When
+        // The ladder reads off the pinned Claude Code version `--help`. When
         // `capabilities` degrades `reasoning_levels` for an engine off that
         // line, session create refuses every level, so advertising the
         // pinned ladder would offer a control that only fails. The empty
@@ -841,7 +843,8 @@ mod tests {
         };
         let adapter = ClaudeCodeAdapter::new();
 
-        let pinned = probe("2.1.234 (Claude Code)");
+        let pinned_version = crate::pin_for(HarnessKind::ClaudeCode).unwrap().version;
+        let pinned = probe(&format!("{pinned_version} (Claude Code)"));
         assert_eq!(adapter.reasoning_efforts(&pinned), EFFORT_LADDER);
         let models = adapter.list_models(&pinned).await;
         assert!(!models.is_empty());

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -391,7 +391,14 @@ impl EngineChannel {
         let Some(mut child) = child else {
             return Ok(None);
         };
-        let status = child.interrupt(grace).await?;
+        let status = match child.interrupt(grace).await {
+            Ok(status) => status,
+            Err(error) => {
+                let status = child.terminate().await.ok();
+                *self.reaped.lock().expect("claude child exit") = status;
+                return Err(error);
+            }
+        };
         *self.reaped.lock().expect("claude child exit") = Some(status);
         Ok(Some(status))
     }
@@ -996,7 +1003,7 @@ impl ClaudeSession {
             tokio::task::yield_now().await;
         }
         if eof && !reader.lines.pending().is_empty() {
-            let pending = reader.lines.pending().to_owned();
+            let pending = reader.lines.pending().into_owned();
             saw_terminal |= emit_parsed(self, &mut reader.parser, &self.resume_ref, &pending).await;
         }
         if eof {

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -1,7 +1,7 @@
 //! Codex CLI adapter. Secondary tier.
 //!
-//! Process model for 0.147.0: one long-lived `codex app-server --stdio`
-//! JSON-RPC child per session. Chosen over `codex exec --json` because the
+//! Process model for the pinned Codex version: one long-lived
+//! `codex app-server --stdio` JSON-RPC child per session. Chosen over `codex exec --json` because the
 //! installed version's app-server handshake is stable and is the richer
 //! approval channel (`item/commandExecution/requestApproval`).
 
@@ -29,9 +29,9 @@ use crate::{
 const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
 const MODEL_LIST_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Codex CLI adapter. Capabilities below are for the captured version
-/// 0.147.0: verified flags are `Supported`/`Unsupported`; anything not
-/// seen in a fixture is `Unknown`.
+/// Codex CLI adapter. Capabilities below are for the captured protocol line
+/// beginning at 0.147.0: verified flags are `Supported`/`Unsupported`; anything
+/// not seen in a fixture is `Unknown`.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CodexAdapter;
 
@@ -404,8 +404,8 @@ async fn observe_login(
 
 /// The first status-shaped line from either stream, stdout first.
 ///
-/// The pinned 0.147 writes the status line to stderr under the probe's spawn
-/// shape (null stdin, piped stdout), so neither stream alone is authoritative:
+/// The pinned Codex version writes the status line to stderr under the probe's
+/// spawn shape (null stdin, piped stdout), so neither stream alone is authoritative:
 /// a stdout-only read reported "not observed" on signed-in machines. A
 /// non-status first line on one stream does not hide a status line on the
 /// other.
@@ -972,7 +972,7 @@ mod tests {
 
     #[test]
     fn login_status_reads_the_stream_the_cli_writes() {
-        // The pinned 0.147 writes `login status` to stderr when stdin is not
+        // The pinned Codex version writes `login status` to stderr when stdin is not
         // a terminal — the probe's spawn shape — so a stdout-only read
         // reported "not observed" on signed-in machines.
         assert_eq!(

--- a/crates/tidebreak-harness/src/grok/acp.rs
+++ b/crates/tidebreak-harness/src/grok/acp.rs
@@ -16,13 +16,8 @@ const MAX_RPC_LINE: usize = 16 * 1_024 * 1_024;
 
 /// Enable only the version whose bidirectional protocol has captured fixtures.
 pub(crate) fn supports_version(version: &str) -> bool {
-    version
-        .trim()
-        .strip_prefix("grok ")
-        .unwrap_or(version.trim())
-        .split_whitespace()
-        .next()
-        == Some("1.0.13")
+    crate::probe::version_patch_line(Some(version))
+        .is_some_and(|(major, minor, patch)| major == 1 && minor == 0 && patch >= 13)
 }
 
 #[derive(Default)]
@@ -300,6 +295,19 @@ impl GrokSession {
         result
     }
 
+    fn map_resume_error(resuming: bool, error: HarnessError) -> HarnessError {
+        if resuming
+            && (error.to_string().contains("not found")
+                || error.to_string().contains("Failed to restore session"))
+        {
+            HarnessError::ResumeLost(format!(
+                "Grok ACP could not load the stored session: {error}"
+            ))
+        } else {
+            error
+        }
+    }
+
     async fn drive_acp(
         &self,
         input: &TurnInput,
@@ -323,18 +331,7 @@ impl GrokSession {
         let response = self
             .acp_rpc(2, method, params, reader, parser, true)
             .await
-            .map_err(|error| {
-                if resume.is_some()
-                    && (error.to_string().contains("not found")
-                        || error.to_string().contains("Failed to restore session"))
-                {
-                    HarnessError::ResumeLost(format!(
-                        "Grok ACP could not load the stored session: {error}"
-                    ))
-                } else {
-                    error
-                }
-            })?;
+            .map_err(|error| Self::map_resume_error(resume.is_some(), error))?;
         let session_id = match resume {
             Some(id) => id,
             None => response

--- a/crates/tidebreak-harness/src/grok/acp_tests.rs
+++ b/crates/tidebreak-harness/src/grok/acp_tests.rs
@@ -101,16 +101,34 @@ fn captured_acp_updates_keep_command_results_and_terminal_outcomes() {
 }
 
 #[test]
-fn approval_capabilities_are_only_enabled_for_the_captured_pin() {
-    for version in ["1.0.13", "grok 1.0.13 (5e9a58528b76)"] {
+fn approval_capabilities_follow_the_captured_version_line() {
+    for version in ["1.0.13", "1.0.14", "grok 1.0.13 (5e9a58528b76)"] {
         assert!(supports_version(version));
         assert!(refuse_versioned_mode(PermissionMode::Ask, version).is_ok());
         assert!(refuse_versioned_mode(PermissionMode::Plan, version).is_err());
     }
-    for version in ["1.0.4", "1.0.14", "unknown", "1.0.130"] {
+    for version in ["1.0.4", "2.0.0", "unknown", "1.0.12"] {
         assert!(!supports_version(version));
         assert!(refuse_versioned_mode(PermissionMode::Ask, version).is_err());
     }
+}
+
+#[test]
+fn captured_resume_replays_load_model_mode_and_resume_loss() {
+    let frames = frames("acp-resume.ndjson");
+    let methods: Vec<_> = frames
+        .iter()
+        .filter(|frame| frame["direction"] == "client")
+        .filter_map(|frame| frame["value"]["method"].as_str())
+        .collect();
+    for method in ["session/load", "session/set_model", "session/set_mode"] {
+        assert!(methods.contains(&method), "capture is missing {method}");
+    }
+    let mapped = GrokSession::map_resume_error(
+        true,
+        HarnessError::Other("Failed to restore session fixture-session".into()),
+    );
+    assert!(matches!(mapped, HarnessError::ResumeLost(_)));
 }
 
 #[test]

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -23,7 +23,7 @@ use crate::{HarnessAdapter, HarnessError, HarnessProbe, HarnessSession, SessionS
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// The ladder `grok --reasoning-effort` takes through 1.0.4.
+/// The original `grok --reasoning-effort` ladder captured on 1.0.4.
 pub(crate) const EFFORT_LADDER_1_0_4: &[ReasoningEffort] = &[
     ReasoningEffort::Low,
     ReasoningEffort::Medium,
@@ -145,6 +145,10 @@ impl HarnessAdapter for GrokAdapter {
         });
         if !captured_print_auto {
             caps.auto_mode = CapLevel::Unknown;
+        }
+        if crate::probe::off_pinned_line(probe.version.as_deref(), (1, 0)) {
+            caps.structured_approvals = CapLevel::Unknown;
+            caps.plan_mode = CapLevel::Unknown;
         }
         if probe
             .version
@@ -593,6 +597,22 @@ mod tests {
     }
 
     #[test]
+    fn acp_capabilities_continue_on_the_captured_1_0_line() {
+        let caps = GrokAdapter::new().capabilities(&HarnessProbe {
+            found: true,
+            binary_path: None,
+            version: Some("grok 1.0.14".into()),
+            authenticated: Some(true),
+            stderr: String::new(),
+            env: Vec::new(),
+            commands: Vec::new(),
+        });
+        assert_eq!(caps.structured_approvals, CapLevel::Supported);
+        assert_eq!(caps.auto_mode, CapLevel::Supported);
+        assert_eq!(caps.plan_mode, CapLevel::Unsupported);
+    }
+
+    #[test]
     fn auto_posture_degrades_off_the_1_0_line() {
         let caps = GrokAdapter::new().capabilities(&HarnessProbe {
             found: true,
@@ -604,11 +624,11 @@ mod tests {
             commands: Vec::new(),
         });
         assert_eq!(caps.auto_mode, CapLevel::Unknown);
-        // The adapter composes no approval channel or plan flags at any
-        // version, so those verdicts hold.
-        assert_eq!(caps.structured_approvals, CapLevel::Unsupported);
+        // Off the captured version line, unverified approval and plan behavior
+        // degrades to Unknown.
+        assert_eq!(caps.structured_approvals, CapLevel::Unknown);
         assert_eq!(caps.mid_turn_steering, CapLevel::Unsupported);
-        assert_eq!(caps.plan_mode, CapLevel::Unsupported);
+        assert_eq!(caps.plan_mode, CapLevel::Unknown);
         assert_eq!(caps.allow_mode, CapLevel::Supported);
     }
 

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -732,13 +732,22 @@ impl GrokSession {
             let mut chunks_this_tick = 0;
             let mut eof = false;
             while chunks_this_tick < budget.max_chunks_per_tick {
-                match reader.read(&mut chunk).await? {
-                    0 => {
+                match reader.read(&mut chunk).await {
+                    Err(error) => {
+                        if let Some(mut child) = self.child.lock().await.take() {
+                            let _ = child.terminate().await;
+                        }
+                        self.pid.clear();
+                        let _ = stderr_task.await;
+                        return Err(error.into());
+                    }
+                    Ok(0) => {
                         eof = true;
                         break;
                     }
-                    n => {
+                    Ok(n) => {
                         let tick = lines.push(&chunk[..n], budget);
+
                         if tick.overflow_chunks > 0 {
                             warn!(
                                 overflow_chunks = tick.overflow_chunks,
@@ -760,7 +769,7 @@ impl GrokSession {
             tokio::task::yield_now().await;
         }
         if !lines.pending().is_empty() {
-            let pending = lines.pending().to_owned();
+            let pending = lines.pending().into_owned();
             if emit_parsed(&self.spec, &mut parser, &self.resume_ref, &pending).await {
                 saw_terminal = true;
             }

--- a/crates/tidebreak-harness/src/launch.rs
+++ b/crates/tidebreak-harness/src/launch.rs
@@ -28,7 +28,7 @@ const DENIED_EXACT: &[&str] = &[
 ];
 
 /// Bypass mode values that can appear as a `--permission-mode` argument.
-const DENIED_VALUES: &[&str] = &["bypassPermissions"];
+const DENIED_VALUES: &[&str] = &["bypasspermissions"];
 
 /// Whether a composed launch plan may include the engine's bypass flags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -55,7 +55,7 @@ pub fn validate_launch_plan_with(
         return Ok(());
     }
     for arg in &plan.argv {
-        if DENIED_VALUES.contains(&arg.as_str()) {
+        if DENIED_VALUES.contains(&arg.to_ascii_lowercase().as_str()) {
             return Err(BypassFlagError(arg.clone()));
         }
         if arg.starts_with('-') && is_bypass_flag(arg) {
@@ -71,7 +71,7 @@ fn is_bypass_flag(arg: &str) -> bool {
         return true;
     }
     if let Some((_, value)) = arg.split_once('=') {
-        if DENIED_VALUES.contains(&value) {
+        if DENIED_VALUES.contains(&value.to_ascii_lowercase().as_str()) {
             return true;
         }
     }
@@ -122,13 +122,14 @@ mod tests {
             "--always-approve",
             "--yolo",
             "bypassPermissions",
+            "--permission-mode=BypassPermissions",
         ] {
             let err = validate_launch_plan(&plan(&["claude", flag])).unwrap_err();
             assert!(
                 err.0.contains("dangerous")
                     || err.0.contains("always-approve")
                     || err.0.contains("yolo")
-                    || err.0.contains("bypassPermissions"),
+                    || err.0.to_ascii_lowercase().contains("bypasspermissions"),
                 "{flag} => {err}"
             );
         }

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -49,9 +49,9 @@ pub use pin::{
 };
 pub use probe::{
     capture_login_env, display_model_label, env_value, filter_child_env, filter_engine_child_env,
-    infer_listed_default, list_cli_models, observe_version, prefer_gateway_models, probe_shell,
-    resolve_binary, resolve_command_on_path, with_reasoning_efforts, DeclaredBinary, HostEnv,
-    ListedHarnessModel, ProbeCapture, ProbeError,
+    list_cli_models, observe_version, prefer_gateway_models, probe_shell, resolve_binary,
+    resolve_command_on_path, with_reasoning_efforts, DeclaredBinary, HostEnv, ListedHarnessModel,
+    ProbeCapture, ProbeError,
 };
 
 /// Whether some auth mode besides the vendor login a probe observes could
@@ -1420,7 +1420,16 @@ mod tests {
                 for capture in read_dir_sorted(&version.path()) {
                     let path = capture.path();
                     if path.extension().is_some_and(|ext| ext == "ndjson") {
-                        streams.push((name.clone(), path));
+                        // Grok ACP captures are bidirectional JSON-RPC frames, not the
+                        // print-mode stream consumed by `GrokStreamParser`. ACP replay
+                        // coverage lives in `grok::acp_tests`.
+                        let framed_acp = name == "grok"
+                            && path
+                                .file_name()
+                                .is_some_and(|file| file.to_string_lossy().starts_with("acp-"));
+                        if !framed_acp {
+                            streams.push((name.clone(), path));
+                        }
                     }
                 }
             }

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -582,8 +582,10 @@ impl OpencodeSession {
         tokio::spawn(async move {
             let _ = drain_capped(stdout, MAX_STDERR_BYTES).await;
         });
-        tokio::spawn(async move {
-            let _ = drain_capped(stderr, MAX_STDERR_BYTES).await;
+        let stderr_tail = Arc::new(Mutex::new(Vec::new()));
+        let stderr_sink = stderr_tail.clone();
+        let stderr_task = tokio::spawn(async move {
+            drain_capped_into(stderr, MAX_STDERR_BYTES, &stderr_sink).await;
         });
 
         *self.base_url.lock().expect("opencode base url") = format!("http://127.0.0.1:{port}");
@@ -601,7 +603,12 @@ impl OpencodeSession {
             }
             self.child_pid.store(0, Ordering::SeqCst);
             *self.events.lock().await = None;
-            return Err(err);
+            let _ = timeout(Duration::from_secs(1), stderr_task).await;
+            let stderr = {
+                let tail = stderr_tail.lock().expect("opencode stderr");
+                String::from_utf8_lossy(&tail).into_owned()
+            };
+            return Err(HarnessError::Other(format!("{err}; stderr: {stderr}")));
         }
         Ok(())
     }
@@ -617,6 +624,20 @@ impl OpencodeSession {
         let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
         let url = format!("{}/global/health", self.base_url());
         loop {
+            {
+                let mut slot = self.child.lock().await;
+                if let Some(child) = slot.as_mut() {
+                    match child.try_wait() {
+                        Ok(Some(status)) => {
+                            return Err(HarnessError::Other(format!(
+                                "opencode serve exited before /global/health was ready: {status}"
+                            )));
+                        }
+                        Ok(None) => {}
+                        Err(error) => return Err(error.into()),
+                    }
+                }
+            }
             if tokio::time::Instant::now() > deadline {
                 return Err(HarnessError::Other(
                     "timed out waiting for opencode serve /global/health".into(),
@@ -1043,12 +1064,22 @@ async fn drain_capped<R>(mut reader: R, cap: usize) -> String
 where
     R: AsyncReadExt + Unpin,
 {
-    let mut out = Vec::new();
+    let out = Arc::new(Mutex::new(Vec::new()));
+    drain_capped_into(&mut reader, cap, &out).await;
+    let bytes = out.lock().expect("opencode drain").clone();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+async fn drain_capped_into<R>(mut reader: R, cap: usize, out: &Mutex<Vec<u8>>)
+where
+    R: AsyncReadExt + Unpin,
+{
     let mut buf = [0_u8; 4_096];
     loop {
         match reader.read(&mut buf).await {
             Ok(0) | Err(_) => break,
             Ok(n) => {
+                let mut out = out.lock().expect("opencode drain");
                 if out.len() < cap {
                     let room = cap - out.len();
                     out.extend_from_slice(&buf[..n.min(room)]);
@@ -1056,7 +1087,6 @@ where
             }
         }
     }
-    String::from_utf8_lossy(&out).into_owned()
 }
 
 #[cfg(test)]

--- a/crates/tidebreak-harness/src/pin.rs
+++ b/crates/tidebreak-harness/src/pin.rs
@@ -401,7 +401,7 @@ fn verified_managed_node_root(managed_node_root: Option<&Path>) -> Option<&Path>
 /// the first thing npm does is fail to create `/.npm/_logs`, so every install
 /// died before a byte was fetched. The cache lives beside the installs so it
 /// depends on nothing but the data directory.
-pub fn npm_cache_dir(data_dir: &Path) -> PathBuf {
+fn npm_cache_dir(data_dir: &Path) -> PathBuf {
     data_dir.join("tools").join("npm-cache")
 }
 

--- a/crates/tidebreak-harness/src/probe.rs
+++ b/crates/tidebreak-harness/src/probe.rs
@@ -229,7 +229,11 @@ pub fn resolve_command_on_path(name: &str, path: &OsStr) -> Option<PathBuf> {
 /// The command is `$SHELL -ilc '…'` with unique sentinel markers so
 /// profile banners cannot forge the result.
 pub async fn probe_shell(host: &HostEnv, name: &str) -> Result<ProbeCapture, ProbeError> {
-    if name.is_empty() || name.contains(['/', '\\', '\0', '\'', '"', ';', '|', '&']) {
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
         return Err(ProbeError::NotFound(name.to_owned()));
     }
     if let Some(declared) = kind_for_command(name).and_then(|kind| host.declared(kind)) {
@@ -963,7 +967,7 @@ pub async fn list_cli_models(
 }
 
 /// Mark the engine's current model from listing markers or its own env.
-pub fn infer_listed_default(
+fn infer_listed_default(
     models: &mut [ListedHarnessModel],
     env: &[(std::ffi::OsString, std::ffi::OsString)],
 ) {
@@ -1356,6 +1360,23 @@ eval "$cmd"
             harness_versions: Vec::new(),
             declared_binaries: Vec::new(),
             declared_env: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn shell_probe_rejects_non_binary_name_characters() {
+        let host = host_with_path(Path::new("/bin"));
+        for name in [
+            "claude`id`",
+            "$PATH",
+            "tool(name)",
+            "two words",
+            "line\nfeed",
+        ] {
+            assert!(matches!(
+                probe_shell(&host, name).await,
+                Err(ProbeError::NotFound(_))
+            ));
         }
     }
 

--- a/crates/tidebreak-harness/src/wiring.rs
+++ b/crates/tidebreak-harness/src/wiring.rs
@@ -43,8 +43,10 @@ pub struct InferenceWiring<'a> {
 /// those providers rides the caller's grant. Grok takes a custom models
 /// endpoint plus the relay key itself; its CLI reads credentials only from
 /// an auth file, so the grok adapter materializes the key as a
-/// session-scoped `GROK_AUTH_PATH` file. The wired key variable also stays
-/// available to shell tools that borrow credentials through the host.
+/// session-scoped `GROK_AUTH_PATH` file. Codex and Grok also retain the wired
+/// key variable for shell tools that borrow credentials through the host; Claude
+/// and opencode consume the key through their engine-specific authentication
+/// surfaces.
 #[must_use]
 pub fn spawn_wiring(
     kind: HarnessKind,


### PR DESCRIPTION
## Audit items

1. Accumulate raw stream bytes and decode only complete lines, preserving byte caps and adding a split-emoji regression test.
2. Preserve the opencode serve stderr tail, stop health polling when the child exits, and include startup stderr in the error.
3. Retire and record the Claude child outcome before returning an interrupt error.
4. Retire the Grok child and clear its published pid when stdout reading fails.
5. Compare permission-mode deny values case-insensitively and cover `--permission-mode=BypassPermissions`.
6. Race process exit against the interrupt grace timer, while still terminating surviving descendants.
7. Treat Grok ACP 1.0.13+ on the captured 1.0 line consistently, cover 1.0.14, and degrade off-line approval/plan capability claims to Unknown.
8. Skipped: current `main` already filters `PWD` in `compose_serve_plan` at `src/opencode/session.rs:331-334`.
9. Restrict shell-probed binary names to ASCII alphanumerics, `-`, `_`, and `.`, with injection-character coverage.
10. Exclude framed Grok ACP captures from the print-stream parser contract with an explicit comment and replay `acp-resume.ndjson` for load/model/mode and ResumeLost behavior.
11. Refresh stale pin comments, use the Claude pin constant in the pinned-version test, and correct relay-key environment documentation.
12. Make `infer_listed_default` and `npm_cache_dir` private and remove the obsolete re-export.

## Skipped

- Item 7 Plan-mode subclaim: the captured 1.0.13 ACP path explicitly rejects `PermissionMode::Plan` in `refuse_versioned_mode`, so 1.0.14 preserves that existing behavior instead of claiming unsupported capability.
- Item 8: `compose_serve_plan` already contains `key != "PWD"` on current `main`, matching the other adapters.

## Checks

- `cargo fmt --all --check` — passed (no output).
- `cargo clippy -p tidebreak-harness --all-targets --locked -- -D warnings` — blocked before harness linting by 22 existing `tidebreak-core` unused/dead-code errors; final line: `error: could not compile tidebreak-core (lib) due to 22 previous errors`.
- Supplemental `cargo clippy -p tidebreak-harness --all-targets --locked --no-deps -- -D warnings` — harness passed; final line: `Finished dev profile [unoptimized + debuginfo] target(s) in 5.44s`.
- `cargo test -p tidebreak-harness --locked` — 396 passed, 1 failed; persistent failure is `child::unix_process_tree_tests::cancelling_output_collection_kills_a_pipe_owning_descendant` reporting a descendant still visible after cancellation; final line: `error: test failed, to rerun pass -p tidebreak-harness --lib`.
- Focused changed-path tests, including mixed-case bypass, early interrupt exit, ACP 1.0.14, split UTF-8, and ACP resume replay, passed.