### PR TITLE
improve(mobile): attach the advertised machine automatically after pairing

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -42,11 +42,25 @@ Shipping to TestFlight: see [`DEPLOYING.md`](DEPLOYING.md).
    `://callback` (`tidebreak://callback` in production).
 4. The authorization code is exchanged at `{gateway}/oauth/token`. Refresh
    tokens rotate; only `control` and `tidebreak:<hex>` resources are minted.
+5. When the gateway advertised a machine URL, the app attaches to it
+   automatically and lands on the hub. There is no confirm step: attach
+   validation refuses any machine but the paired deployment's own, so
+   confirming a prefilled field decides nothing.
 
 Attach validates the machine URL the same way desktop does, reads
 `/auth/discovery`, derives `tidebreak:<sha256(canonical_url)>` locally, and
 refuses a mismatched echo or a gateway URL that is not the paired deployment.
-`GET /policy` is the authenticated probe.
+`GET /policy` is the authenticated probe. Auto-attach runs exactly this
+sequence — nothing is skipped but the tap.
+
+The Attach screen is the fallback, and it is where the app lands whenever
+auto-attach cannot finish:
+
+- the gateway advertised no `tidebreak_machine_url` (enter one),
+- discovery timed out after 10s — usually a hosted machine on a VPN this phone
+  isn't on, shown with that hint and a Retry,
+- the echo or gateway URL failed validation,
+- or the machine URL needs correcting by hand.
 
 ## Environment variants
 

--- a/mobile/app/attach.tsx
+++ b/mobile/app/attach.tsx
@@ -1,29 +1,34 @@
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
 import { Pressable, Text, TextInput } from "react-native";
 import { Screen, Body, ErrorText } from "../src/components/Screen";
 import {
-  AttachError,
-  REASON_UNREACHABLE,
-  discoverMachine,
-  probePolicy,
-} from "../src/lib/attach";
+  attachFailureFromParams,
+  attachMachine,
+  describeAttachFailure,
+  type AttachFailure,
+  type AttachStage,
+} from "../src/lib/autoAttach";
 import { tokenStore } from "../src/session/runtime";
 import { useSessionStore } from "../src/session/store";
 
