### PR TITLE
fix(desktop): code session store re-render, badge acquisition, and dead state

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.test.ts
@@ -84,6 +84,28 @@ describe("CodeSessionController", () => {
     controller.dispose();
   });
 
+  it("delivers a frame emitted synchronously while opening the socket", () => {
+    const batches: (readonly SequencedCodeEventFrame[])[] = [];
+    const frame: SequencedCodeEventFrame = {
+      seq: 1,
+      event: { type: "turn_started", turn_id: "turn-1" },
+    };
+    const controller = new CodeSessionController({
+      openSocket: (_after, onFrame) => {
+        onFrame(frame);
+        return new FakeSocket(onFrame) as unknown as WebSocket;
+      },
+      getAfter: () => 0,
+      onEvents: (events) => batches.push(events),
+      onConnectionState: () => undefined,
+    });
+
+    controller.start();
+
+    expect(batches).toEqual([[frame]]);
+    controller.dispose();
+  });
+
   it("reveals the durable snapshot while reconnecting after an initial failure", () => {
     const batches: Array<{
       events: readonly SequencedCodeEventFrame[];

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionController.ts
@@ -77,6 +77,7 @@ export class CodeSessionController {
   private disposed = false;
   private hydrated = false;
   private socket: WebSocket | null = null;
+  private connection: object | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
   private turnRefreshTimer: ReturnType<typeof setTimeout> | null = null;
@@ -195,6 +196,7 @@ export class CodeSessionController {
   /** Close the socket and silence every callback and pending timer, forever. */
   dispose(): void {
     this.disposed = true;
+    this.connection = null;
     this.turnRefreshRequested = false;
     this.cancelReplayFlush();
     this.replayFrames = [];
@@ -317,9 +319,11 @@ export class CodeSessionController {
   private connect(): void {
     if (this.disposed) return;
     let socket: WebSocket;
+    const connection = {};
+    this.connection = connection;
     try {
       socket = this.options.openSocket(this.options.getAfter(), (frame) => {
-        if (this.disposed || this.socket !== socket) return;
+        if (this.disposed || this.connection !== connection) return;
         if (!isWellFormedFrame(frame)) {
           console.error("dropping malformed code event frame", frame);
           return;
@@ -332,13 +336,14 @@ export class CodeSessionController {
         this.options.onEvents([...replay, frame], this.settleInitialView());
       });
     } catch {
+      if (this.connection === connection) this.connection = null;
       this.scheduleReconnect();
       return;
     }
 
     this.socket = socket;
     socket.onopen = () => {
-      if (this.disposed || this.socket !== socket) return;
+      if (this.disposed || this.connection !== connection) return;
       this.reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
       this.options.onConnectionState("live");
       // The protocol has no explicit replay-complete frame. If this session
@@ -352,12 +357,13 @@ export class CodeSessionController {
       }
     };
     socket.onerror = () => {
-      if (this.disposed || this.socket !== socket) return;
+      if (this.disposed || this.connection !== connection) return;
       socket.close();
       this.scheduleReconnect();
     };
     socket.onclose = () => {
-      if (this.socket !== socket) return;
+      if (this.connection !== connection) return;
+      this.connection = null;
       this.socket = null;
       this.scheduleReconnect();
     };

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -9,7 +9,6 @@ import {
   initialCodeSessionState,
   mainAgentTranscriptItems,
   markCodeSessionHydrated,
-  reconcileCodeTurnSnapshot,
   reconcilePendingCodeTurns,
   reduceCodeSessionEvent,
   subagentTranscriptItems,
@@ -192,6 +191,28 @@ describe("seq cursor", () => {
     ).toHaveLength(1);
   });
 
+  it("appends a capped-window notice after retained history on reconnect", () => {
+    const existing = play([
+      { type: "turn_started", turn_id: "t1" },
+      { type: "assistant_delta", text: "Existing history" },
+    ]).state;
+    const reconnected = reduceCodeSessionEvent(
+      existing,
+      {
+        seq: existing.lastSeq + 1,
+        event: { type: "turn_started", turn_id: "t2" },
+        replayed: true,
+        truncated: true,
+      },
+      deps(),
+    );
+
+    expect(reconnected.state.items.at(-1)).toMatchObject({
+      id: "notice:truncated-replay",
+      kind: "notice",
+    });
+  });
+
   it("advances the cursor for unknown event kinds", () => {
     const { state, effects } = reduceCodeSessionEvent(
       initialCodeSessionState(),
@@ -294,7 +315,6 @@ describe("turn lifecycle", () => {
     expect(state.busy).toBe(false);
     expect(state.activeTurnId).toBeNull();
     expect(state.lifecycle).toBe("idle");
-    expect(state.harnessKind).toBe("claude_code");
     expect(state.lastUsage).toEqual(NO_USAGE);
     expect(effects.at(-1)).toEqual({ type: "turn_resolved" });
     const kinds = state.items.map((item) => item.kind);
@@ -765,11 +785,13 @@ describe("hydrate then replay", () => {
       durationMs: null,
     });
 
-    const reconciled = reconcileCodeTurnSnapshot(completed.state, {
-      ...SNAPSHOT_TURN,
-      started_at: LONG_TURN_START,
-      ended_at: LONG_TURN_END,
-    });
+    const reconciled = reconcilePendingCodeTurns(completed.state, [
+      {
+        ...SNAPSHOT_TURN,
+        started_at: LONG_TURN_START,
+        ended_at: LONG_TURN_END,
+      },
+    ]);
     expect(reconciled).toMatchObject({
       busy: false,
       activeTurnId: null,
@@ -1546,11 +1568,21 @@ describe("hydrate then replay", () => {
       deps(),
     );
 
-    const reconciled = reconcileCodeTurnSnapshot(t2Started.state, {
-      ...SNAPSHOT_TURN,
-      started_at: LONG_TURN_START,
-      ended_at: LONG_TURN_END,
-    });
+    const reconciled = reconcilePendingCodeTurns(t2Started.state, [
+      {
+        ...SNAPSHOT_TURN,
+        started_at: LONG_TURN_START,
+        ended_at: LONG_TURN_END,
+      },
+      {
+        ...SNAPSHOT_TURN,
+        id: "t2",
+        ordinal: 2,
+        status: "running",
+        user_input: "run the tests",
+        ended_at: undefined,
+      },
+    ]);
 
     expect(reconciled).toMatchObject({
       busy: true,
@@ -2264,6 +2296,16 @@ describe("applyTurnRewrite", () => {
     rewrite: "The turn added three tools.",
     rewriteState: "rewritten" as const,
   };
+
+  it("returns the original items when the rewrite is already current", () => {
+    const items = [closing];
+    expect(
+      applyTurnRewrite(items, "t1", {
+        rewrite: "The turn added three tools.",
+        rewriteState: "rewritten",
+      }),
+    ).toBe(items);
+  });
 
   it("does not let a rewriting notice clear a stored rewrite", () => {
     const next = applyTurnRewrite([closing], "t1", {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -8,7 +8,6 @@ import type {
   CodeUsage,
   Diffstat,
   FileChangeKind,
-  HarnessKind,
   HarnessNoticeLevel,
   SequencedCodeEventFrame,
   ToolDetail,
@@ -177,8 +176,6 @@ export type CodeSessionState = {
   >;
   assistantBuffer: string;
   reasoningBuffer: string;
-  harnessKind: HarnessKind | null;
-  harnessVersion: string | null;
   lastUsage: CodeUsage | null;
   /** Session lifecycle as the journal last stated it. */
   lifecycle: CodeSessionLifecycle | null;
@@ -250,8 +247,6 @@ export function initialCodeSessionState(): CodeSessionState {
     pendingTerminalReconciliations: new Map(),
     assistantBuffer: "",
     reasoningBuffer: "",
-    harnessKind: null,
-    harnessVersion: null,
     lastUsage: null,
     lifecycle: null,
     contentRevision: 0,
@@ -397,14 +392,6 @@ export function applyCodeTurnSnapshot(
  * started while the request was in flight, the snapshot still fills durable
  * transcript data but leaves the newer activity untouched.
  */
-export function reconcileCodeTurnSnapshot(
-  state: CodeSessionState,
-  turn: CodeTurnSnapshot,
-): CodeSessionState {
-  const pending = latestPendingForTurn(state, turn.id);
-  return reconcileCodeTurnSnapshotWithPending(state, turn, pending);
-}
-
 function reconcileCodeTurnSnapshotWithPending(
   state: CodeSessionState,
   turn: CodeTurnSnapshot,
@@ -840,14 +827,8 @@ export function reduceCodeSessionEvent(
 
   switch (event.type) {
     case "session_started":
-      return {
-        state: {
-          ...state,
-          harnessKind: event.harness_kind,
-          harnessVersion: event.harness_version,
-        },
-        effects,
-      };
+      // Session metadata already comes from the durable session snapshot.
+      return { state, effects };
 
     case "turn_resumed": {
       // Same turn, not a new one. Keep the transcript on this turn so the
@@ -1323,6 +1304,15 @@ export function reduceCodeSessionEvent(
       };
     }
 
+    case "stream_interrupted":
+    case "tool_args_delta":
+    case "task_plan_updated":
+    case "context_truncated":
+    case "compaction_started":
+    case "compaction_finished":
+      // Only the internal harness emits these, and code mode filters it out.
+      return { state, effects };
+
     default:
       return { state, effects };
   }
@@ -1382,15 +1372,13 @@ function withTruncationNotice(
   items: CodeTranscriptItem[],
 ): CodeTranscriptItem[] {
   if (items.some((item) => item.id === TRUNCATED_NOTICE_ID)) return items;
-  return [
-    {
-      kind: "notice",
-      id: TRUNCATED_NOTICE_ID,
-      level: "info",
-      message: "Earlier history in this session is not shown.",
-    },
-    ...items,
-  ];
+  const notice: CodeTranscriptItem = {
+    kind: "notice",
+    id: TRUNCATED_NOTICE_ID,
+    level: "info",
+    message: "Earlier history in this session is not shown.",
+  };
+  return items.length === 0 ? [notice] : [...items, notice];
 }
 
 /** Fixed so a reconnect does not stack a second copy of the same line. */
@@ -1787,6 +1775,9 @@ export function applyTurnRewrite(
     rewrite.rewriteState !== "rewritten"
       ? (item.rewriteState ?? "rewritten")
       : rewrite.rewriteState;
+  if (item.rewrite === nextRewrite && item.rewriteState === nextState) {
+    return items;
+  }
   const next = items.slice();
   next[last] = {
     ...item,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CodeTurnSnapshot, SequencedCodeEventFrame } from "../api/types";
 import {
@@ -12,6 +14,7 @@ import {
 import { resetCodeClientGenerationForTests } from "./CodeClientGeneration";
 import { activateCodeClient } from "./CodeClientScope";
 import { userItemId } from "./CodeSessionReducer";
+import { useRegisteredCodeSession } from "./workspace/CodeSessionPane";
 
 class FakeSocket {
   closed = false;
@@ -69,12 +72,41 @@ function turnSnapshot(
 }
 
 afterEach(() => {
+  cleanup();
   vi.useRealTimers();
   resetCodeSessionRegistry();
   resetCodeClientGenerationForTests();
 });
 
 describe("CodeSessionRegistry", () => {
+  it("switches hook stores and registry references with the session id", () => {
+    const client = {
+      listCodeSessionTurns: vi.fn(async () => []),
+      openCodeEvents: vi.fn(
+        (
+          _sessionId: string,
+          after: number,
+          onFrame: (frame: SequencedCodeEventFrame) => void,
+        ) => new FakeSocket(after, onFrame) as unknown as WebSocket,
+      ),
+    };
+    const hook = renderHook(
+      ({ sessionId }) => useRegisteredCodeSession(sessionId, client as never),
+      { initialProps: { sessionId: "s1" } },
+    );
+    const first = hook.result.current;
+
+    expect(peekCodeSession("s1")).toMatchObject({ store: first, refCount: 1 });
+
+    hook.rerender({ sessionId: "s2" });
+
+    expect(hook.result.current).not.toBe(first);
+    expect(peekCodeSession("s1")?.refCount).toBe(0);
+    expect(peekCodeSession("s2")).toMatchObject({
+      store: hook.result.current,
+      refCount: 1,
+    });
+  });
   it("does not let old session hydration populate a replacement client", async () => {
     const staleTurns = deferred<CodeTurnSnapshot[]>();
     const oldSockets: FakeSocket[] = [];
@@ -190,8 +222,8 @@ describe("CodeSessionRegistry", () => {
 
     first
       .getState()
-      .applyEvent(
-        { seq: 1, event: { type: "turn_started", turn_id: "t1" } },
+      .applyEvents(
+        [{ seq: 1, event: { type: "turn_started", turn_id: "t1" } }],
         { nextId: () => "id", now: () => "2026-08-15T00:00:00.000Z" },
       );
     expect(second.getState().busy).toBe(true);
@@ -202,10 +234,7 @@ describe("CodeSessionRegistry", () => {
 
     releaseCodeSession("s1");
     expect(sockets[0]?.closed).toBe(true);
-    expect(peekCodeSession("s1")).toMatchObject({
-      controller: null,
-      refCount: 0,
-    });
+    expect(peekCodeSession("s1")?.refCount).toBe(0);
     expect(first.getState().connectionState).toBe("reconnecting");
   });
 
@@ -237,8 +266,8 @@ describe("CodeSessionRegistry", () => {
     await Promise.resolve();
     first
       .getState()
-      .applyEvent(
-        { seq: 7, event: { type: "turn_started", turn_id: "t2" } },
+      .applyEvents(
+        [{ seq: 7, event: { type: "turn_started", turn_id: "t2" } }],
         { nextId: () => "id", now: () => "2026-08-15T12:00:03.000Z" },
       );
 
@@ -342,20 +371,24 @@ describe("CodeSessionRegistry", () => {
     });
     expect(sockets[0]?.after).toBe(0);
 
-    store.getState().applyEvent(
-      {
-        seq: 1,
-        event: { type: "turn_started", turn_id: "t1" },
-        replayed: true,
-      },
+    store.getState().applyEvents(
+      [
+        {
+          seq: 1,
+          event: { type: "turn_started", turn_id: "t1" },
+          replayed: true,
+        },
+      ],
       { nextId: () => "id", now: () => "2026-08-15T12:00:02.500Z" },
     );
-    store.getState().applyEvent(
-      {
-        seq: 2,
-        event: { type: "assistant_delta", text: "README.md" },
-        replayed: true,
-      },
+    store.getState().applyEvents(
+      [
+        {
+          seq: 2,
+          event: { type: "assistant_delta", text: "README.md" },
+          replayed: true,
+        },
+      ],
       { nextId: () => "a1", now: () => "2026-08-15T12:00:02.500Z" },
     );
     expect(
@@ -744,7 +777,9 @@ describe("CodeSessionRegistry", () => {
 
     expect(hydrateTurns).toHaveBeenCalledTimes(2);
     expect(store.getState().pendingTerminalReconciliations.size).toBe(1);
-    expect(store.getState().items.at(-1)).toMatchObject({
+    expect(
+      store.getState().items.find((item) => item.id === "boundary:t2"),
+    ).toMatchObject({
       kind: "turn_boundary",
       turnId: "t2",
       status: "failed",

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { StrictMode } from "react";
 import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CodeTurnSnapshot, SequencedCodeEventFrame } from "../api/types";
@@ -106,6 +107,37 @@ describe("CodeSessionRegistry", () => {
       store: hook.result.current,
       refCount: 1,
     });
+  });
+  it("keeps one live registration through StrictMode's unmount and remount", () => {
+    const client = {
+      listCodeSessionTurns: vi.fn(async () => []),
+      openCodeEvents: vi.fn(
+        (
+          _sessionId: string,
+          after: number,
+          onFrame: (frame: SequencedCodeEventFrame) => void,
+        ) => new FakeSocket(after, onFrame) as unknown as WebSocket,
+      ),
+    };
+    // StrictMode runs the mount effect, its cleanup, and the effect again on
+    // one mounted tree. The cleanup releases the render-time acquire; the
+    // rerun has to reacquire, or the pane renders from a disposed controller.
+    const hook = renderHook(
+      ({ sessionId }) => useRegisteredCodeSession(sessionId, client as never),
+      { initialProps: { sessionId: "s1" }, wrapper: StrictMode },
+    );
+    const store = hook.result.current;
+    expect(peekCodeSession("s1")).toMatchObject({ store, refCount: 1 });
+
+    hook.rerender({ sessionId: "s2" });
+    expect(peekCodeSession("s1")?.refCount).toBe(0);
+    expect(peekCodeSession("s2")).toMatchObject({
+      store: hook.result.current,
+      refCount: 1,
+    });
+
+    hook.unmount();
+    expect(peekCodeSession("s2")?.refCount).toBe(0);
   });
   it("does not let old session hydration populate a replacement client", async () => {
     const staleTurns = deferred<CodeTurnSnapshot[]>();

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionRegistry.ts
@@ -237,8 +237,9 @@ export function releaseCodeSession(sessionId: string): void {
 
 export function peekCodeSession(
   sessionId: string,
-): CodeSessionEntry | undefined {
-  return registry.get(sessionId);
+): Readonly<Pick<CodeSessionEntry, "store" | "refCount">> | undefined {
+  const entry = registry.get(sessionId);
+  return entry ? { store: entry.store, refCount: entry.refCount } : undefined;
 }
 
 /** Stamp a finished recap onto a retained or open session store. */
@@ -266,7 +267,7 @@ export function applyLiveTurnRewrite(
   });
 }
 
-/** Test-only: drop every live entry without waiting for unmounts. */
+/** Dispose and forget every session; client swaps call this before remounting. */
 export function resetCodeSessionRegistry(): void {
   for (const entry of registry.values()) {
     entry.controller?.dispose();

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionSend.test.ts
@@ -75,30 +75,32 @@ describe("accepted turn after the socket already painted", () => {
     };
     store
       .getState()
-      .applyEvent(
-        { seq: 1, event: { type: "turn_started", turn_id: "turn-1" } },
+      .applyEvents(
+        [{ seq: 1, event: { type: "turn_started", turn_id: "turn-1" } }],
         deps,
       );
     store
       .getState()
-      .applyEvent(
-        { seq: 2, event: { type: "assistant_delta", text: "README.md" } },
+      .applyEvents(
+        [{ seq: 2, event: { type: "assistant_delta", text: "README.md" } }],
         deps,
       );
-    store.getState().applyEvent(
-      {
-        seq: 3,
-        event: {
-          type: "turn_completed",
-          usage: {
-            input_tokens: 1,
-            output_tokens: 1,
-            cache_read_input_tokens: 0,
-            cache_creation_input_tokens: 0,
-            context_tokens: 0,
+    store.getState().applyEvents(
+      [
+        {
+          seq: 3,
+          event: {
+            type: "turn_completed",
+            usage: {
+              input_tokens: 1,
+              output_tokens: 1,
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+              context_tokens: 0,
+            },
           },
         },
-      },
+      ],
       deps,
     );
     await submitAcceptedTurn(store.getState().update, async () => ({

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.test.ts
@@ -32,18 +32,34 @@ describe("CodeSessionStore", () => {
     const store = createCodeSessionStore();
     store
       .getState()
-      .applyEvent(
-        { seq: 1, event: { type: "turn_started", turn_id: "turn-1" } },
+      .applyEvents(
+        [{ seq: 1, event: { type: "turn_started", turn_id: "turn-1" } }],
         deps,
       );
+    store.getState().update((session) => ({
+      ...session,
+      items: [
+        {
+          kind: "assistant",
+          id: "assistant-1",
+          turnId: "turn-1",
+          parentCallId: null,
+          text: "Done.",
+          streaming: false,
+          rewrite: "Recap.",
+          rewriteState: "rewritten",
+        },
+      ],
+      storedRewrites: { "turn-1": "Recap." },
+    }));
     const listener = vi.fn();
     store.subscribe(listener);
 
     expect(
       store
         .getState()
-        .applyEvent(
-          { seq: 1, event: { type: "assistant_delta", text: "late" } },
+        .applyEvents(
+          [{ seq: 1, event: { type: "assistant_delta", text: "late" } }],
           deps,
         ),
     ).toEqual([]);

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionStore.ts
@@ -28,15 +28,6 @@ export type CodeSessionStore = CodeSessionState & {
   connectionState: CodeConnectionState;
   setConnectionState: (connectionState: CodeConnectionState) => void;
   /**
-   * Turn id from the last `turn_began` effect. The pane watches this to drop
-   * a queued follow-up once the worker promotes it.
-   */
-  lastTurnBeganId: string | null;
-  applyEvent: (
-    framed: SequencedCodeEventFrame,
-    deps: CodeSessionDeps,
-  ) => CodeSessionEffect[];
-  /**
    * Reduce a replay chunk and publish it as one store update.
    *
    * A reopened session can contain hundreds of journal frames. Publishing
@@ -50,7 +41,6 @@ export type CodeSessionStore = CodeSessionState & {
     settleInitialView?: boolean,
   ) => CodeSessionEffect[];
   update: (change: (session: CodeSessionState) => CodeSessionState) => void;
-  reset: () => void;
 };
 
 export function createCodeSessionStore() {
@@ -74,10 +64,7 @@ export function createCodeSessionStore() {
       // The reducer returns its input for duplicate/stale frames. Do not turn
       // that no-op into a fresh Zustand snapshot and wake every subscriber.
       if (state !== current) {
-        const began = [...effects]
-          .reverse()
-          .find((effect) => effect.type === "turn_began");
-        set(began ? { ...state, lastTurnBeganId: began.turnId } : state);
+        set(state);
       }
       return effects;
     };
@@ -85,23 +72,14 @@ export function createCodeSessionStore() {
     return {
       ...initialCodeSessionState(),
       connectionState: "live",
-      lastTurnBeganId: null,
       setConnectionState: (connectionState) => {
         if (get().connectionState !== connectionState) set({ connectionState });
       },
-      applyEvent: (framed, deps) => applyEvents([framed], deps),
       applyEvents,
       update: (change) => {
         const current = sessionOf(get());
         const next = change(current);
         if (next !== current) set(next);
-      },
-      reset: () => {
-        set({
-          ...initialCodeSessionState(),
-          connectionState: "live",
-          lastTurnBeganId: null,
-        });
       },
     };
   });
@@ -109,21 +87,15 @@ export function createCodeSessionStore() {
 
 function sessionOf(store: CodeSessionStore): CodeSessionState {
   const {
-    applyEvent,
     applyEvents,
     update,
-    reset,
     connectionState,
     setConnectionState,
-    lastTurnBeganId,
     ...session
   } = store;
-  void applyEvent;
   void applyEvents;
   void update;
-  void reset;
   void connectionState;
   void setConnectionState;
-  void lastTurnBeganId;
   return session;
 }

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerMigration.ts
@@ -59,6 +59,7 @@ export function triggersForNotificationRules(
     if (!rule.enabled) {
       continue;
     }
+    // `tidebreakLinkedOnly` is redundant: triggers only bind linked repositories.
     const scoped =
       rule.repositoryKeys.length === 0
         ? repositories

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.dom.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.dom.test.ts
@@ -81,6 +81,7 @@ describe("workspace rail preferences", () => {
   });
 
   it("uses repository grouping for an old Created preference and preserves card choices", async () => {
+    window.localStorage.setItem("tidebreak.code-workspace-sort", "by-status");
     window.localStorage.setItem(
       PREFS_KEY,
       JSON.stringify({
@@ -97,12 +98,18 @@ describe("workspace rail preferences", () => {
       showRepoChip: false,
       showBranch: true,
     });
+    expect(
+      window.localStorage.getItem("tidebreak.code-workspace-sort"),
+    ).toBeNull();
   });
 
   it("falls back from the legacy Created sort key", async () => {
     window.localStorage.setItem("tidebreak.code-workspace-sort", "by-created");
     const { useCodeUiStore } = await import("./CodeUiStore");
     expect(useCodeUiStore.getState().railPrefs.sortMode).toBe("by-repo");
+    expect(
+      window.localStorage.getItem("tidebreak.code-workspace-sort"),
+    ).toBeNull();
   });
 
   it("clears selection on host change and keeps rail preferences", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -275,8 +275,14 @@ function readStoredRailPrefs(): CodeRailPrefs {
   try {
     const raw = window.localStorage.getItem(RAIL_PREFS_KEY);
     if (!raw) {
-      return { ...DEFAULT_RAIL_PREFS, sortMode: readStoredWorkspaceSort() };
+      const seeded = {
+        ...DEFAULT_RAIL_PREFS,
+        sortMode: readStoredWorkspaceSort(),
+      };
+      window.localStorage.removeItem(WORKSPACE_SORT_KEY);
+      return seeded;
     }
+    window.localStorage.removeItem(WORKSPACE_SORT_KEY);
     const parsed: unknown = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object") return DEFAULT_RAIL_PREFS;
     const record = parsed as Record<string, unknown>;

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -17,7 +17,6 @@ import {
 } from "./CodeClientGeneration";
 import {
   INITIAL_RECONNECT_DELAY_MS,
-  MAX_RECONNECT_DELAY_MS,
   nextReconnectDelay,
 } from "../ChatSessionController";
 import { requestUserAttention } from "../host";
@@ -1020,5 +1019,3 @@ function reconcileTrackedClones(
     }
   }
 }
-
-export { MAX_RECONNECT_DELAY_MS };

--- a/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
@@ -720,14 +720,19 @@ export function CodeSessionPane({
 }
 
 export function useRegisteredCodeSession(sessionId: string, client: ApiClient) {
-  const registrationRef = useRef<{
+  type Registration = {
     sessionId: string;
     client: ApiClient;
     store: ReturnType<typeof acquireCodeSessionFromClient>;
-  } | null>(null);
+  };
+  const registrationRef = useRef<Registration | null>(null);
+  // Acquire during render so the first paint already has the store. Every
+  // acquire is released exactly once by the effect cleanup that closes over
+  // it below, so a key change never releases the registration that replaced
+  // it, and StrictMode's simulated unmount/remount (release, then rerun)
+  // reacquires instead of rendering from a disposed controller.
   const current = registrationRef.current;
   if (current?.sessionId !== sessionId || current.client !== client) {
-    if (current) releaseCodeSession(current.sessionId);
     registrationRef.current = {
       sessionId,
       client,
@@ -735,12 +740,24 @@ export function useRegisteredCodeSession(sessionId: string, client: ApiClient) {
     };
   }
   useEffect(() => {
+    let registration = registrationRef.current;
+    if (
+      registration === null ||
+      registration.sessionId !== sessionId ||
+      registration.client !== client
+    ) {
+      registration = {
+        sessionId,
+        client,
+        store: acquireCodeSessionFromClient(sessionId, client),
+      };
+      registrationRef.current = registration;
+    }
+    const owned = registration;
     return () => {
-      const registration = registrationRef.current;
-      if (!registration) return;
-      releaseCodeSession(registration.sessionId);
-      registrationRef.current = null;
+      releaseCodeSession(owned.sessionId);
+      if (registrationRef.current === owned) registrationRef.current = null;
     };
-  }, []);
+  }, [sessionId, client]);
   return registrationRef.current!.store;
 }

--- a/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/CodeSessionPane.tsx
@@ -720,17 +720,27 @@ export function CodeSessionPane({
 }
 
 export function useRegisteredCodeSession(sessionId: string, client: ApiClient) {
-  const storeRef = useRef<ReturnType<
-    typeof acquireCodeSessionFromClient
-  > | null>(null);
-  if (storeRef.current === null) {
-    storeRef.current = acquireCodeSessionFromClient(sessionId, client);
+  const registrationRef = useRef<{
+    sessionId: string;
+    client: ApiClient;
+    store: ReturnType<typeof acquireCodeSessionFromClient>;
+  } | null>(null);
+  const current = registrationRef.current;
+  if (current?.sessionId !== sessionId || current.client !== client) {
+    if (current) releaseCodeSession(current.sessionId);
+    registrationRef.current = {
+      sessionId,
+      client,
+      store: acquireCodeSessionFromClient(sessionId, client),
+    };
   }
   useEffect(() => {
     return () => {
-      releaseCodeSession(sessionId);
-      storeRef.current = null;
+      const registration = registrationRef.current;
+      if (!registration) return;
+      releaseCodeSession(registration.sessionId);
+      registrationRef.current = null;
     };
-  }, [sessionId, client]);
-  return storeRef.current;
+  }, []);
+  return registrationRef.current!.store;
 }


### PR DESCRIPTION
Fixes the code-mode session state layer so duplicate rewrites stay no-op, session badges acquire the active session, reconnect ordering remains correct, and obsolete state is removed.

1. `applyTurnRewrite` now preserves item identity when stored rewrite content/state already match, with the store no-publish regression covering a stored rewrite.
2. `useRegisteredCodeSession` now synchronously releases and reacquires on `sessionId` or client changes, including registry-reset-safe release behavior; the hook test switches sessions and verifies stores/refcounts.
3. Truncation notices append after retained reconnect history while remaining the first item for an empty transcript, with updated reducer coverage.
4. `CodeSessionController` uses a pre-open connection token so synchronous socket frames are accepted, with a synchronous-open regression test.
5. Removed reducer-only `harnessKind`/`harnessVersion`; `session_started` remains an explicit no-op because durable session snapshots own that metadata.
6. Removed the write-only `lastTurnBeganId` store field and its initialization/update paths.
7. Removed test-only/unused session APIs and the unused updates-store export; tests use `reconcilePendingCodeTurns` and `applyEvents`, and registry peeks expose only read-only store/refcount snapshots.
8. Documented why `tidebreakLinkedOnly` is intentionally ignored during trigger migration.
9. Named the six internal-harness-only event variants as explicit reducer no-ops because code mode filters them out.
10. Corrected `resetCodeSessionRegistry` documentation to include its production client-swap role.
11. Preserved the legacy workspace-sort seed and remove its local-storage key after the one-time rail-preference read, with migration coverage.

Skipped: None; every listed claim held against the rebased code or the checkpoint regression demonstrated the requested behavior.

Checks:

- `pnpm install --frozen-lockfile`: `Done in 23.2s using pnpm v10.18.3`
- `pnpm exec biome format --write src`: `Formatted 926 files in 994ms. No fixes applied.`
- `pnpm exec biome format src`: `Checked 926 files in 878ms. No fixes applied.`
- `pnpm lint`: `Checked 926 files in 1051ms. No fixes applied.`
- `pnpm test`: `Test Files 287 passed (287)` / `Tests 2530 passed (2530)`
- `pnpm build`: `✓ built in 7.60s`