### PR TITLE
fix(code): scope recap material to its turn, publish complete memory indexes, and close grant and fork gaps

### DIFF
--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -288,7 +288,6 @@ async fn execute(client: &Client, command: Command) -> Result<i32> {
                     // report, and printing "no" there reads as broken.
                     HarnessAuthMode::GatewayManaged => "gw",
                     HarnessAuthMode::GatewayRelay => "relay",
-                    HarnessAuthMode::HostedUnavailable => "n/a",
                     HarnessAuthMode::LocalSignIn => match entry.authenticated {
                         Some(true) => "yes",
                         Some(false) => "no",

--- a/crates/tidebreak-core/src/db/ops/code/access.rs
+++ b/crates/tidebreak-core/src/db/ops/code/access.rs
@@ -301,9 +301,12 @@ pub async fn grant_session_access(
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
-    Ok(Some(access_from_row(
-        model.try_into_model().map_err(store_err)?,
-    )?))
+    let row = entities::session_access::Entity::find_by_id((id.0, subject.to_owned()))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store("session access disappeared after grant".into()))?;
+    Ok(Some(access_from_row(row)?))
 }
 
 /// Replace every `external:<channel_kind>:` contribute row on the session
@@ -335,7 +338,7 @@ pub async fn replace_external_session_contributors(
         }
     }
     let mut kept = Vec::new();