-type Stage = "idle" | "discover" | "verify" | "probe";
-
-type Failure =
-  | { kind: "unreachable"; detail: string }
-  | { kind: "error"; message: string };
+type Stage = "idle" | AttachStage;
 
 export default function AttachScreen() {
   const router = useRouter();
+  const params = useLocalSearchParams<{
+    failure?: string | string[];
+    detail?: string | string[];
+  }>();
   const session = useSessionStore((state) => state.session);
   const setSession = useSessionStore((state) => state.setSession);
   const [url, setUrl] = useState(session?.machinePrefillUrl ?? "");
   const [stage, setStage] = useState<Stage>("idle");
-  const [failure, setFailure] = useState<Failure | null>(null);
+  // Auto-attach hands its failure over in route params. Read once: a retry
+  // owns the error state from then on, so the params must not resurrect it.
+  const [failure, setFailure] = useState<AttachFailure | null>(() =>
+    attachFailureFromParams(params),
+  );
 
   const hint = useMemo(() => {
     switch (stage) {
@@ -44,32 +49,16 @@ export default function AttachScreen() {
       return;
     }
     setFailure(null);
-    setStage("discover");
     try {
-      const discovered = await discoverMachine(url, session.gatewayUrl);
-      setStage("verify");
-      setStage("probe");
-      const token = await tokenStore.getAccessToken(discovered.resource);
-      await probePolicy(discovered.baseUrl, token);
-      await tokenStore.update({
-        machine: {
-          baseUrl: discovered.baseUrl,
-          resource: discovered.resource,
-        },
+      const machine = await attachMachine(url, session.gatewayUrl, {
+        getAccessToken: (resource) => tokenStore.getAccessToken(resource),
+        onStage: setStage,
       });
+      await tokenStore.update({ machine });
       setSession(tokenStore.snapshot());
       router.replace("/home");
     } catch (err) {
-      if (err instanceof AttachError && err.reason === REASON_UNREACHABLE) {
-        setFailure({ kind: "unreachable", detail: err.message });
-      } else if (err instanceof AttachError) {
-        setFailure({ kind: "error", message: `${err.stage}: ${err.message}` });
-      } else {
-        setFailure({
-          kind: "error",
-          message: err instanceof Error ? err.message : "Attach failed.",
-        });
-      }
+      setFailure(describeAttachFailure(err));
     } finally {
       setStage("idle");
     }

--- a/mobile/app/pair.tsx
+++ b/mobile/app/pair.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import { useState } from "react";
 import { Pressable, Text, TextInput } from "react-native";
 import { Screen, Body, ErrorText } from "../src/components/Screen";
+import { attachFailureParams, autoAttach } from "../src/lib/autoAttach";
 import {
   buildAuthorizeRequest,
   exchangeAuthorizationCode,
@@ -29,12 +30,15 @@ export default function PairScreen() {
   const router = useRouter();
   const setSession = useSessionStore((state) => state.setSession);
   const [url, setUrl] = useState("");
-  const [busy, setBusy] = useState(false);
+  const [phase, setPhase] = useState<"idle" | "authorizing" | "attaching">(
+    "idle",
+  );
   const [error, setError] = useState<string | null>(null);
+  const busy = phase !== "idle";
 
   async function pair() {
     setError(null);
-    setBusy(true);
+    setPhase("authorizing");
     try {
       const gatewayUrl = validatedBaseUrl(url);
       const meta = await fetchGatewayMeta(gatewayUrl);
@@ -67,11 +71,29 @@ export default function PairScreen() {
         // Identity is shown later from a control-scoped mint.
       }
       setSession(tokenStore.snapshot());
-      router.replace("/attach");
+      // The gateway named a machine and attach validation refuses anything but
+      // that deployment's own, so the confirm screen would be ceremony: run it
+      // here. A failure routes to the Attach screen with its error state.
+      setPhase("attaching");
+      const outcome = await autoAttach(
+        { gatewayUrl, machinePrefillUrl: meta.tidebreak_machine_url ?? undefined },
+        { getAccessToken: (resource) => tokenStore.getAccessToken(resource) },
+      );
+      if (outcome.kind === "attached") {
+        await tokenStore.update({ machine: outcome.machine });
+        setSession(tokenStore.snapshot());
+        router.replace("/home");
+        return;
+      }
+      router.replace(
+        outcome.failure
+          ? { pathname: "/attach", params: attachFailureParams(outcome.failure) }
+          : "/attach",
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Pairing failed.");
     } finally {
-      setBusy(false);
+      setPhase("idle");
     }
   }
 
@@ -92,6 +114,11 @@ export default function PairScreen() {
         onChangeText={setUrl}
         className="rounded-lg border border-border bg-background px-3 py-3 text-base text-foreground"
       />
+      {phase === "attaching" ? (
+        <Text className="text-sm text-info-foreground">
+          Attaching to the machine this gateway advertises…
+        </Text>
+      ) : null}
       {error ? <ErrorText>{error}</ErrorText> : null}
       <Pressable
         disabled={busy || url.trim().length === 0}
@@ -99,7 +126,11 @@ export default function PairScreen() {
         onPress={() => void pair()}
       >
         <Text className="text-center text-base font-medium text-primary-foreground">
-          {busy ? "Opening browser…" : "Continue"}
+          {phase === "attaching"
+            ? "Attaching…"
+            : phase === "authorizing"
+              ? "Opening browser…"
+              : "Continue"}
         </Text>
       </Pressable>
     </Screen>

--- a/mobile/src/lib/autoAttach.test.ts
+++ b/mobile/src/lib/autoAttach.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  advertisedMachineUrl,
+  attachFailureFromParams,
+  attachFailureParams,
+  autoAttach,
+  describeAttachFailure,
+} from "./autoAttach";
+import { AttachError, REASON_UNREACHABLE } from "./attach";
+import { tidebreakMachineResource } from "./resource";
+import type { HttpFetch, HttpResponse } from "./http";
+
+const GATEWAY = "https://gateway.example.test";
+const MACHINE = "https://machine.example.com";
+
+/** Discovery + `/policy` answered the way a healthy paired machine answers. */
+function healthyMachine(overrides: { resource?: string; gatewayUrl?: string } = {}) {
+  const calls: string[] = [];
+  const fetchImpl: HttpFetch = async (url) => {
+    calls.push(url);
+    if (url.endsWith("/auth/discovery")) {
+      return new Response(
+        JSON.stringify({
+          mode: "gateway",
+          gateway_url: overrides.gatewayUrl ?? GATEWAY,
+          resource: overrides.resource ?? tidebreakMachineResource(MACHINE),
+        }),
+        { status: 200 },
+      ) as unknown as HttpResponse;
+    }
+    return new Response("{}", { status: 200 }) as unknown as HttpResponse;
+  };
+  return { fetchImpl, calls };
+}
+
+describe("advertisedMachineUrl", () => {
+  it("treats a missing, null, or blank machine URL as nothing to attach", () => {
+    expect(advertisedMachineUrl(null)).toBeNull();
+    expect(advertisedMachineUrl({})).toBeNull();
+    expect(advertisedMachineUrl({ machinePrefillUrl: "   " })).toBeNull();
+    expect(advertisedMachineUrl({ machinePrefillUrl: ` ${MACHINE} ` })).toBe(
+      MACHINE,
+    );
+  });
+});
+
+describe("autoAttach", () => {
+  it("attaches the advertised machine without a confirm step", async () => {
+    const { fetchImpl, calls } = healthyMachine();
+    const getAccessToken = vi.fn(async () => "machine-token");
+    const outcome = await autoAttach(
+      { gatewayUrl: GATEWAY, machinePrefillUrl: MACHINE },
+      { getAccessToken, fetchImpl },
+    );
+    expect(outcome).toEqual({
+      kind: "attached",
+      machine: {
+        baseUrl: MACHINE,
+        resource: tidebreakMachineResource(MACHINE),
+      },
+    });
+    // The same validation the Attach screen runs, in the same order.
+    expect(calls).toEqual([
+      `${MACHINE}/auth/discovery`,
+      `${MACHINE}/policy`,
+    ]);
+    expect(getAccessToken).toHaveBeenCalledWith(tidebreakMachineResource(MACHINE));
+  });
+
+  it("falls back with no failure when the gateway advertised no machine", async () => {
+    const getAccessToken = vi.fn(async () => "machine-token");
+    const fetchImpl = vi.fn();
+    const outcome = await autoAttach(
+      { gatewayUrl: GATEWAY },
+      { getAccessToken, fetchImpl: fetchImpl as unknown as HttpFetch },
+    );
+    expect(outcome).toEqual({ kind: "manual", failure: null });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the screen's error state when validation refuses the machine", async () => {
+    const { fetchImpl } = healthyMachine({
+      resource:
+        "tidebreak:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
+    const outcome = await autoAttach(
+      { gatewayUrl: GATEWAY, machinePrefillUrl: MACHINE },
+      { getAccessToken: async () => "machine-token", fetchImpl },
+    );
+    expect(outcome.kind).toBe("manual");
+    expect(outcome).toMatchObject({
+      failure: { kind: "error" },
+    });
+  });
+
+  it("falls back to the unreachable state when discovery times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = (() =>
+        new Promise<HttpResponse>(() => {
+          // A machine behind a VPN drops packets; the transport never settles.
+        })) as unknown as HttpFetch;
+      const pending = autoAttach(
+        { gatewayUrl: GATEWAY, machinePrefillUrl: MACHINE },
+        { getAccessToken: async () => "machine-token", fetchImpl },
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+      const outcome = await pending;
+      // Never throws: a dead spinner is the one outcome the caller cannot show.
+      expect(outcome).toMatchObject({
+        kind: "manual",
+        failure: { kind: "unreachable" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("attach failure round-trip", () => {
+  it("carries the unreachable state to the Attach screen's route params", () => {
+    const failure = describeAttachFailure(
+      new AttachError("discover", REASON_UNREACHABLE, "No response after 10 seconds."),
+    );
+    expect(failure).toEqual({
+      kind: "unreachable",
+      detail: "No response after 10 seconds.",
+    });
+    expect(attachFailureFromParams(attachFailureParams(failure))).toEqual(
+      failure,
+    );
+  });
+
+  it("carries a validation failure with its stage prefix", () => {
+    const failure = describeAttachFailure(
+      new AttachError("verify", "resource_mismatch", "Refusing to attach."),
+    );
+    expect(failure).toEqual({
+      kind: "error",
+      message: "verify: Refusing to attach.",
+    });
+    expect(attachFailureFromParams(attachFailureParams(failure))).toEqual(
+      failure,
+    );
+  });
+
+  it("reads no failure from a plain visit to the Attach screen", () => {
+    expect(attachFailureFromParams({})).toBeNull();
+    expect(attachFailureFromParams({ failure: "nonsense" })).toBeNull();
+    // expo-router hands back an array when a param repeats.
+    expect(
+      attachFailureFromParams({ failure: ["error"], detail: ["boom"] }),
+    ).toEqual({ kind: "error", message: "boom" });
+  });
+
+  it("describes a non-AttachError as a plain message", () => {
+    expect(describeAttachFailure(new Error("network down"))).toEqual({
+      kind: "error",
+      message: "network down",
+    });
+    expect(describeAttachFailure("nope")).toEqual({
+      kind: "error",
+      message: "Attach failed.",
+    });
+  });
+});

--- a/mobile/src/lib/autoAttach.ts
+++ b/mobile/src/lib/autoAttach.ts
@@ -1,0 +1,146 @@
+/**
+ * Attaching the machine the paired gateway advertises.
+ *
+ * `GET /api/v1/meta` names `tidebreak_machine_url` when the deployment hosts a
+ * machine. There is no legitimate cross-gateway attach: `discoverMachine`
+ * derives `tidebreak:<sha256(canonical_url)>` locally and refuses a machine
+ * whose discovery echo or `gateway_url` is not the paired deployment. So on the
+ * advertised-URL path a confirm screen adds no decision the user can make, and
+ * pairing runs the sequence itself.
+ *
+ * Everything the Attach screen would have done still runs — same discovery,
+ * same verification, same authenticated probe. Only the tap is gone. When any
+ * of it fails, or when the gateway advertised nothing, the Attach screen is
+ * still the answer, and it renders the failure this module describes.
+ */
+
+import {
+  AttachError,
+  REASON_UNREACHABLE,
+  discoverMachine,
+  probePolicy,
+} from "./attach";
+import type { HttpFetch } from "./http";
+import type { AttachedMachine, PersistedSession } from "./types";
+
+/** What the Attach screen renders when a machine could not be attached. */
+export type AttachFailure =
+  | { kind: "unreachable"; detail: string }
+  | { kind: "error"; message: string };
+
+export type AttachStage = "discover" | "verify" | "probe";
+
+export type AttachDeps = {
+  getAccessToken: (resource: string) => Promise<string>;
+  onStage?: (stage: AttachStage) => void;
+  fetchImpl?: HttpFetch;
+};
+
+/**
+ * Discovery, resource/gateway verification, then the authenticated `/policy`
+ * probe. Persisting the result is the caller's job so this stays a pure
+ * network sequence both the Attach screen and pairing can run.
+ */
+export async function attachMachine(
+  machineUrl: string,
+  gatewayUrl: string,
+  deps: AttachDeps,
+): Promise<AttachedMachine> {
+  deps.onStage?.("discover");
+  const discovered = await discoverMachine(
+    machineUrl,
+    gatewayUrl,
+    deps.fetchImpl,
+  );
+  deps.onStage?.("verify");
+  deps.onStage?.("probe");
+  const token = await deps.getAccessToken(discovered.resource);
+  await probePolicy(discovered.baseUrl, token, deps.fetchImpl);
+  return { baseUrl: discovered.baseUrl, resource: discovered.resource };
+}
+
+/**
+ * The machine URL the gateway advertised at pairing, or null when the
+ * deployment hosts no machine and the user must name one.
+ */
+export function advertisedMachineUrl(
+  session: Pick<PersistedSession, "machinePrefillUrl"> | null,
+): string | null {
+  const advertised = session?.machinePrefillUrl?.trim();
+  return advertised ? advertised : null;
+}
+
+export type AutoAttachOutcome =
+  /** Attached; the caller persists the machine and lands on the hub. */
+  | { kind: "attached"; machine: AttachedMachine }
+  /**
+   * The Attach screen owns it from here. `failure` is null when the gateway
+   * advertised no machine at all — that is not an error, just a URL only the
+   * user knows.
+   */
+  | { kind: "manual"; failure: AttachFailure | null };
+
+/**
+ * The auto-vs-fallback decision. Never throws: an attach that fails is a
+ * routing outcome, not an exception, so the caller cannot strand the user on
+ * a spinner.
+ */
+export async function autoAttach(
+  session: Pick<PersistedSession, "gatewayUrl" | "machinePrefillUrl">,
+  deps: AttachDeps,
+): Promise<AutoAttachOutcome> {
+  const advertised = advertisedMachineUrl(session);
+  if (!advertised) {
+    return { kind: "manual", failure: null };
+  }
+  try {
+    const machine = await attachMachine(advertised, session.gatewayUrl, deps);
+    return { kind: "attached", machine };
+  } catch (error) {
+    return { kind: "manual", failure: describeAttachFailure(error) };
+  }
+}
+
+export function describeAttachFailure(error: unknown): AttachFailure {
+  if (error instanceof AttachError && error.reason === REASON_UNREACHABLE) {
+    return { kind: "unreachable", detail: error.message };
+  }
+  if (error instanceof AttachError) {
+    return { kind: "error", message: `${error.stage}: ${error.message}` };
+  }
+  return {
+    kind: "error",
+    message: error instanceof Error ? error.message : "Attach failed.",
+  };
+}
+
+/**
+ * A failed auto-attach hands the Attach screen its error state through route
+ * params; the URL itself is already the screen's prefill from the session.
+ */
+export function attachFailureParams(
+  failure: AttachFailure,
+): Record<string, string> {
+  return failure.kind === "unreachable"
+    ? { failure: "unreachable", detail: failure.detail }
+    : { failure: "error", detail: failure.message };
+}
+
+export function attachFailureFromParams(params: {
+  failure?: string | string[];
+  detail?: string | string[];
+}): AttachFailure | null {
+  const kind = firstParam(params.failure);
+  const detail = firstParam(params.detail) ?? "Attach failed.";
+  if (kind === "unreachable") {
+    return { kind: "unreachable", detail };
+  }
+  if (kind === "error") {
+    return { kind: "error", message: detail };
+  }
+  return null;
+}
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}


### PR DESCRIPTION
## Problem

Pairing always ended on the Attach screen (title "Machine"), even when the
gateway's unauthenticated `GET /api/v1/meta` advertised a
`tidebreak_machine_url`. The screen came up with that URL already in the field
and the user's only move was to tap **Attach**.

That tap decides nothing. `discoverMachine` derives
`tidebreak:<sha256(canonical_url)>` locally and refuses a machine whose
discovery echo or `gateway_url` isn't the paired deployment, so there is no
cross-gateway attach for the user to confirm or prevent.

## Change

`src/lib/autoAttach.ts` holds the decision and the shared sequence:

- `attachMachine()` — discovery → resource/gateway verification →
  authenticated `/policy` probe. Extracted verbatim from the Attach screen, so
  both callers run identical validation; persisting the result stays with the
  caller.
- `autoAttach()` — returns `attached` or `manual`, and **never throws**: an
  attach that fails is a routing outcome, so no caller can strand the user on a
  spinner.
- `describeAttachFailure()` / `attachFailureParams()` /
  `attachFailureFromParams()` — the Attach screen's error state, carried across
  the redirect in route params.

`app/pair.tsx` runs it right after the token exchange and lands on `/home`.
`app/attach.tsx` keeps its markup and semantics; it now calls the shared
sequence and seeds its error state from the params once (a retry owns it from
then on). The machine URL needs no param — the screen already prefills from
`session.machinePrefillUrl`.

### Fallbacks

Everything that isn't the happy path still routes to the Attach screen, with
the URL prefilled and the failure rendered:

| Case | Lands on |
| --- | --- |
| No advertised machine URL | Attach, no error |
| Discovery timeout (#3295) | Attach, unreachable + VPN hint + Retry |
| Echo / gateway mismatch | Attach, `stage: message` |
| Manual correction | Attach, unchanged |

The #3295 timeout work is integrated, not replaced: `DISCOVERY_TIMEOUT_MS` and
the `REASON_UNREACHABLE` path are what auto-attach races against, and its
distinct VPN-hint rendering is what a timed-out auto-attach shows.

### Progress

The pair screen shows "Attaching to the machine this gateway advertises…" with
an "Attaching…" button label, matching the existing `hint` line on the Attach
screen — the app is never blank between the OAuth redirect and the hub.

Onboarding/welcome and navigation are untouched; the IA pass owns those.
`app/index.tsx` still sends a session without a machine to `/attach`, so a
relaunch mid-flow behaves exactly as before.

## Tests

`src/lib/autoAttach.test.ts`, stubbed transports in the style of the existing
`src/lib/*.test.ts`:

- attaches an advertised machine and asserts the call order
  (`/auth/discovery` then `/policy`) and that the minted resource is the
  derived one;
- no advertised URL → manual fallback with no network touched at all;
- validation refusal (foreign resource echo) → manual with the error state;
- discovery timeout on fake timers → manual with the unreachable state, and
  notably *not* a rejection;
- failure round-trips through route params in both shapes, including
  expo-router's repeated-param array form.

`pnpm typecheck`, `pnpm lint`, and `pnpm test` (23 files, 105 tests) are green
in `mobile/`. JS-only change — no native inputs touched, so the fingerprint
route should be `ota`.

Closes #3316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
