### PR TITLE
fix(code): persist sandbox permission modes, fence a lost mode confirmation, and stop runtime map leaks

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/session.rs
+++ b/crates/tidebreak-core/src/db/ops/code/session.rs
@@ -1,3 +1,4 @@
+use sea_orm::sea_query::ExprTrait as _;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Condition, ConnectionTrait, EntityTrait, QueryFilter,
     QueryOrder, QuerySelect, Set, TransactionTrait,
@@ -384,6 +385,44 @@ pub async fn replace_session_execution_settings(
     current.reasoning_effort = next.reasoning_effort;
     current.fast_mode = next.fast_mode;
     Ok(Some(current))
+}
+
+/// Replace a sandbox session's permission mode while its exact durable state
+/// still matches the caller's copy.
+pub async fn replace_sandbox_permission_mode(
+    store: &DbStore,
+    owner: &OwnerId,
+    expected: &Session,
+    requested_mode: PermissionMode,
+) -> Result<Option<Session>> {
+    if &expected.owner != owner || expected.execution_location != ExecutionLocation::Sandbox {
+        return Ok(None);
+    }
+    let updated = entities::session::Entity::update_many()
+        .col_expr(
+            entities::session::Column::PermissionMode,
+            sea_orm::sea_query::Expr::value(requested_mode.as_str()),
+        )
+        .col_expr(
+            entities::session::Column::PermissionModeRevision,
+            sea_orm::sea_query::Expr::col(entities::session::Column::PermissionModeRevision).add(1),
+        )
+        .filter(entities::session::Column::Id.eq(expected.id.0))
+        .filter(entities::session::Column::Owner.eq(owner.as_str()))
+        .filter(entities::session::Column::Lifecycle.eq(expected.lifecycle.as_str()))
+        .filter(entities::session::Column::SpawnEpoch.eq(expected.spawn_epoch))
+        .filter(entities::session::Column::PermissionMode.eq(expected.permission_mode.as_str()))
+        .filter(entities::session::Column::PermissionModeIntent.is_null())
+        .filter(
+            entities::session::Column::ExecutionLocation.eq(ExecutionLocation::Sandbox.as_str()),
+        )
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        return Ok(None);
+    }
+    get_session(store, owner, expected.id).await
 }
 
 /// Persist a versioned mode-change intent before any live engine mutation.