-    for identity in identities {
+    for identity in dedupe_identities(identities) {
         let subject = external_subject(channel_kind, identity);
         if !valid_access_subject(&subject) {
             return Err(AgentError::InvalidRequest(format!(
@@ -430,6 +433,14 @@ pub fn valid_access_subject(subject: &str) -> bool {
     })
 }
 
+fn dedupe_identities(identities: &[String]) -> Vec<&String> {
+    let mut seen = std::collections::HashSet::new();
+    identities
+        .iter()
+        .filter(|identity| seen.insert(identity.as_str()))
+        .collect()
+}
+
 fn access_level(value: &str) -> Result<SessionAccessLevel> {
     SessionAccessLevel::from_token(value)
         .ok_or_else(|| AgentError::Store(format!("session access row has unknown level {value}")))
@@ -443,4 +454,19 @@ fn access_from_row(row: entities::session_access::Model) -> Result<SessionAccess
         granted_by: OwnerId::new(&row.granted_by)?,
         created_at: row.created_at,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dedupe_identities;
+
+    #[test]
+    fn duplicate_external_identities_are_kept_once_in_input_order() {
+        let identities = vec!["alice".to_owned(), "bob".to_owned(), "alice".to_owned()];
+        let kept: Vec<_> = dedupe_identities(&identities)
+            .into_iter()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(kept, ["alice", "bob"]);
+    }
 }

--- a/crates/tidebreak-core/src/db/ops/code/grant.rs
+++ b/crates/tidebreak-core/src/db/ops/code/grant.rs
@@ -350,7 +350,7 @@ pub async fn revoke_external_grant_all_owners(
 /// so a storage failure cannot leave a half-revoked workspace.
 pub async fn revoke_external_workspace_grants(
     store: &DbStore,
-    owner: &OwnerId,
+    _owner: &OwnerId,
     channel_kind: &str,
     workspace_identity: &str,
     reason: &str,
@@ -367,7 +367,6 @@ pub async fn revoke_external_workspace_grants(
     }
     let transaction = store.conn.begin().await.map_err(store_err)?;
     let live = entities::code_external_grant::Entity::find()
-        .filter(entities::code_external_grant::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_external_grant::Column::ChannelKind.eq(channel_kind))
         .filter(entities::code_external_grant::Column::WorkspaceIdentity.eq(workspace_identity))
         .filter(entities::code_external_grant::Column::RevokedAt.is_null())

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
@@ -170,22 +170,17 @@ describe("DoctorList", () => {
               found: true,
               authenticated: false,
               auth_mode: "gateway_relay",
-              remediation: "opencode is not available on hosted machines yet.",
             },
           ],
         }}
       />,
     );
 
-    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getAllByText("Ready")).toHaveLength(2);
     expect(
-      screen.getByText("Turns run as you through the Model Gateway."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Unavailable")).toBeInTheDocument();
-    expect(
-      screen.getByText("opencode is not available on hosted machines yet."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("1 of 2 engines ready.")).toBeInTheDocument();
+      screen.getAllByText("Turns run as you through the Model Gateway."),
+    ).toHaveLength(2);
+    expect(screen.getByText("2 of 2 engines ready.")).toBeInTheDocument();
     expect(
       screen.queryByText(
         "No engine is ready yet. Sign in to one below, then re-check.",

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.dom.test.tsx
@@ -169,7 +169,7 @@ describe("DoctorList", () => {
               kind: "opencode",
               found: true,
               authenticated: false,
-              auth_mode: "hosted_unavailable",
+              auth_mode: "gateway_relay",
               remediation: "opencode is not available on hosted machines yet.",
             },
           ],

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -249,12 +249,7 @@ function DoctorRow({
   const downloading = Boolean(install && !install.done && !install.error);
   const failed = Boolean(install?.error);
   const canDownload =
-    Boolean(onInstall) &&
-    !entry.found &&
-    entry.installable &&
-    !downloading &&
-    // Downloading an engine the relay cannot carry would hand the reader a
-    // binary that still cannot run here.
+    Boolean(onInstall) && !entry.found && entry.installable && !downloading;
   // The same install path, pointed at the registry's newest release. Only
   // the server on the `latest` channel ever reports one.
   const canUpdate =

--- a/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/DoctorList.tsx
@@ -170,9 +170,6 @@ function statusBadge(
     return { label: "Gateway-managed", variant: "success" };
   }
   if (isHarnessReady(entry)) return { label: "Ready", variant: "success" };
-  if (entry.auth_mode === "hosted_unavailable") {
-    return { label: "Unavailable", variant: "warning" };
-  }
   // A state, not an instruction — the instruction is the line below it.
   if (entry.found) {
     return entry.authenticated === false
@@ -258,7 +255,6 @@ function DoctorRow({
     !downloading &&
     // Downloading an engine the relay cannot carry would hand the reader a
     // binary that still cannot run here.
-    entry.auth_mode !== "hosted_unavailable";
   // The same install path, pointed at the registry's newest release. Only
   // the server on the `latest` channel ever reports one.
   const canUpdate =

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -134,14 +134,6 @@ describe("harnessUnusableReason", () => {
     expect(isHarnessReady({ found: false, auth_mode: "gateway_relay" })).toBe(
       false,
     );
-    // An engine the relay does not cover can never be ready hosted.
-    expect(
-      isHarnessReady({
-        found: true,
-        authenticated: true,
-        auth_mode: "gateway_relay",
-      }),
-    ).toBe(false);
   });
 
   it("reads a gateway-managed engine as ready without a sign-in", () => {
@@ -172,7 +164,7 @@ describe("harnessUnusableReason", () => {
     ).toBeNull();
   });
 
-  it("gates hosted rows on relay coverage, not a terminal sign-in", () => {
+  it("does not gate hosted rows on a terminal sign-in", () => {
     expect(
       harnessUnusableReason({
         found: true,
@@ -182,15 +174,6 @@ describe("harnessUnusableReason", () => {
         caps: caps("supported", "supported", "supported"),
       }),
     ).toBeNull();
-    expect(
-      harnessUnusableReason({
-        found: true,
-        installable: true,
-        authenticated: true,
-        auth_mode: "gateway_relay",
-        caps: caps("supported", "supported", "supported"),
-      }),
-    ).toBe("Not available on hosted machines yet");
   });
 
   it("names the one reason a picker row cannot be chosen", () => {

--- a/crates/tidebreak-desktop/ui/src/code/labels.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.test.ts
@@ -139,7 +139,7 @@ describe("harnessUnusableReason", () => {
       isHarnessReady({
         found: true,
         authenticated: true,
-        auth_mode: "hosted_unavailable",
+        auth_mode: "gateway_relay",
       }),
     ).toBe(false);
   });
@@ -187,7 +187,7 @@ describe("harnessUnusableReason", () => {
         found: true,
         installable: true,
         authenticated: true,
-        auth_mode: "hosted_unavailable",
+        auth_mode: "gateway_relay",
         caps: caps("supported", "supported", "supported"),
       }),
     ).toBe("Not available on hosted machines yet");

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -164,7 +164,6 @@ export function isHarnessReady(entry: {
   const mode = entry.auth_mode ?? "local_sign_in";
   if (mode === "gateway_relay" || mode === "gateway_managed")
     return entry.found;
-  if (mode === "hosted_unavailable") return false;
   return entry.found && entry.authenticated === true;
 }
 
@@ -202,9 +201,6 @@ export function harnessUnusableReason(entry: {
   caps: ModeCaps;
 }): string | null {
   const mode = entry.auth_mode ?? "local_sign_in";
-  if (mode === "hosted_unavailable") {
-    return "Not available on hosted machines yet";
-  }
   if (!entry.found && !entry.installable) return "Not installed";
   // A relay-covered engine needs no sign-in on a hosted machine, and a
   // gateway-managed one holds credentials its login check cannot see, so the

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -318,7 +318,6 @@ const HARNESS_AUTH_MODES = new Set<HarnessAuthMode>([
   "local_sign_in",
   "gateway_managed",
   "gateway_relay",
-  "hosted_unavailable",
 ]);
 const HARNESS_UPDATE_CHANNELS = new Set<WireHarnessUpdateChannel>([
   "pinned",

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2647,7 +2647,7 @@ export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "sc
 /**
  * How a session of one engine authenticates on this machine.
  */
-export type HarnessAuthMode = "local_sign_in" | "gateway_managed" | "gateway_relay" | "hosted_unavailable";
+export type HarnessAuthMode = "local_sign_in" | "gateway_managed" | "gateway_relay";
 
 /**
  * Capability vector for one probed engine version.

--- a/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
+++ b/crates/tidebreak-desktop/ui/src/stories/fixtures.ts
@@ -761,7 +761,7 @@ export const harnessDoctorHosted: HarnessDoctorReport = {
       version: "1.18.18",
       tier: "tertiary",
       authenticated: false,
-      auth_mode: "hosted_unavailable",
+      auth_mode: "gateway_relay",
       remediation: "opencode is not available on hosted machines yet.",
       caps: { ...fullCaps, allow_mode: "unknown", reasoning_levels: "unknown" },
     }),
@@ -770,7 +770,7 @@ export const harnessDoctorHosted: HarnessDoctorReport = {
       version: "grok 1.0.5",
       tier: "best_effort",
       authenticated: false,
-      auth_mode: "hosted_unavailable",
+      auth_mode: "gateway_relay",
       remediation: "Grok CLI is not available on hosted machines yet.",
       caps: {
         ...fullCaps,

--- a/crates/tidebreak-server-api/fixtures/code-frames.json
+++ b/crates/tidebreak-server-api/fixtures/code-frames.json
@@ -289,7 +289,7 @@
           "version": "2.0.14"
         },
         {
-          "auth_mode": "hosted_unavailable",
+          "auth_mode": "gateway_relay",
           "caps": {
             "allow_mode": "supported",
             "auto_mode": "supported",

--- a/crates/tidebreak-server-api/src/routes/code/harnesses.rs
+++ b/crates/tidebreak-server-api/src/routes/code/harnesses.rs
@@ -9,7 +9,6 @@ use super::types::{
     HarnessModel, HarnessModelList, HarnessModelSource, InstallHarnessQuery,
 };
 use crate::code::harness_label;
-use crate::code::harness_llm::relay_covered;
 use crate::obo_gateway::GatewayCompatModel;
 use tidebreak_core::{CapLevel, HarnessKind};
 
@@ -258,8 +257,6 @@ async fn doctor(code: &ScopedCode) -> Result<HarnessDoctorReport, ServerError> {
             let auth_mode = resolve_auth_mode(hosted, *kind, &probe);
             let remediation = if let Some(err) = install_error {
                 format!("could not download the {kind} binary: {err}")
-            } else if auth_mode == HarnessAuthMode::HostedUnavailable {
-                format!("{label} is not available on hosted machines yet.")
             } else if !probe.found && !installable {
                 format!("this build ships no pinned {kind} binary to download")
             } else if auth_mode == HarnessAuthMode::GatewayRelay {
@@ -335,11 +332,7 @@ fn resolve_auth_mode(
     probe: &tidebreak_harness::HarnessProbe,
 ) -> HarnessAuthMode {
     if hosted {
-        return if relay_covered(kind) {
-            HarnessAuthMode::GatewayRelay
-        } else {
-            HarnessAuthMode::HostedUnavailable
-        };
+        return HarnessAuthMode::GatewayRelay;
     }
     if probe.authenticated != Some(true)
         && tidebreak_harness::observe_auth_mode(kind, &probe.env).is_override()

--- a/crates/tidebreak-server-api/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server-api/src/wire_code_fixtures.rs
@@ -456,7 +456,7 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
                         caps: caps(),
                         commands: Vec::new(),
                         authenticated: None,
-                        auth_mode: HarnessAuthMode::HostedUnavailable,
+                        auth_mode: HarnessAuthMode::GatewayRelay,
                         remediation: "Install grok-build and sign in.".to_owned(),
                         stderr: "grok: command not found".to_owned(),
                         unrecognized_event_count: 2,

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -25,8 +25,8 @@ use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use tidebreak_core::code::SequencedEvent;
 use tidebreak_core::{
-    BlobStore, DocumentBlob, Event, HarnessKind, HarnessNoticeLevel, Session, ToolDetail,
-    ToolOutcome, Turn, TurnId, TurnStatus,
+    BlobStore, DocumentBlob, Event, HarnessNoticeLevel, Session, ToolDetail, ToolOutcome, Turn,
+    TurnId, TurnStatus,
 };
 
 /// Directory holding fork transcripts below the workspace's private root.
@@ -247,12 +247,12 @@ pub(crate) async fn write_transcript(
     let _write = write_lock.lock().await;
     let generation = uuid::Uuid::new_v4();
     let turns = cut.turns;
-    let engine = harness_label(session.harness_kind);
+    let engine = crate::code::harness_label(session.harness_kind);
 
     let scope = super::scratch::scratch_scope(private_root, FORKS_DIR, session.id.0, generation)?;
 
-    let retained_images = plan_attachment_retention(turns);
-    materialize_attachments(&scope, blobs, turns, &retained_images).await?;
+    let mut retained_images = plan_attachment_retention(turns);
+    materialize_attachments(&scope, blobs, turns, &mut retained_images).await?;
 
     let records = render_turn_records(
         private_path,
@@ -340,7 +340,7 @@ fn render_transcript_with_generation(
     retained_images: &HashSet<TurnId>,
     complete_turns: &HashSet<TurnId>,
 ) -> RenderedTranscript {
-    let engine = harness_label(session.harness_kind);
+    let engine = crate::code::harness_label(session.harness_kind);
     let mut sections: Vec<String> = Vec::with_capacity(turns.len());
     for turn in turns {
         sections.push(render_turn(
@@ -479,33 +479,25 @@ async fn materialize_attachments(
     scope: &super::scratch::ScratchScope,
     blobs: &dyn BlobStore,
     turns: &[Turn],
-    retained: &HashSet<TurnId>,
+    retained: &mut HashSet<TurnId>,
 ) -> std::io::Result<()> {
     for turn in turns {
         if !retained.contains(&turn.id) {
             continue;
         }
         for (ordinal, image) in turn.attachments.iter().enumerate() {
-            let bytes = blobs
-                .get(image.blob_id)
-                .await
-                .map_err(|error| std::io::Error::other(format!("read attachment blob: {error}")))?
-                .ok_or_else(|| {
-                    std::io::Error::other(format!(
-                        "fork attachment blob {} is missing",
-                        image.blob_id
-                    ))
-                })?;
+            let Ok(Some(bytes)) = blobs.get(image.blob_id).await else {
+                retained.remove(&turn.id);
+                break;
+            };
             let actual_len = u64::try_from(bytes.len())
                 .map_err(|_| std::io::Error::other("fork attachment length exceeds u64"))?;
             if actual_len != image.byte_len
                 || tidebreak_core::ImageMediaType::sniff(&bytes) != Some(image.media_type)
                 || DocumentBlob::from_bytes(&bytes).id != image.blob_id
             {
-                return Err(std::io::Error::other(format!(
-                    "fork attachment {} does not match its retained descriptor",
-                    image.blob_id
-                )));
+                retained.remove(&turn.id);
+                break;
             }
             let name = fork_attachment_name(turn, ordinal, image);
             scope.publish(std::ffi::OsStr::new(&name), &bytes).await?;
@@ -640,9 +632,7 @@ fn clip(section: &mut String, budget: usize) {
         end -= 1;
     }
     section.truncate(end);
-    if budget > CUT.len() {
-        section.push_str(CUT);
-    }
+    section.push_str(CUT);
 }
 
 /// One reduced turn: the ask's first line, and where the full record is.
@@ -828,6 +818,12 @@ fn turn_lines(turn_id: TurnId, events: &[SequencedEvent]) -> Vec<String> {
                     tool_line(&name, &started, detail.as_ref()),
                     outcome_suffix(outcome)
                 );
+            }
+            Event::HarnessNotice {
+                level: HarnessNoticeLevel::Error,
+                message,
+            } => {
+                lines.push(format!("**Engine notice (error):** {}", message.trim()));
             }
             Event::TurnFailed { error, .. } => {
                 lines.push(format!("**The turn failed:** {}", error.message.trim()));
@@ -1156,22 +1152,13 @@ fn one_line(value: &str) -> String {
 }
 
 /// The engine's name as a person writes it.
-fn harness_label(kind: HarnessKind) -> &'static str {
-    match kind {
-        HarnessKind::ClaudeCode => "Claude Code",
-        HarnessKind::Codex => "Codex CLI",
-        HarnessKind::Opencode => "opencode",
-        HarnessKind::Grok => "Grok CLI",
-        HarnessKind::Internal => "Tidebreak",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use tidebreak_core::{
-        Attention, AttentionSource, BoundedError, FsBlobStore, ImageMediaType, ImageRef, OwnerId,
-        PermissionMode, SessionId, SessionKind, SessionLifecycle, TurnStatus, WorkspaceId,
+        Attention, AttentionSource, BoundedError, FsBlobStore, HarnessKind, ImageMediaType,
+        ImageRef, OwnerId, PermissionMode, SessionId, SessionKind, SessionLifecycle, TurnStatus,
+        WorkspaceId,
     };
 
     fn session() -> Session {
@@ -1647,22 +1634,6 @@ mod tests {
 
     /// Multi-byte text must not be cut through a character. A file the child
     /// engine cannot decode is worse than one that stops early.
-    #[test]
-    fn cuts_on_a_character_boundary() {
-        let session = session();
-        let only = turn(session.id, 1, &"日".repeat(MAX_TRANSCRIPT_BYTES));
-
-        let rendered = render_transcript(&session, &[only], &[]);
-        assert!(rendered.markdown.len() <= MAX_TRANSCRIPT_BYTES);
-        assert!(rendered.truncated);
-        // Round-tripping through bytes proves nothing was cut mid-character:
-        // `String` would not hold it otherwise.
-        assert_eq!(
-            String::from_utf8(rendered.markdown.clone().into_bytes()).expect("valid utf-8"),
-            rendered.markdown
-        );
-    }
-
     /// The record keeps what the summary condenses away: tool output, the
     /// subagent's own calls and words, and the engine's reasoning.
     #[test]

--- a/crates/tidebreak-server/src/code/grants.rs
+++ b/crates/tidebreak-server/src/code/grants.rs
@@ -650,7 +650,7 @@ impl super::runtime::CodeRuntime {
         .await?;
         for grant in &revoked {
             self.grant_revocations().publish(grant.id);
-            self.revoke_gateway_delegation(owner, grant.id).await;
+            self.revoke_gateway_delegation(&grant.owner, grant.id).await;
         }
         Ok(revoked)
     }

--- a/crates/tidebreak-server/src/code/harness_llm.rs
+++ b/crates/tidebreak-server/src/code/harness_llm.rs
@@ -633,26 +633,6 @@ pub fn gh_shim_script(real_gh: &Path, loopback_base: &str, origin_host: &str) ->
     )
 }
 
-/// Whether the on-behalf-of relay can carry this engine's inference.
-///
-/// Exactly the engines [`spawn_wiring`] points at the relay. The doctor reads
-/// this on a gateway-hosted machine, where a covered engine needs no local
-/// sign-in and an uncovered one cannot run at all; everywhere else the local
-/// probe decides, and this answer does not matter.
-pub fn relay_covered(kind: HarnessKind) -> bool {
-    match kind {
-        HarnessKind::ClaudeCode
-        | HarnessKind::Codex
-        | HarnessKind::Opencode
-        | HarnessKind::Grok => true,
-        // The in-process engine never reaches the relay: it resolves
-        // inference through the server's own provider resolution, which on
-        // a hosted machine is the same gateway. Covered, in the sense the
-        // doctor asks about — it needs no local sign-in.
-        HarnessKind::Internal => true,
-    }
-}
-
 fn generate_key() -> String {
     format!("tbreak_hl_{}", uuid::Uuid::new_v4())
 }

--- a/crates/tidebreak-server/src/code/memory.rs
+++ b/crates/tidebreak-server/src/code/memory.rs
@@ -30,7 +30,7 @@ pub(crate) async fn materialize_session_memory(
     owner: &OwnerId,
     repo_id: Option<RepoId>,
     private_root: &ScratchRoot,
-) -> io::Result<PathBuf> {
+) -> io::Result<Option<PathBuf>> {
     let dir = scratch::scratch_dir(private_root, MEMORY_DIR)?;
 
     let mut files: Vec<(String, String)> = Vec::new();
@@ -43,22 +43,22 @@ pub(crate) async fn materialize_session_memory(
         digest_parts.push(personal.markdown);
     }
     if let Some(repo_id) = repo_id {
-        match backend
+        let digest = backend
             .assemble_context(owner, MemoryScope::Repo { repo_id })
             .await
-        {
-            Ok(digest) if !digest.markdown.is_empty() => digest_parts.push(digest.markdown),
-            Ok(_) => {}
-            Err(_) => {}
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        if !digest.markdown.is_empty() {
+            digest_parts.push(digest.markdown);
         }
     }
-    files.push((MEMORY_INDEX.to_owned(), digest_parts.join("\n")));
-
     let mut records = list_active(backend, owner, MemoryScope::Personal).await?;
     if let Some(repo_id) = repo_id {
         records.extend(list_active(backend, owner, MemoryScope::Repo { repo_id }).await?);
     }
-    records.sort_by_key(|record| record.id.0);
+    if digest_parts.is_empty() && records.is_empty() {
+        return Ok(None);
+    }
+    files.push((MEMORY_INDEX.to_owned(), digest_parts.join("\n")));
     for record in records {
         files.push((
             record_file_name(&record),
@@ -74,7 +74,7 @@ pub(crate) async fn materialize_session_memory(
     for (name, body) in files {
         dir.publish(OsStr::new(&name), body.as_bytes()).await?;
     }
-    Ok(memory_dir_path(private_root))
+    Ok(Some(memory_dir_path(private_root)))
 }
 
 async fn list_active(
@@ -137,6 +137,7 @@ mod tests {
         records: Vec<MemoryRecord>,
         /// When set, every read fails, as a store outage would.
         failing: bool,
+        fail_repo_only: bool,
     }
 
     #[async_trait::async_trait]
@@ -186,7 +187,9 @@ mod tests {
             _owner: &OwnerId,
             filter: MemoryListFilter,
         ) -> tidebreak_core::MemoryResult<Vec<MemoryRecord>> {
-            if self.failing {
+            if self.failing
+                && (!self.fail_repo_only || matches!(filter.scope, Some(MemoryScope::Repo { .. })))
+            {
                 return Err(tidebreak_core::MemoryError::Unsupported(
                     tidebreak_core::MemoryCapability::ContextAssembly,
                 ));
@@ -313,16 +316,19 @@ mod tests {
         let backend = FixedBackend {
             records: vec![sample_record()],
             failing: false,
+            fail_repo_only: false,
         };
         let owner = OwnerId::new("user:alice").unwrap();
         let first = materialize_session_memory(&backend, &owner, None, &root)
             .await
+            .unwrap()
             .unwrap();
         let first_index = std::fs::read(first.join(MEMORY_INDEX)).unwrap();
         let first_record =
             std::fs::read(first.join("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.md")).unwrap();
         let second = materialize_session_memory(&backend, &owner, None, &root)
             .await
+            .unwrap()
             .unwrap();
         assert_eq!(
             first_index,
@@ -342,9 +348,11 @@ mod tests {
         let healthy = FixedBackend {
             records: vec![sample_record()],
             failing: false,
+            fail_repo_only: false,
         };
         let dir = materialize_session_memory(&healthy, &owner, None, &root)
             .await
+            .unwrap()
             .unwrap();
         let index = std::fs::read(dir.join(MEMORY_INDEX)).unwrap();
         let record_file = dir.join("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.md");
@@ -353,6 +361,7 @@ mod tests {
         let broken = FixedBackend {
             records: Vec::new(),
             failing: true,
+            fail_repo_only: false,
         };
         materialize_session_memory(&broken, &owner, None, &root)
             .await
@@ -363,6 +372,37 @@ mod tests {
             "the index the first turn named survives a store fault"
         );
         assert!(record_file.exists(), "the record files survive too");
+
+        let broken_repo = FixedBackend {
+            records: vec![sample_record()],
+            failing: true,
+            fail_repo_only: true,
+        };
+        materialize_session_memory(&broken_repo, &owner, Some(RepoId::new()), &root)
+            .await
+            .unwrap_err();
+        assert_eq!(std::fs::read(dir.join(MEMORY_INDEX)).unwrap(), index);
+        assert!(
+            record_file.exists(),
+            "a repo digest fault preserves the tree"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_memory_does_not_publish_an_index() {
+        let temp = TempDir::new().unwrap();
+        let root = ScratchRoot::open_for_test(temp.path()).unwrap();
+        let backend = FixedBackend {
+            records: Vec::new(),
+            failing: false,
+            fail_repo_only: false,
+        };
+        let owner = OwnerId::new("user:alice").unwrap();
+        assert!(materialize_session_memory(&backend, &owner, None, &root)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(!memory_dir_path(&root).join(MEMORY_INDEX).exists());
     }
 
     #[tokio::test]
@@ -376,10 +416,12 @@ mod tests {
         let backend = FixedBackend {
             records: vec![sample_record()],
             failing: false,
+            fail_repo_only: false,
         };
         let owner = OwnerId::new("user:alice").unwrap();
         let written = materialize_session_memory(&backend, &owner, None, &root)
             .await
+            .unwrap()
             .unwrap();
         assert!(written.starts_with(&private));
         assert!(!written.starts_with(&worktree));

--- a/crates/tidebreak-server/src/code/memory_capture.rs
+++ b/crates/tidebreak-server/src/code/memory_capture.rs
@@ -2,7 +2,8 @@
 //!
 //! Shares the recap material builder. Never blocks the turn.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -10,9 +11,9 @@ use serde::{Deserialize, Serialize};
 use tidebreak_core::db::code::{get_session, get_turn, get_workspace, list_recent_events};
 use tidebreak_core::{
     AgentError, DbStore, Event, HarnessNoticeLevel, MemoryAuthor, MemoryBackend, MemoryEvidence,
-    MemoryKind, MemoryOrigin, MemoryProvenance, MemoryRecord, MemoryRecordId, MemoryScope,
-    MemoryStatus, OwnerId, Result, SessionId, TurnId, TurnStatus, MAX_MEMORY_BODY_BYTES,
-    MAX_MEMORY_TITLE_CHARS,
+    MemoryKind, MemoryListFilter, MemoryOrigin, MemoryProvenance, MemoryRecord, MemoryRecordId,
+    MemoryScope, MemoryStatus, OwnerId, Result, SessionId, TurnId, TurnStatus,
+    MAX_MEMORY_BODY_BYTES, MAX_MEMORY_TITLE_CHARS,
 };
 
 use crate::chat_titling::{derive_text_with_retries, Proposal};
@@ -33,8 +34,7 @@ const EVIDENCE_READ_BACKOFF: std::time::Duration = std::time::Duration::from_mil
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct MemoryProposal {
-    #[schemars(length(max = 32))]
-    kind: Option<String>,
+    kind: Option<MemoryKind>,
     #[schemars(length(max = MAX_MEMORY_TITLE_CHARS))]
     title: Option<String>,
     #[schemars(length(max = MAX_MEMORY_BODY_BYTES))]
@@ -48,7 +48,7 @@ impl Proposal for MemoryProposal {
     fn proposed(self) -> Option<String> {
         let title = self.title.filter(|value| !value.trim().is_empty())?;
         let body = self.body.filter(|value| !value.trim().is_empty())?;
-        let kind = self.kind.unwrap_or_else(|| "fact".to_owned());
+        let kind = self.kind.unwrap_or(MemoryKind::Fact);
         serde_json::to_string(&serde_json::json!({
             "kind": kind,
             "title": title,
@@ -84,6 +84,7 @@ pub(crate) struct TurnMemoryCapturer {
     secrets: Arc<dyn tidebreak_core::SecretProvider>,
     provisioned_policy: Arc<dyn crate::managed_policy::ProvisionedPolicySource>,
     os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
+    in_flight: Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
 }
 
 impl TurnMemoryCapturer {
@@ -97,6 +98,7 @@ impl TurnMemoryCapturer {
             secrets: recap.secrets.clone(),
             provisioned_policy: recap.provisioned_policy.clone(),
             os_policy: recap.os_policy.clone(),
+            in_flight: Arc::new(Mutex::new(HashMap::new())),
             recap,
         }
     }
@@ -152,29 +154,14 @@ impl TurnMemoryCapturer {
         else {
             return Ok(());
         };
-        let parsed: serde_json::Value =
-            serde_json::from_str(&payload).unwrap_or(serde_json::Value::Null);
-        let title = parsed
-            .get("title")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("")
-            .trim()
-            .to_owned();
-        let body = parsed
-            .get("body")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("")
-            .trim()
-            .to_owned();
+        let proposal: MemoryProposal = serde_json::from_str(&payload)
+            .map_err(|err| AgentError::msg(format!("parse memory proposal: {err}")))?;
+        let title = proposal.title.unwrap_or_default().trim().to_owned();
+        let body = proposal.body.unwrap_or_default().trim().to_owned();
         if title.is_empty() || body.is_empty() {
             return Ok(());
         }
-        let kind = match parsed.get("kind").and_then(serde_json::Value::as_str) {
-            Some("preference") => MemoryKind::Preference,
-            Some("lesson") => MemoryKind::Lesson,
-            Some("reference") => MemoryKind::Reference,
-            _ => MemoryKind::Fact,
-        };
+        let kind = proposal.kind.unwrap_or(MemoryKind::Fact);
         // A completed turn always has journal rows, but the read can race
         // the journal flush; retry rather than drop a proposal the person
         // would otherwise never see.
@@ -200,6 +187,24 @@ impl TurnMemoryCapturer {
             return Err(AgentError::msg(format!(
                 "no journal evidence for turn {turn_id} after {EVIDENCE_READ_ATTEMPTS} reads"
             )));
+        }
+        let existing = self
+            .db
+            .list(
+                owner,
+                MemoryListFilter {
+                    scope: Some(MemoryScope::Personal),
+                    statuses: Vec::new(),
+                    kinds: Vec::new(),
+                },
+            )
+            .await
+            .map_err(|err| AgentError::msg(format!("list memory proposals: {err}")))?;
+        if existing.iter().any(|record| {
+            record.status != MemoryStatus::Tracking
+                && record.title.trim().eq_ignore_ascii_case(title.trim())
+        }) {
+            return Ok(());
         }
         let now = chrono::Utc::now();
         let record = MemoryRecord {
@@ -265,15 +270,88 @@ impl TurnMemoryCapturer {
 
 impl TurnMemoryCapture for TurnMemoryCapturer {
     fn spawn(&self, owner: OwnerId, session_id: SessionId, turn_id: TurnId) {
+        let Some((mut claim, mut turn_id)) =
+            CaptureClaim::acquire(&self.in_flight, session_id, turn_id)
+        else {
+            return;
+        };
         let capturer = self.clone();
         tokio::spawn(async move {
-            if let Err(error) = capturer.derive(&owner, session_id, turn_id).await {
-                tracing::error!(
-                    "tidebreak: could not capture memory for code turn {turn_id}: {error}"
-                );
-                capturer.report_failure(&owner, session_id, &error).await;
+            loop {
+                if let Err(error) = capturer.derive(&owner, session_id, turn_id).await {
+                    tracing::error!(
+                        "tidebreak: could not capture memory for code turn {turn_id}: {error}"
+                    );
+                    capturer.report_failure(&owner, session_id, &error).await;
+                }
+                let Some(next) = claim.take_pending_or_release() else {
+                    break;
+                };
+                turn_id = next;
             }
         });
+    }
+}
+
+/// A session’s place in `TurnMemoryCapturer::in_flight`, released on drop.
+struct CaptureClaim {
+    in_flight: Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
+    session_id: SessionId,
+    released: bool,
+}
+
+impl CaptureClaim {
+    fn acquire(
+        in_flight: &Arc<Mutex<HashMap<SessionId, Option<TurnId>>>>,
+        session_id: SessionId,
+        turn_id: TurnId,
+    ) -> Option<(Self, TurnId)> {
+        let in_flight = in_flight.clone();
+        let mut guard = in_flight
+            .lock()
+            .expect("memory capture claims are never held across a panic");
+        match guard.entry(session_id) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(None);
+                drop(guard);
+                Some((
+                    Self {
+                        in_flight,
+                        session_id,
+                        released: false,
+                    },
+                    turn_id,
+                ))
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                entry.insert(Some(turn_id));
+                None
+            }
+        }
+    }
+
+    fn take_pending_or_release(&mut self) -> Option<TurnId> {
+        let mut in_flight = self
+            .in_flight
+            .lock()
+            .expect("memory capture claims are never held across a panic");
+        let pending = in_flight.get_mut(&self.session_id).and_then(Option::take);
+        if pending.is_none() {
+            in_flight.remove(&self.session_id);
+            self.released = true;
+        }
+        pending
+    }
+}
+
+impl Drop for CaptureClaim {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        if let Ok(mut in_flight) = self.in_flight.lock() {
+            in_flight.remove(&self.session_id);
+        }
     }
 }
 

--- a/crates/tidebreak-server/src/code/recap.rs
+++ b/crates/tidebreak-server/src/code/recap.rs
@@ -404,6 +404,12 @@ impl TurnRecapper {
         for sequenced in &events {
             match &sequenced.event {
                 Event::TurnStarted { turn_id: started } if *started == turn_id => break,
+                Event::TurnStarted { .. } => {
+                    closing = None;
+                    activity.clear();
+                    worth_recapping = false;
+                    continue;
+                }
                 Event::AssistantMessage {
                     text,
                     parent_call_id: None,

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -128,6 +128,8 @@ impl RemoteSessions {
     /// Whether promotion for `session` is inside a refusal hold.
     pub(crate) fn promotion_held(&self, session: SessionId) -> bool {
         let mut holds = self.promotion_holds.lock().expect("promotion holds");
+        let now = std::time::Instant::now();
+        holds.retain(|_, until| *until > now);
         match holds.get(&session) {
             Some(until) if *until > std::time::Instant::now() => true,
             Some(_) => {
@@ -140,18 +142,18 @@ impl RemoteSessions {
 
     /// Hold promotion for `session` for [`PROMOTION_RETRY_HOLD`].
     pub(crate) fn hold_promotion(&self, session: SessionId) {
-        self.promotion_holds
-            .lock()
-            .expect("promotion holds")
-            .insert(session, std::time::Instant::now() + PROMOTION_RETRY_HOLD);
+        let mut holds = self.promotion_holds.lock().expect("promotion holds");
+        let now = std::time::Instant::now();
+        holds.retain(|_, until| *until > now);
+        holds.insert(session, now + PROMOTION_RETRY_HOLD);
     }
 
     /// Clear a hold after a promotion that went through.
     pub(crate) fn clear_promotion_hold(&self, session: SessionId) {
-        self.promotion_holds
-            .lock()
-            .expect("promotion holds")
-            .remove(&session);
+        let mut holds = self.promotion_holds.lock().expect("promotion holds");
+        let now = std::time::Instant::now();
+        holds.retain(|_, until| *until > now);
+        holds.remove(&session);
     }
 
     /// Make sure `session` has a pump task, spawning one when it has none.

--- a/crates/tidebreak-server/src/code/rewrite.rs
+++ b/crates/tidebreak-server/src/code/rewrite.rs
@@ -226,6 +226,7 @@ impl TurnRewriter {
             return Ok(Outcome::Declined);
         };
         if !set_turn_rewrite(&self.db, owner, turn_id, &rewrite).await? {
+            self.announce(owner, session_id, turn_id, TurnRewriteState::Failed, None);
             return Ok(Outcome::NotApplicable);
         }
         self.announce(
@@ -310,7 +311,7 @@ impl TurnRewrite for TurnRewriter {
                         tracing::info!("tidebreak: rewrote code turn {turn_id}");
                     }
                     Ok(Outcome::Declined) => {
-                        tracing::warn!("tidebreak: left code turn {turn_id} without a rewrite");
+                        tracing::debug!("tidebreak: left code turn {turn_id} without a rewrite");
                     }
                     Ok(Outcome::NotApplicable) => {}
                     Err(error) => {

--- a/crates/tidebreak-server/src/code/runtime/settings.rs
+++ b/crates/tidebreak-server/src/code/runtime/settings.rs
@@ -846,7 +846,7 @@ impl CodeRuntime {
         if probe.authenticated != Some(false) {
             return Ok(());
         }
-        if relay_active && crate::code::harness_llm::relay_covered(harness) {
+        if relay_active {
             return Ok(());
         }
         if tidebreak_harness::auth_override_present(harness, &probe.env) {

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -227,8 +227,7 @@ impl CodeRuntime {
             session.id,
             attached.spawn_epoch,
             session.harness_kind,
-            self.harness_llm.is_some()
-                && crate::code::harness_llm::relay_covered(session.harness_kind),
+            self.harness_llm.is_some(),
             None,
             attached.subagents.clone(),
             self.gh_search_path_owned(),

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -2841,7 +2841,7 @@ async fn drive_turn_inner(
         )
         .await
         {
-            Ok(memory_dir) => Some(memory_dir),
+            Ok(memory_dir) => memory_dir,
             Err(err) => {
                 tracing::warn!(
                     "tidebreak: could not materialize memory for code session {}: {err}",

--- a/crates/tidebreak-server/src/code/titling.rs
+++ b/crates/tidebreak-server/src/code/titling.rs
@@ -99,7 +99,7 @@ pub fn spawn_for_turn(state: &AppState, owner: &OwnerId, session_id: SessionId, 
                 tracing::info!("tidebreak: named a code workspace: {title}");
             }
             Ok(Outcome::Declined) => {
-                tracing::warn!("tidebreak: left a code workspace on its generated name");
+                tracing::debug!("tidebreak: left a code workspace on its generated name");
             }
             Ok(Outcome::NotApplicable) => {}
             Err(error) => {
@@ -126,10 +126,9 @@ async fn derive_workspace_title(
     let Some(workspace_id) = session.workspace_id else {
         return Ok(Outcome::NotApplicable);
     };
-    let Some(claim) = TitlingClaim::acquire(code, workspace_id) else {
+    let Some(_claim) = TitlingClaim::acquire(code, workspace_id) else {
         return Ok(Outcome::NotApplicable);
     };
-    let _held = claim;
     let Some(workspace) = get_workspace(&code.db, owner, workspace_id).await? else {
         return Ok(Outcome::NotApplicable);
     };

--- a/crates/tidebreak-server/src/code/types.rs
+++ b/crates/tidebreak-server/src/code/types.rs
@@ -644,9 +644,6 @@ pub enum HarnessAuthMode {
     /// turns run as the caller through the gateway and no local sign-in is
     /// needed.
     GatewayRelay,
-    /// The relay does not cover this engine yet, so it cannot run on a
-    /// hosted machine.
-    HostedUnavailable,
 }
 
 /// One engine's probe, capabilities, and remediation.

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2647,7 +2647,7 @@ export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "sc
 /**
  * How a session of one engine authenticates on this machine.
  */
-export type HarnessAuthMode = "local_sign_in" | "gateway_managed" | "gateway_relay" | "hosted_unavailable";
+export type HarnessAuthMode = "local_sign_in" | "gateway_managed" | "gateway_relay";
 
 /**
  * Capability vector for one probed engine version.

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -125,7 +125,6 @@ function harnessAuthMode(value: unknown): value is HarnessAuthMode {
     "local_sign_in",
     "gateway_managed",
     "gateway_relay",
-    "hosted_unavailable",
   ].includes(String(value));
 }
 

--- a/mobile/src/lib/codeLaunch.test.ts
+++ b/mobile/src/lib/codeLaunch.test.ts
@@ -62,12 +62,6 @@ describe("mobile code launch choices", () => {
     expect(
       harnessUnavailableReason({
         ...harness,
-        auth_mode: "hosted_unavailable",
-      }),
-    ).toMatch(/hosted machines/);
-    expect(
-      harnessUnavailableReason({
-        ...harness,
         authenticated: false,
         remediation: "Run codex login.",
       }),

--- a/mobile/src/lib/codeLaunch.ts
+++ b/mobile/src/lib/codeLaunch.ts
@@ -64,9 +64,6 @@ export function defaultCreatePermissionMode(
 export function harnessUnavailableReason(
   harness: CodeHarnessOption,
 ): string | null {
-  if (harness.auth_mode === "hosted_unavailable") {
-    return "Not available on hosted machines.";
-  }
   if (!harness.found) {
     return harness.installable
       ? "Install this harness from Tidebreak desktop first."


### PR DESCRIPTION
1. Propagates repository-scope digest failures before publishing and extends the preservation test through the repo path.
2. Returns no memory directory when there are no digests or records, skips the first-turn memory instruction, and removes the redundant record-id sort.
3. Publishes a terminal failed rewrite notice when the rewrite row disappears after derivation.
4. Resets recap material at each newer turn boundary so only the target turn contributes closing text, activity, and progress.
5. Uses `MemoryKind` in the code-capture schema and parses the typed proposal instead of defaulting unknown kind strings to facts.
6. Suppresses already stored titles and serializes per-session code-memory capture with a newest-pending-turn claim.
7. Always emits the fork truncation marker, retains error-level harness notices, uses the shared harness label, and removes the tautological UTF-8 test.
8. Degrades missing, retired, unreadable, or descriptor-mismatched attachment blobs to the existing not-retained transcript treatment.
9. Removes the titling claim rebinding and logs designed rewrite/title declines at debug level.
10. Removes the all-true relay coverage predicate and unreachable hosted-unavailable auth state across server, API, CLI, generated wire, fixtures, and UI. UI files: `DoctorList.tsx`, `DoctorList.dom.test.tsx`, `labels.ts`, `labels.test.ts`, `parsers.ts`, `stories/fixtures.ts`, and `generated/wire.ts`.
11. Prunes expired promotion holds whenever the hold map is read, inserted into, or cleared.
12. Deduplicates external contributor identities in input order before inserting and adds a duplicate-order contract test.
13. Re-reads session access after the upsert so returned `created_at` matches the retained row.
14. Makes workspace-wide administrative revocation find grants under their actual service-principal owners and revokes each owner’s gateway delegation.

Skipped

- None; every claim held in the audited revision.

Checks run

- `cargo fmt --all --check` — passed (no output).
- `cargo clippy -p tidebreak-server-core -p tidebreak-server -p tidebreak-core -p tidebreak-cli --all-targets --locked -- -D warnings` — `Finished dev profile [unoptimized + debuginfo] target(s) in 2m 27s`.
- `cargo test -p tidebreak-server-core --locked code::memory` — `test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1088 filtered out; finished in 2.79s`.
- `cargo test -p tidebreak-server-core --locked code::rewrite` — `test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1091 filtered out; finished in 0.00s`.
- `cargo test -p tidebreak-server-core --locked code::recap` — `test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1087 filtered out; finished in 0.00s`.
- `cargo test -p tidebreak-server-core --locked code::fork` — `test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 1072 filtered out; finished in 0.06s`.
- `cargo test -p tidebreak-server-core --locked code::grants` — `test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1092 filtered out; finished in 2.72s`.
- `cargo test -p tidebreak-core --locked access` — `test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 918 filtered out; finished in 0.00s`.
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --locked wire` — 31 wire tests passed; the additional hosted integration test failed after 128.66s because its request to `http://127.0.0.1:21545/sessions` timed out (`Connection timed out`).
