### PR TITLE
fix(code): clean up failed clones, bound git reads, and fix gh and forge REST edge cases

### DIFF
--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -433,6 +433,13 @@ async fn write_snapshot_ref(
     parent_oid: Option<&str>,
     message: &str,
 ) -> Result<String, CheckpointError> {
+    let expected_old = git_text(
+        worktree,
+        &["rev-parse", "--verify", "--quiet", r#ref],
+        GIT_TIMEOUT,
+    )
+    .await
+    .ok();
     let tree = snapshot_tree(worktree).await?;
     let parent = match parent_oid {
         Some(oid) => oid.to_owned(),
@@ -447,14 +454,30 @@ async fn write_snapshot_ref(
     )
     .await
     .map_err(CheckpointError::internal)?;
+    move_snapshot_ref(worktree, r#ref, &commit, expected_old.as_deref()).await?;
+    Ok(commit)
+}
+
+async fn move_snapshot_ref(
+    worktree: &Path,
+    r#ref: &str,
+    commit: &str,
+    expected_old: Option<&str>,
+) -> Result<(), CheckpointError> {
     git_text(
         worktree,
-        &["update-ref", "--no-deref", r#ref, &commit],
+        &[
+            "update-ref",
+            "--no-deref",
+            r#ref,
+            commit,
+            expected_old.unwrap_or(""),
+        ],
         GIT_TIMEOUT,
     )
     .await
-    .map_err(CheckpointError::internal)?;
-    Ok(commit)
+    .map(|_| ())
+    .map_err(CheckpointError::internal)
 }
 
 /// Changed files between two trees or a tree and the live worktree snapshot.
@@ -2219,6 +2242,22 @@ mod tests {
         // first in the ref path.
         let removed = delete_workspace_refs(&repo, workspace).await.unwrap();
         assert_eq!(removed, 2);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_ref_writes_refuse_a_stale_expected_value() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "checkpoint-race");
+        let reference = checkpoint_ref(ws(), sess(), 1);
+
+        let first = write_snapshot_ref(&tree, &reference, None, "first writer")
+            .await
+            .unwrap();
+        let error = move_snapshot_ref(&tree, &reference, &first, None)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("cannot lock ref"), "{error}");
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/ci_logs.rs
+++ b/crates/tidebreak-server/src/code/ci_logs.rs
@@ -30,6 +30,7 @@ const CI_LOGS_DIR: &str = "ci-logs";
 /// caller waits one request rather than one per job — which is what keeps the
 /// whole fetch inside the client's own timeout.
 const MAX_JOBS: usize = 6;
+const MAX_FAILURES: usize = MAX_JOBS;
 
 /// Largest log written per job, in bytes, header included.
 ///
@@ -71,6 +72,18 @@ pub struct CheckLogFailure {
 pub struct WrittenCheckLogs {
     pub logs: Vec<WrittenCheckLog>,
     pub failures: Vec<CheckLogFailure>,
+}
+
+fn push_failure(
+    failures: &mut Vec<CheckLogFailure>,
+    omitted: &mut usize,
+    failure: CheckLogFailure,
+) {
+    if failures.len() < MAX_FAILURES {
+        failures.push(failure);
+    } else {
+        *omitted += 1;
+    }
 }
 
 /// A GitHub Actions job, addressed the way its check URL spells it.
@@ -135,22 +148,31 @@ pub(crate) async fn write_failing_check_logs(
 ) -> std::io::Result<WrittenCheckLogs> {
     let mut targets = Vec::new();
     let mut failures = Vec::new();
+    let mut omitted_failures = 0;
     for check in checks
         .iter()
         .filter(|check| check.bucket == PullRequestCheckBucket::Fail)
     {
         let Some(url) = check.url.as_deref() else {
-            failures.push(CheckLogFailure {
-                check: check.name.clone(),
-                message: UNSUPPORTED_CHECK_LOG_MESSAGE.to_owned(),
-            });
+            push_failure(
+                &mut failures,
+                &mut omitted_failures,
+                CheckLogFailure {
+                    check: check.name.clone(),
+                    message: UNSUPPORTED_CHECK_LOG_MESSAGE.to_owned(),
+                },
+            );
             continue;
         };
         let Some(job) = job_ref_from_check_url(url) else {
-            failures.push(CheckLogFailure {
-                check: check.name.clone(),
-                message: UNSUPPORTED_CHECK_LOG_MESSAGE.to_owned(),
-            });
+            push_failure(
+                &mut failures,
+                &mut omitted_failures,
+                CheckLogFailure {
+                    check: check.name.clone(),
+                    message: UNSUPPORTED_CHECK_LOG_MESSAGE.to_owned(),
+                },
+            );
             continue;
         };
         if targets.len() < MAX_JOBS {
@@ -182,7 +204,11 @@ pub(crate) async fn write_failing_check_logs(
         let raw = match raw {
             Ok(raw) => raw,
             Err(message) => {
-                failures.push(CheckLogFailure { check, message });
+                push_failure(
+                    &mut failures,
+                    &mut omitted_failures,
+                    CheckLogFailure { check, message },
+                );
                 continue;
             }
         };
@@ -203,6 +229,19 @@ pub(crate) async fn write_failing_check_logs(
             url,
         });
         written_names.push(name);
+    }
+    if omitted_failures > 0 {
+        let replace_last = failures.len() == MAX_FAILURES;
+        omitted_failures += usize::from(replace_last);
+        let summary = CheckLogFailure {
+            check: "Additional failing checks".to_owned(),
+            message: format!("{omitted_failures} additional failing checks were omitted."),
+        };
+        if replace_last {
+            failures[MAX_FAILURES - 1] = summary;
+        } else {
+            failures.push(summary);
+        }
     }
     prune_stale_logs(&dir, &written_names)?;
     Ok(WrittenCheckLogs { logs, failures })
@@ -456,6 +495,37 @@ mod tests {
         assert_eq!(written.failures[0].check, "external CI");
         assert_eq!(written.failures[0].message, UNSUPPORTED_CHECK_LOG_MESSAGE);
         assert!(!root.path().join(CI_LOGS_DIR).join(old_name).exists());
+    }
+
+    #[tokio::test]
+    async fn unsupported_failure_reports_are_bounded() {
+        let directory = tempfile::tempdir().expect("temp root");
+        let root = super::super::scratch::ScratchRoot::open_for_test(directory.path())
+            .expect("scratch root");
+        let checks = (0..MAX_FAILURES + 4)
+            .map(|index| PullRequestCheck {
+                name: format!("external CI {index}"),
+                bucket: PullRequestCheckBucket::Fail,
+                detail: None,
+                url: None,
+            })
+            .collect::<Vec<_>>();
+
+        let written = write_failing_check_logs(
+            &root,
+            &directory.path().join("gh-must-not-run"),
+            &checks,
+            None,
+        )
+        .await
+        .expect("bounded failures");
+
+        assert_eq!(written.failures.len(), MAX_FAILURES);
+        assert_eq!(
+            written.failures.last().unwrap().check,
+            "Additional failing checks"
+        );
+        assert!(written.failures.last().unwrap().message.contains("omitted"));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -5,6 +5,7 @@
 //! setup. Named-member clones receive only an explicit borrowed credential
 //! inside an isolated process and never store secrets.
 
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Mutex;
@@ -37,6 +38,7 @@ const CLONE_TIMEOUT: Duration = Duration::from_secs(900);
 /// without git reports so rather than stalling the dialog that asked.
 const GIT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_STDERR_CHARS: usize = 4_096;
+const MAX_PROGRESS_LINE_BYTES: usize = 4_096;
 const COMPLETED_JOB_RETENTION: Duration = Duration::from_secs(30 * 60);
 const MAX_COMPLETED_JOBS: usize = 256;
 pub const CLONE_PARENT_DIR_SETTING: &str = "code_clone_parent_dir";
@@ -61,6 +63,27 @@ struct CloneJob {
     repo_id: Option<RepoId>,
     external_origin: Option<String>,
     finished_at: Option<Instant>,
+}
+
+struct CloneJobGuard {
+    runtime: std::sync::Arc<CodeRuntime>,
+    owner: OwnerId,
+    id: Uuid,
+    target: PathBuf,
+    armed: bool,
+}
+
+impl Drop for CloneJobGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_dir_all(&self.target);
+            self.runtime.fail_clone(
+                &self.owner,
+                self.id,
+                "clone job stopped before it completed",
+            );
+        }
+    }
 }
 
 impl CloneJobs {
@@ -416,6 +439,30 @@ impl CodeRuntime {
             ));
         }
         write_clone_parent_dir(&*self.db, &parent).await?;
+        tokio::fs::create_dir_all(target.parent().expect("clone target has a parent"))
+            .await
+            .map_err(|error| {
+                ServerError::bad_request_kind(
+                    "clone_target_unusable",
+                    format!("could not create clone destination parent: {error}"),
+                )
+            })?;
+        tokio::fs::create_dir(&target).await.map_err(|error| {
+            if error.kind() == std::io::ErrorKind::AlreadyExists {
+                ServerError::conflict_kind(
+                    "clone_target_exists",
+                    format!("destination {} already exists", target.display()),
+                )
+            } else {
+                ServerError::bad_request_kind(
+                    "clone_target_unusable",
+                    format!(
+                        "could not create clone destination {}: {error}",
+                        target.display()
+                    ),
+                )
+            }
+        })?;
 
         let id = Uuid::new_v4();
         let job = CloneJob {
@@ -435,9 +482,17 @@ impl CodeRuntime {
         let runtime = std::sync::Arc::clone(self);
         let owner = owner.clone();
         tokio::spawn(async move {
+            let mut guard = CloneJobGuard {
+                runtime: std::sync::Arc::clone(&runtime),
+                owner: owner.clone(),
+                id,
+                target: target.clone(),
+                armed: true,
+            };
             runtime
                 .run_clone(&owner, id, source, target, attribution, lender)
                 .await;
+            guard.armed = false;
         });
         Ok(job.to_snapshot())
     }
@@ -459,6 +514,7 @@ impl CodeRuntime {
                 match lender.git_credential(owner, slug, attribution).await {
                     Ok(credential) => Some(credential),
                     Err(refusal) => {
+                        let _ = tokio::fs::remove_dir_all(&target).await;
                         self.fail_clone(owner, id, git_forge_refusal_message(&refusal));
                         return;
                     }
@@ -483,7 +539,7 @@ impl CodeRuntime {
             Ok(()) => match self
                 .register_repo(
                     owner,
-                    target,
+                    target.clone(),
                     super::runtime::RepoRegistration {
                         cloned_from: Some(redact_clone_url(&source.url)),
                         ..Default::default()
@@ -500,10 +556,14 @@ impl CodeRuntime {
                     });
                 }
                 Err(error) => {
+                    let _ = tokio::fs::remove_dir_all(&target).await;
                     self.fail_clone(owner, id, error.message());
                 }
             },
-            Err(error) => self.fail_clone(owner, id, error),
+            Err(error) => {
+                let _ = tokio::fs::remove_dir_all(&target).await;
+                self.fail_clone(owner, id, error);
+            }
         }
     }
 
@@ -560,7 +620,7 @@ pub async fn registered_legacy_clone_target(
     let canonical = match tokio::fs::canonicalize(target).await {
         Ok(path) => path,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(_) => return Ok(false),
+        Err(error) => return Err(ServerError::internal(error.to_string())),
     };
     Ok(
         get_repo_by_root_path(store, owner, &canonical.display().to_string())
@@ -1196,7 +1256,7 @@ async fn write_clone_parent_dir(store: &dyn Store, parent: &Path) -> Result<(), 
 async fn read_progress_line<R: AsyncReadExt + Unpin>(
     reader: &mut BufReader<R>,
 ) -> Result<Option<String>, String> {
-    let mut buf = Vec::new();
+    let mut buf = VecDeque::new();
     loop {
         let mut byte = [0u8; 1];
         match reader.read(&mut byte).await {
@@ -1213,12 +1273,17 @@ async fn read_progress_line<R: AsyncReadExt + Unpin>(
                     }
                     break;
                 }
-                buf.push(byte[0]);
+                if buf.len() == MAX_PROGRESS_LINE_BYTES {
+                    buf.pop_front();
+                }
+                buf.push_back(byte[0]);
             }
             Err(err) => return Err(format!("git clone stderr: {err}")),
         }
     }
-    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
+    Ok(Some(
+        String::from_utf8_lossy(buf.make_contiguous()).into_owned(),
+    ))
 }
 
 fn append_tail(tail: &mut String, line: &str) {
@@ -1312,6 +1377,15 @@ mod tests {
             Some(("compressing objects".into(), 100))
         );
         assert_eq!(parse_clone_progress_line("Cloning into 'foo'..."), None);
+    }
+
+    #[tokio::test]
+    async fn progress_reader_keeps_only_the_bounded_tail() {
+        let input = format!("{}tail\n", "x".repeat(MAX_PROGRESS_LINE_BYTES + 10));
+        let mut reader = BufReader::new(input.as_bytes());
+        let line = read_progress_line(&mut reader).await.unwrap().unwrap();
+        assert_eq!(line.len(), MAX_PROGRESS_LINE_BYTES);
+        assert!(line.ends_with("tail"));
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -14,6 +14,7 @@
 //! explicit refusals. Host stacks ride the same generic GET the rest of
 //! Delivery uses.
 
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use futures::{stream, StreamExt as _};
@@ -31,6 +32,7 @@ const REST_TIMEOUT: Duration = Duration::from_secs(30);
 /// Cap on one REST response body. PR and check payloads are kilobytes; the
 /// bound exists so a confused origin cannot grow the process.
 const RESPONSE_LIMIT: usize = 2 * 1024 * 1024;
+static REST_CLIENT: OnceLock<Result<reqwest::Client, String>> = OnceLock::new();
 
 /// Pinned mutation that arms auto-merge, or enqueues when the repository
 /// uses a merge queue. Not a general GraphQL runner.
@@ -141,12 +143,17 @@ async fn request(
     credential: &GitCredential,
     body: Option<&Value>,
 ) -> Result<(reqwest::StatusCode, Value), String> {
-    let client = reqwest::Client::builder()
-        .timeout(REST_TIMEOUT)
-        .redirect(reqwest::redirect::Policy::none())
-        .user_agent(concat!("tidebreak/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .map_err(|error| format!("the forge REST client could not be built: {error}"))?;
+    let client = REST_CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(REST_TIMEOUT)
+                .redirect(reqwest::redirect::Policy::none())
+                .user_agent(concat!("tidebreak/", env!("CARGO_PKG_VERSION")))
+                .build()
+                .map_err(|error| format!("the forge REST client could not be built: {error}"))
+        })
+        .as_ref()
+        .map_err(Clone::clone)?;
     let mut request = client
         .request(method, url)
         .bearer_auth(&credential.secret)
@@ -224,6 +231,7 @@ pub(crate) async fn api_get(
     credential: &GitCredential,
     endpoint: &str,
 ) -> Result<Value, String> {
+    validate_endpoint(endpoint)?;
     let (status, value) = request(
         reqwest::Method::GET,
         format!("{api_base}/{endpoint}"),
@@ -235,6 +243,30 @@ pub(crate) async fn api_get(
         return Err(forge_message(status, &value));
     }
     Ok(value)
+}
+
+fn validate_endpoint(endpoint: &str) -> Result<(), String> {
+    if endpoint.contains(['?', '#']) {
+        return Err("the forge REST endpoint must not contain a query or fragment".to_owned());
+    }
+    Ok(())
+}
+
+fn pulls_for_head_url(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    head_branch: &str,
+    per_page: &str,
+) -> String {
+    let query = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("head", &format!("{}:{head_branch}", target.owner))
+        .append_pair("state", "all")
+        .append_pair("per_page", per_page)
+        .finish();
+    format!(
+        "{api_base}/repos/{}/{}/pulls?{query}",
+        target.owner, target.name
+    )
 }
 
 /// Read one pull request in the `gh pr view --json` vocabulary, checks
@@ -603,10 +635,7 @@ pub(crate) async fn list_pull_requests_for_head(
 ) -> Result<Vec<Value>, String> {
     let (status, value) = request(
         reqwest::Method::GET,
-        format!(
-            "{api_base}/repos/{}/{}/pulls?head={}:{}&state=all&per_page=5",
-            target.owner, target.name, target.owner, head_branch
-        ),
+        pulls_for_head_url(api_base, target, head_branch, "5"),
         credential,
         None,
     )
@@ -634,10 +663,7 @@ pub(crate) async fn pull_request_digest(
 ) -> Result<Option<PullRequestDigest>, String> {
     let (status, listed) = request(
         reqwest::Method::GET,
-        format!(
-            "{api_base}/repos/{}/{}/pulls?head={}:{}&state=all&per_page=10",
-            target.owner, target.name, target.owner, head_branch
-        ),
+        pulls_for_head_url(api_base, target, head_branch, "10"),
         credential,
         None,
     )
@@ -979,6 +1005,26 @@ mod tests {
             graphql_url("https://ghe.acme.test/api/v3"),
             "https://ghe.acme.test/api/graphql"
         );
+    }
+
+    #[test]
+    fn branch_names_are_query_encoded() {
+        let target = CodeGitHubRepositoryTarget {
+            host: "github.com".to_owned(),
+            owner: "acme".to_owned(),
+            name: "demo".to_owned(),
+        };
+        assert_eq!(
+            pulls_for_head_url("https://api.github.com", &target, "fix/a&b#c%+d", "5"),
+            "https://api.github.com/repos/acme/demo/pulls?head=acme%3Afix%2Fa%26b%23c%25%2Bd&state=all&per_page=5"
+        );
+    }
+
+    #[test]
+    fn generic_endpoints_reject_queries_and_fragments() {
+        assert!(validate_endpoint("repos/acme/demo/issues").is_ok());
+        assert!(validate_endpoint("repos/acme/demo/issues?state=open").is_err());
+        assert!(validate_endpoint("repos/acme/demo/issues#latest").is_err());
     }
 
     /// The pull-request merge endpoint's status contract is independent of

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -231,7 +231,6 @@ pub(crate) async fn api_get(
     credential: &GitCredential,
     endpoint: &str,
 ) -> Result<Value, String> {
-    validate_endpoint(endpoint)?;
     let (status, value) = request(
         reqwest::Method::GET,
         format!("{api_base}/{endpoint}"),
@@ -243,13 +242,6 @@ pub(crate) async fn api_get(
         return Err(forge_message(status, &value));
     }
     Ok(value)
-}
-
-fn validate_endpoint(endpoint: &str) -> Result<(), String> {
-    if endpoint.contains(['?', '#']) {
-        return Err("the forge REST endpoint must not contain a query or fragment".to_owned());
-    }
-    Ok(())
 }
 
 fn pulls_for_head_url(
@@ -1018,13 +1010,6 @@ mod tests {
             pulls_for_head_url("https://api.github.com", &target, "fix/a&b#c%+d", "5"),
             "https://api.github.com/repos/acme/demo/pulls?head=acme%3Afix%2Fa%26b%23c%25%2Bd&state=all&per_page=5"
         );
-    }
-
-    #[test]
-    fn generic_endpoints_reject_queries_and_fragments() {
-        assert!(validate_endpoint("repos/acme/demo/issues").is_ok());
-        assert!(validate_endpoint("repos/acme/demo/issues?state=open").is_err());
-        assert!(validate_endpoint("repos/acme/demo/issues#latest").is_err());
     }
 
     /// The pull-request merge endpoint's status contract is independent of

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -27,6 +27,7 @@ const GIT_PUSH_TIMEOUT: Duration = Duration::from_secs(120);
 const GH_TIMEOUT: Duration = Duration::from_secs(30);
 const ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_OUTPUT_CHARS: usize = 4_096;
+const MAX_UNTRACKED_DIFFSTAT_BYTES: u64 = 1024 * 1024;
 const MAX_ACTION_OUTPUT_BYTES: usize = 4_096;
 const MAX_ACTION_OUTPUT_LINES: usize = 256;
 const GH_OBSERVATION_TTL: Duration = Duration::from_secs(30);
@@ -1136,16 +1137,27 @@ async fn working_tree_diffstat(worktree: &Path) -> Result<Diffstat, GhError> {
             .await
             .unwrap_or_default(),
     );
-    let status = git(worktree, &["status", "--porcelain"], GIT_TIMEOUT).await?;
+    let status = git(
+        worktree,
+        &["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+        GIT_TIMEOUT,
+    )
+    .await?;
     let mut untracked_files = 0_u32;
     let mut untracked_insertions = 0_u32;
-    for line in status.lines() {
-        if let Some(path) = line.strip_prefix("?? ") {
+    for record in status.split('\0').filter(|record| !record.is_empty()) {
+        if let Some(path) = record.strip_prefix("?? ") {
             untracked_files += 1;
-            if let Ok(bytes) = tokio::fs::read(worktree.join(path.trim())).await {
-                untracked_insertions +=
-                    u32::try_from(String::from_utf8_lossy(&bytes).lines().count())
-                        .unwrap_or(u32::MAX);
+            let path = worktree.join(path);
+            let Ok(metadata) = tokio::fs::metadata(&path).await else {
+                continue;
+            };
+            if metadata.is_file() && metadata.len() <= MAX_UNTRACKED_DIFFSTAT_BYTES {
+                if let Ok(bytes) = tokio::fs::read(path).await {
+                    untracked_insertions +=
+                        u32::try_from(String::from_utf8_lossy(&bytes).lines().count())
+                            .unwrap_or(u32::MAX);
+                }
             }
         }
     }
@@ -2239,12 +2251,8 @@ async fn spawn_gh_with_login_env(
     let output = spawn_gh_output(cwd, binary, login_env, args, limit).await?;
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if output.status.success() || args == ["pr", "checks"] {
-        // `gh pr checks` exits non-zero when checks are pending or failing;
-        // the table is still the digest we want.
-        if output.status.success() || !stdout.is_empty() {
-            return Ok(stdout);
-        }
+    if output.status.success() {
+        return Ok(stdout);
     }
     Err(if stderr.is_empty() { stdout } else { stderr })
 }
@@ -2329,9 +2337,9 @@ pub async fn run_gh_http(
 }
 
 fn refuse_gh_args(args: &[&str]) -> bool {
-    args.iter()
-        .any(|arg| *arg == "merge" || *arg == "--merge" || *arg == "--auto" || *arg == "graphql")
+    matches!(args, ["merge", ..] | ["pr", "merge", ..])
         || args.windows(2).any(|pair| pair == ["api", "graphql"])
+        || args.first() == Some(&"graphql")
 }
 
 /// Parse a `gh api --include` answer: status line, headers, blank line, body.
@@ -2451,6 +2459,30 @@ mod tests {
         assert_eq!(parsed.unstaged_files, 2);
         assert_eq!(parsed.untracked_files, 1);
         assert_eq!(parsed.conflicted_files, 1);
+    }
+
+    #[tokio::test]
+    async fn working_tree_diffstat_decodes_raw_paths_and_skips_large_untracked_files() {
+        let dir = TempDir::new().unwrap();
+        let work = dir.path();
+        run(work, &["git", "init", "-b", "main"]);
+        run(work, &["git", "config", "user.email", "dev.com"]);
+        run(work, &["git", "config", "user.name", "Dev"]);
+        std::fs::write(work.join("README.md"), "initial\n").unwrap();
+        run(work, &["git", "add", "."]);
+        run(work, &["git", "commit", "-m", "init"]);
+
+        std::fs::write(work.join("quoted \" path.txt"), "one\ntwo\n").unwrap();
+        std::fs::write(
+            work.join("large.txt"),
+            vec![b'x'; usize::try_from(MAX_UNTRACKED_DIFFSTAT_BYTES).unwrap() + 1],
+        )
+        .unwrap();
+
+        let diffstat = working_tree_diffstat(work).await.unwrap();
+        assert_eq!(diffstat.files, 2);
+        assert_eq!(diffstat.insertions, 2);
+        assert_eq!(diffstat.deletions, 0);
     }
 
     #[tokio::test]
@@ -3277,6 +3309,13 @@ exit 3
         assert_eq!(inline[0].line, Some(42));
         assert_eq!(inline[1].line, Some(7), "falls back to original_line");
         assert_eq!(parse_review_comments("surprise!").len(), 0);
+    }
+
+    #[test]
+    fn gh_argument_refusal_ignores_comment_bodies_named_merge() {
+        assert!(!refuse_gh_args(&["pr", "comment", "12", "--body", "merge"]));
+        assert!(refuse_gh_args(&["pr", "merge", "12"]));
+        assert!(refuse_gh_args(&["api", "graphql"]));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/worktree.rs
+++ b/crates/tidebreak-server/src/code/worktree.rs
@@ -21,11 +21,11 @@ const SEARCH_TIMEOUT: Duration = Duration::from_secs(15);
 /// Default number of paths the tree route returns.
 pub const DEFAULT_TREE_LIMIT: u32 = 50;
 /// Hard cap on the tree route. The explorer may request this many paths.
-pub const MAX_TREE_LIMIT: u32 = 5_000;
+const MAX_TREE_LIMIT: u32 = 5_000;
 /// Default number of matching lines returned by content search.
 pub const DEFAULT_SEARCH_LIMIT: u32 = 200;
 /// Hard cap for one content-search response.
-pub const MAX_SEARCH_LIMIT: u32 = 500;
+const MAX_SEARCH_LIMIT: u32 = 500;
 const MAX_SEARCH_QUERY_CHARS: usize = 500;
 const MAX_SEARCH_PREVIEW_CHARS: usize = 500;
 const ARCHIVE_SCAN_MAX_PATH_BYTES: usize = 1024 * 1024;
@@ -1598,15 +1598,12 @@ pub async fn archive_blockers(
     let uncommitted = has_uncommitted_work(worktree_path).await?;
     let unpushed = has_unpushed_work(worktree_path, base_ref).await?;
     let ignored = has_non_disposable_ignored_content(worktree_path).await?;
-    Ok(if ignored {
-        Some(ArchiveBlock::IgnoredContent)
-    } else {
-        match (uncommitted, unpushed) {
-            (true, true) => Some(ArchiveBlock::UncommittedAndUnpushed),
-            (true, false) => Some(ArchiveBlock::Uncommitted),
-            (false, true) => Some(ArchiveBlock::Unpushed),
-            (false, false) => None,
-        }
+    Ok(match (uncommitted, unpushed) {
+        (true, true) => Some(ArchiveBlock::UncommittedAndUnpushed),
+        (true, false) => Some(ArchiveBlock::Uncommitted),
+        (false, true) => Some(ArchiveBlock::Unpushed),
+        (false, false) if ignored => Some(ArchiveBlock::IgnoredContent),
+        (false, false) => None,
     })
 }
 
@@ -2900,6 +2897,13 @@ mod tests {
             archive_blockers(&path, "main").await.unwrap(),
             Some(ArchiveBlock::IgnoredContent)
         );
+
+        std::fs::write(path.join("tracked-change.txt"), "not committed\n").unwrap();
+        assert_eq!(
+            archive_blockers(&path, "main").await.unwrap(),
+            Some(ArchiveBlock::Uncommitted)
+        );
+        std::fs::remove_file(path.join("tracked-change.txt")).unwrap();
 
         run(
             &path,

--- a/crates/tidebreak-server/src/code/worktree_root.rs
+++ b/crates/tidebreak-server/src/code/worktree_root.rs
@@ -103,24 +103,52 @@ async fn validate_worktree_root(root: &Path) -> Result<(), ServerError> {
         ));
     }
     match tokio::fs::metadata(root).await {
-        Ok(meta) if meta.is_dir() => Ok(()),
-        Ok(_) => Err(ServerError::bad_request_kind(
-            "worktree_root_not_dir",
-            format!("worktree root {} is not a directory", root.display()),
-        )),
+        Ok(meta) if meta.is_dir() => {}
+        Ok(_) => {
+            return Err(ServerError::bad_request_kind(
+                "worktree_root_not_dir",
+                format!("worktree root {} is not a directory", root.display()),
+            ));
+        }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             tokio::fs::create_dir_all(root).await.map_err(|err| {
                 ServerError::bad_request_kind(
                     "worktree_root_unusable",
                     format!("could not create worktree root {}: {err}", root.display()),
                 )
-            })
+            })?;
         }
-        Err(err) => Err(ServerError::bad_request_kind(
-            "worktree_root_unusable",
-            format!("could not read worktree root {}: {err}", root.display()),
-        )),
+        Err(err) => {
+            return Err(ServerError::bad_request_kind(
+                "worktree_root_unusable",
+                format!("could not read worktree root {}: {err}", root.display()),
+            ));
+        }
     }
+    let probe = root.join(format!(".tidebreak-write-probe-{}", uuid::Uuid::new_v4()));
+    tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe)
+        .await
+        .map_err(|err| {
+            ServerError::bad_request_kind(
+                "worktree_root_unusable",
+                format!(
+                    "could not write under worktree root {}: {err}",
+                    root.display()
+                ),
+            )
+        })?;
+    tokio::fs::remove_file(&probe).await.map_err(|err| {
+        ServerError::bad_request_kind(
+            "worktree_root_unusable",
+            format!(
+                "could not remove write probe under {}: {err}",
+                root.display()
+            ),
+        )
+    })
 }
 
 async fn read_worktree_root(store: &dyn Store) -> Result<Option<String>, ServerError> {


### PR DESCRIPTION
1. Clone jobs now reserve only a newly created empty target, remove that owned target on credential, clone, timeout, cancellation/panic, or registration failure, and mark interrupted jobs failed.
2. Clone progress lines retain only the latest 4 KiB before stderr-tail aggregation.
3. A clone task drop guard marks cancelled or panicked jobs failed so completed-job pruning can evict them.
4. Legacy clone target canonicalization now treats only NotFound as absent and propagates other filesystem errors.
5. Working-tree diffstat reads porcelain v1 with NUL delimiters, stats untracked files first, and skips line reads over the named 1 MiB cap while still counting the file.
6. gh refusal checks only merge subcommand positions plus the api graphql pair, allowing comment bodies such as merge.
7. Removed the dead gh pr checks exit-status exception and its stale comment.
8. Forge REST requests reuse one process-wide reqwest client with the existing timeout, redirect, and user-agent settings.
9. Forge REST percent-encodes head-branch query values and rejects generic endpoints containing query or fragment delimiters.
10. Snapshot ref writes now compare against the observed old ref value so concurrent writers conflict instead of clobbering.
11. Archive blockers now report uncommitted or unpushed work ahead of ignored content while preserving the existing wire variants and UI copy.
12. Worktree-root validation now creates and removes a unique probe file before accepting the setting.
13. CI log failures are capped with targets and include one bounded summary whose count includes any row displaced by the summary.
14. Tree and search hard caps are private because no external code reads them.

Skipped
- Did not collapse clone.rs bound_stderr and gh.rs bound_text onto tidebreak_harness::OutputBudget: the crate already depends on tidebreak-harness, but OutputBudget configures bounded subprocess byte/line capture and exposes no standalone string truncation operation; the existing helpers also intentionally retain opposite ends using character-count caps.

Checks run
- cargo fmt --all --check — passed (exit 0).
- cargo clippy -p tidebreak-server-core --all-targets --locked -- -D warnings — Finished dev profile successfully.
- cargo test -p tidebreak-server-core --locked code::clone — test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 1091 filtered out; finished in 1.28s.
- cargo test -p tidebreak-server-core --locked code::gh — test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 1075 filtered out; finished in 1.69s.
- cargo test -p tidebreak-server-core --locked code::forge_rest — test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1097 filtered out; finished in 0.00s.
- cargo test -p tidebreak-server-core --locked code::checkpoint — test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 1074 filtered out; finished in 21.36s.
- cargo test -p tidebreak-server-core --locked code::worktree — test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 1068 filtered out; finished in 6.01s.
- cargo test -p tidebreak-server-core --locked code::ci_logs — test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 1093 filtered out; finished in 0.01s.