--- a/crates/tidebreak-server/src/code/approval_sweep.rs
+++ b/crates/tidebreak-server/src/code/approval_sweep.rs
@@ -135,7 +135,9 @@ pub(crate) async fn abandon_for_restart(
 async fn parks_are_durable(db: &DbStore, owner: &OwnerId, session_id: SessionId) -> bool {
     matches!(
         get_session(db, owner, session_id).await,
-        Ok(Some(session)) if session.harness_kind == tidebreak_core::HarnessKind::Internal
+        Ok(Some(session))
+            if crate::code::recovery::durable_parks_for(session.harness_kind)
+                == tidebreak_core::CapLevel::Supported
     )
 }
 

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -319,6 +319,15 @@ impl CodeEventBus {
             .map(|live| live.last_activity)
     }
 
+    /// Drop the live channel and transient tail for a session that ended.
+    /// A late publisher safely creates a fresh entry through [`Self::with_session`].
+    pub fn forget(&self, session: SessionId) {
+        self.channels
+            .lock()
+            .expect("code event bus lock")
+            .remove(&session);
+    }
+
     /// Whether this session might be carrying [`AttentionState::Stalled`].
     ///
     /// A hint, not an answer: it starts pessimistic and is corrected by the
@@ -350,8 +359,8 @@ impl CodeEventBus {
     /// Subscribe to one owner's updates. The receiver is the only view of the
     /// channel available to an `/updates` socket, and it carries nothing else.
     ///
-    /// Subscribing also wakes [`Self::updates_attached`] waiters. A
-    /// A client says it is looking by opening an `/updates` socket. Sweeps
+    /// Subscribing also wakes [`Self::updates_attached`] waiters. A client
+    /// says it is looking by opening an `/updates` socket. Sweeps
     /// that back off while nobody is looking use that moment to return to
     /// their fast cadence.
     pub fn subscribe_updates(&self, owner: &OwnerId) -> broadcast::Receiver<CodeLiveUpdate> {
@@ -470,5 +479,25 @@ mod tests {
                 .is_err(),
             "a drop is not an attach"
         );
+    }
+
+    #[test]
+    fn forgetting_a_session_drops_its_channel_and_late_publish_recreates_it() {
+        let bus = CodeEventBus::default();
+        let session = SessionId::new();
+
+        let _receiver = bus.attach(session).0;
+        assert!(bus.last_activity(session).is_some());
+
+        bus.forget(session);
+        assert!(bus.last_activity(session).is_none());
+
+        bus.publish_transient(
+            session,
+            Event::AssistantDelta {
+                text: "late".into(),
+            },
+        );
+        assert!(bus.last_activity(session).is_some());
     }
 }

--- a/crates/tidebreak-server/src/code/native_channel/mod.rs
+++ b/crates/tidebreak-server/src/code/native_channel/mod.rs
@@ -235,6 +235,12 @@ fn write_capfile(
     if let Err(e) = std::fs::create_dir_all(parent) {
         return Err(format!("could not create native capfile directory: {e}"));
     }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("could not set native capfile directory mode: {e}"))?;
+    }
     let tmp_path = parent.join(format!(
         ".{}.tmp-{}",
         path.file_name()
@@ -243,18 +249,15 @@ fn write_capfile(
         generate_file_id()
     ));
     let result = (|| {
-        use std::fs::OpenOptions;
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
+        #[cfg(unix)]
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options
             .open(&tmp_path)
             .map_err(|e| format!("could not create native capfile temp file: {e}"))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            file.set_permissions(std::fs::Permissions::from_mode(0o600))
-                .map_err(|e| format!("could not set native capfile temp mode: {e}"))?;
-        }
         let payload = serde_json::json!({
             "version": version,
             "endpoint": format!("{loopback_base}/code/native"),
@@ -409,6 +412,15 @@ mod tests {
             #[cfg(unix)]
             assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
         }
+        #[cfg(unix)]
+        assert_eq!(
+            std::fs::metadata(reg.capfile_dir())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
         assert!(leaf.is_dir() || !leaf.exists());
     }
 }

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1380,6 +1380,8 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated.permission_mode, PermissionMode::Ask);
+        let stored = runtime.get_session(&owner, session.id).await.unwrap();
+        assert_eq!(stored.permission_mode, PermissionMode::Ask);
         assert!(fake.spawns.lock().unwrap().is_empty());
     }
 

--- a/crates/tidebreak-server/src/code/runtime/adapters.rs
+++ b/crates/tidebreak-server/src/code/runtime/adapters.rs
@@ -140,8 +140,7 @@ impl CodeRuntime {
         probe
     }
 
-    /// Drop every memoized probe so the next read is cold. The doctor's
-    /// refresh is the on-demand re-probe decision 0034 describes.
+    /// Record the latest managed pin-install result for one harness.
     #[cfg_attr(test, allow(dead_code))]
     pub(crate) fn record_pin_install(&self, kind: HarnessKind, result: Result<(), String>) {
         let mut errors = self.pin_install_errors.lock().expect("pin install errors");

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -38,7 +38,7 @@ use tidebreak_core::db::code::{
     list_pending_permission_mode_changes, list_repos, list_sessions, list_sessions_all_owners,
     list_sessions_for_workspace, list_triggers_for_repo, list_turns, list_workspaces,
     list_workspaces_by_status_all_owners, mark_repo_removed, queued_turn_head,
-    replace_session_execution_settings, save_repo, save_workspace,
+    replace_sandbox_permission_mode, replace_session_execution_settings, save_repo, save_workspace,
     set_active_workspace_pull_request, settle_approval_claim, update_trigger_enabled,
     ClaimedApprovalSettlement, PermissionModeChangeIntent, SessionExecutionSettings,
     MAX_REPLAY_EVENTS,
@@ -764,7 +764,6 @@ impl CodeRuntime {
         self
     }
 
-    /// Refuse local engines on a hosted deployment that requires isolation.
     /// The operator's permission policy for channel-bound sessions on this
     /// machine's engine: the default mode and the ceiling a channel may ask
     /// for. Config validated the pair at boot, so the ceiling is never below

--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -211,6 +211,9 @@ impl CodeRuntime {
         }
         let recovered_sessions = list_sessions_all_owners(&self.db).await?;
         for session in &recovered_sessions {
+            if session.lifecycle == SessionLifecycle::Ended {
+                continue;
+            }
             crate::code::approval_sweep::abandon_for_restart(
                 &self.db,
                 &self.bus,

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -475,6 +475,7 @@ impl CodeRuntime {
             return Ok(());
         };
         if session.lifecycle == SessionLifecycle::Ended {
+            self.bus.forget(session.id);
             return Ok(());
         }
         if let Ok(Some(workspace)) = self.session_workspace(&session).await {
@@ -545,6 +546,7 @@ impl CodeRuntime {
                 "could not clear the ended session's queued turns"
             );
         }
+        self.bus.forget(current.id);
         Ok(())
     }
 

--- a/crates/tidebreak-server/src/code/runtime/settings.rs
+++ b/crates/tidebreak-server/src/code/runtime/settings.rs
@@ -180,13 +180,19 @@ impl CodeRuntime {
         }
 
         if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
-            // The sandbox carries the engine. Persist the mode on the row and
+            // The sandbox carries the engine. Durably replace the mode, but
             // do not relaunch a host harness against the empty worktree.
-            let mut session = session;
-            session.permission_mode = mode;
-            self.validate_remote_execution(&session)?;
-            crate::code::attention::persist_session(&self.db, &self.bus, &session).await?;
-            return Ok(session);
+            let mut requested = session.clone();
+            requested.permission_mode = mode;
+            self.validate_remote_execution(&requested)?;
+            return replace_sandbox_permission_mode(&self.db, owner, &session, mode)
+                .await?
+                .ok_or_else(|| {
+                    ServerError::conflict_kind(
+                        "permission_mode_changed",
+                        "the session changed before the permission mode could be stored",
+                    )
+                });
         }
 
         // Refuse a mode this engine cannot honor here, not at the next turn,
@@ -351,7 +357,16 @@ impl CodeRuntime {
         )
         .await;
         if !confirm_permission_mode_change(&self.db, owner, &intent).await? {
-            let _ = discard_permission_mode_change(&self.db, owner, &intent).await;
+            let reason = permission_mode_fence_reason(&intent);
+            let fenced = fence_permission_mode_change(&self.db, owner, &intent, &reason).await?;
+            if let Some(fenced) = fenced {
+                crate::code::attention::emit_digest(&self.db, &self.bus, &fenced).await;
+                return Err(ServerError::conflict_kind(
+                    "permission_mode_unconfirmed",
+                    "the session changed while its worker stopped for the permission mode update; reap the fenced session before another turn",
+                ));
+            }
+            let _ = discard_permission_mode_change(&self.db, owner, &intent).await?;
             return Err(ServerError::conflict_kind(
                 "permission_mode_changed",
                 "the session changed while its worker stopped for the permission mode update",

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -1116,11 +1116,10 @@ impl CodeRuntime {
             branch
         );
         {
-            let cache = self.branch_rules.lock().expect("branch rules");
+            let mut cache = self.branch_rules.lock().expect("branch rules");
+            cache.retain(|_, entry| entry.fetched_at.elapsed() <= BRANCH_RULES_TTL);
             if let Some(entry) = cache.get(&key) {
-                if entry.fetched_at.elapsed() <= BRANCH_RULES_TTL {
-                    return entry.rules;
-                }
+                return entry.rules;
             }
         }
         let rules = match crate::code::pr_fetch::read_branch_rules(

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -644,6 +644,10 @@ impl CodeRuntime {
             .lock()
             .expect("worktree turn locks")
             .remove(&workspace_id);
+        self.workspace_lifecycles
+            .lock()
+            .expect("workspace lifecycle locks")
+            .remove(&workspace_id);
     }
 
     fn workspace_creation_lock(&self, repo_id: RepoId) -> Arc<tokio::sync::Mutex<()>> {
@@ -1058,6 +1062,7 @@ impl CodeRuntime {
         let sessions = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
         for mut session in sessions {
             if session.lifecycle == SessionLifecycle::Ended {
+                self.bus.forget(session.id);
                 continue;
             }
             let handle = self
@@ -1119,6 +1124,7 @@ impl CodeRuntime {
                 )
                 .await;
             }
+            self.bus.forget(current.id);
         }
         Ok(all_stopped)
     }


### PR DESCRIPTION
## What

Runtime fixes from the code-mode audit.

- A permission-mode change on a sandbox session answered 200 but never reached the row, because `save_session` writes no `permission_mode` column. The sandbox branch now writes the mode durably and answers a conflict if the session changed underneath it.
- When a local worker was stopped for a mode change and the confirmation did not commit, the session was left with no worker until restart. That branch now fences the session the way its sibling does, so reap recovers it.
- Native capfiles are created at mode 0600 with a 0700 parent, matching the browser channel; the previous code created under the umask and chmodded afterwards.
- `workspace_lifecycles` and expired `branch_rules` entries are evicted; the event bus drops a session's channel when the session ends; boot recovery skips ended sessions instead of minting a broadcast ring per historical session.
- `parks_are_durable` keys on the shared `durable_parks_for` answer instead of a hardcoded engine kind, and three stale doc comments are corrected.

## Checks

- `cargo check -p tidebreak-server-core -p tidebreak-core --tests`: clean.
- `cargo test -p tidebreak-server-core --locked code::runtime::settings`: 10 passed.
- `cargo test -p tidebreak-server-core --locked native_channel`: 5 passed.
- `cargo test -p tidebreak-server-core --locked code::bus`: passes (new test for forget and late publish).