### PR TITLE
fix(ci): repoint the sandbox-image digest pin at its moved constant

### DIFF
--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -60,7 +60,7 @@ run-name: >-
 #
 # The final manifest-list digests land in the run summary, and the `pin` job
 # proposes the follow-up PR that records the documents digest as the local
-# backend's verified pin (see `sandbox_docker` in tidebreak-server), as the
+# backend's verified pin (see `docker` in tidebreak-sandbox-runtime), as the
 # ref the Daytona provider registers as a snapshot (see `daytona` in
 # tidebreak-code-execution), and as the base of the E2B template definition
 # (see `crates/tidebreak-sandbox-agent/e2b/`, whose alias is version-suffixed
@@ -445,7 +445,7 @@ jobs:
             echo
             echo "The \`pin\` job proposes the follow-up PR that records the"
             echo "documents digest as \`PUBLISHED_IMAGE_DIGEST\` in"
-            echo "\`crates/tidebreak-server/src/sandbox_docker.rs\`."
+            echo "\`crates/tidebreak-sandbox-runtime/src/docker.rs\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Closes the pin loop: after a successful publish, propose (or refresh) the
@@ -496,7 +496,7 @@ jobs:
           import sys
 
           digest = sys.argv[1]
-          path = "crates/tidebreak-server/src/sandbox_docker.rs"
+          path = "crates/tidebreak-sandbox-runtime/src/docker.rs"
           with open(path) as handle:
               source = handle.read()
 

--- a/scripts/workflow-security-mutations.test.mjs
+++ b/scripts/workflow-security-mutations.test.mjs
@@ -39,6 +39,11 @@ const fixturePaths = [
   "crates/tidebreak-desktop/src/whisper_install.rs",
   "crates/tidebreak-desktop/scripts/prepare-sidecar.mjs",
   "crates/tidebreak-server/build.rs",
+  // The sandbox-image pin job rewrites these by path; the policy test
+  // asserts they exist and carry their pinned constants.
+  "crates/tidebreak-sandbox-runtime/src/docker.rs",
+  "crates/tidebreak-code-execution/src/sandbox_image.rs",
+  "crates/tidebreak-code-execution/src/daytona.rs",
   "deploy/self-host/Dockerfile",
   "deploy/self-host/Dockerfile.dockerignore",
   "crates/tidebreak-sandbox-agent/Dockerfile.dockerignore",

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1524,6 +1524,36 @@ test("sandbox image publishing is tag-driven, immutable, and secret-free", () =>
     /ghcr\.io\/\$\{\{ github\.repository_owner \}\}\/tidebreak-sandbox-agent-documents$/m,
   );
   assert.match(publish, /PUBLISHED_IMAGE_DIGEST/);
+
+  // The pin job rewrites source files by path. A moved file makes the job
+  // die with FileNotFoundError before it proposes anything (PR #3172 moved
+  // the digest pin and nothing noticed for five weeks), so every path the
+  // job names must exist and carry the constant it looks for.
+  const pinTargets = new Map([
+    [
+      /^\s*path = "([^"]+)"$/m,
+      /const PUBLISHED_IMAGE_DIGEST: Option<&str> =/,
+    ],
+    [
+      /"(crates\/tidebreak-code-execution\/src\/sandbox_image\.rs)": \{/,
+      /const DOCUMENTS_IMAGE: &str = "/,
+    ],
+    [
+      /"(crates\/tidebreak-code-execution\/src\/daytona\.rs)": \{/,
+      /const DOCUMENTS_SNAPSHOT: &str = "/,
+    ],
+  ]);
+  for (const [locator, marker] of pinTargets) {
+    const found = publish.match(locator);
+    assert.ok(found, `pin job names a target for ${locator}`);
+    const target = join(repositoryRoot, found[1]);
+    assert.ok(existsSync(target), `pin target exists: ${found[1]}`);
+    assert.match(
+      readFileSync(target, "utf8"),
+      marker,
+      `pin target ${found[1]} carries its pinned constant`,
+    );
+  }
 });
 
 test("sandbox images are scanned in a read-only job before the version tag is published, and the pin loop never touches main", () => {


### PR DESCRIPTION
## What

The `pin` job in `publish-sandbox-image.yml` rewrites `PUBLISHED_IMAGE_DIGEST` by path. PR #3172 moved that constant from `crates/tidebreak-server/src/sandbox_docker.rs` to `crates/tidebreak-sandbox-runtime/src/docker.rs`, so every publish since has failed the job with `FileNotFoundError` before it could propose the digest bump. The checked-in pin still names v0.26.0 from 2026-08-03.

## How

- The job (and its step summary and header comment) now name the moved file. The regex the job uses matches the comment-plus-constant block at its new location unchanged.
- `scripts/workflow-security.test.mjs` resolves every path the pin job rewrites, asserts each exists on disk, and asserts each carries the constant the job looks for, so a future move fails the test instead of the publish.

## Checks

- `node --test scripts/workflow-security.test.mjs`: all tests pass.

Not done here: the publish workflow is not re-run; the next tag push exercises the repaired job.