### PR TITLE
fix(desktop): state the permission posture on create and close code-mode setup dead ends

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/AddRepoInline.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoInline.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { ParentDirField } from "./AddRepoPalette";
-import type { AddRepoInlineState } from "./useAddRepoInline";
+import { displayClonePhase, type AddRepoInlineState } from "./useAddRepoInline";
 
 /**
  * What one submit is about to do with what has been typed.
@@ -109,7 +109,7 @@ export function AddRepoInline({
               className="text-muted-foreground truncate text-xs"
               data-testid="add-repo-clone-phase"
             >
-              {state.phase}
+              {displayClonePhase(state.phase)}
             </span>
             {state.percent !== null && (
               <span className="text-muted-foreground shrink-0 font-mono text-xs">

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.dom.test.tsx
@@ -264,7 +264,7 @@ describe("AddRepoPalette", () => {
     fireEvent.click(screen.getByRole("button", { name: "Clone" }));
     await waitFor(() => expect(started).toHaveBeenCalled());
     expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
-      "starting",
+      "Starting",
     );
     useCodeUpdatesStore.getState().apply({
       type: "clone_progress",
@@ -277,7 +277,7 @@ describe("AddRepoPalette", () => {
     });
     await waitFor(() =>
       expect(screen.getByTestId("clone-phase")).toHaveTextContent(
-        "receiving objects",
+        "Receiving objects",
       ),
     );
     useCodeUpdatesStore.getState().apply({
@@ -298,6 +298,33 @@ describe("AddRepoPalette", () => {
     ).toBeInTheDocument();
   });
 
+  it("offers retry when a finished clone has no repository", async () => {
+    await renderPalette(
+      app({
+        startCodeClone: vi.fn(async () => ({
+          id: "job-without-repo",
+          phase: "done",
+          percent: 100,
+          done: true,
+        })),
+      }),
+    );
+    fireEvent.click(await screen.findByRole("option", { name: /Git URL/ }));
+    fireEvent.change(
+      screen.getByPlaceholderText("https://example.com/acme/app.git"),
+      { target: { value: "/tmp/origin.git" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Clone" }));
+
+    expect(
+      await screen.findByText("The clone finished without a repository."),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(
+      screen.getByPlaceholderText("https://example.com/acme/app.git"),
+    ).toBeVisible();
+  });
+
   it("does not open New Workspace after clone progress is dismissed", async () => {
     const getCodeRepo = vi.fn(async () => REPO);
     const value = app({
@@ -312,7 +339,7 @@ describe("AddRepoPalette", () => {
 
     await startGitClone();
     expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
-      "starting",
+      "Starting",
     );
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     await waitFor(() =>
@@ -877,14 +904,14 @@ describe("AddRepoPalette", () => {
 
     await startGitClone();
     expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
-      "receiving objects",
+      "Receiving objects",
     );
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     fireEvent.click(
       screen.getByRole("button", { name: "Open add repository" }),
     );
     expect(await screen.findByTestId("clone-phase")).toHaveTextContent(
-      "receiving objects",
+      "Receiving objects",
     );
 
     act(() => {
@@ -942,9 +969,8 @@ describe("AddRepoPalette on a machine that answers for itself", () => {
     ).toBeInTheDocument();
     // Absent with no reason reads as a broken dialog; the machine's own
     // sentence is what makes it legible.
-    expect(
-      screen.getAllByText(/This machine has no git\./).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByText("Not available on this machine")).toBeVisible();
+    expect(screen.getAllByText("This machine has no git.")).toHaveLength(1);
   });
 
   it("asks for no destination when the machine places clones itself", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AddRepoPalette.tsx
@@ -65,6 +65,7 @@ import {
   type CodeCloneRequest,
   type ResumableCodeClone,
 } from "./CodeUpdatesStore";
+import { displayClonePhase } from "./useAddRepoInline";
 
 type Stage = "sources" | "local" | "git_url" | "github" | "progress";
 
@@ -226,11 +227,17 @@ export function AddRepoPalette({
   // than swallowed: "GitHub is missing" with no reason is worse than absent.
   const unavailable = useMemo(
     () =>
-      (sources?.sources ?? []).filter(
-        (source) =>
-          !source.available &&
-          source.remediation &&
-          SOURCES.some((row) => row.key === source.kind),
+      Array.from(
+        new Set(
+          (sources?.sources ?? [])
+            .filter(
+              (source) =>
+                !source.available &&
+                source.remediation &&
+                SOURCES.some((row) => row.key === source.kind),
+            )
+            .map((source) => source.remediation),
+        ),
       ),
     [sources],
   );
@@ -865,12 +872,15 @@ export function AddRepoPalette({
               </CommandGroup>
               {unavailable.length > 0 && (
                 <div className="border-t px-3 py-2">
-                  {unavailable.map((source) => (
+                  <p className="mb-1 text-xs font-medium">
+                    Not available on this machine
+                  </p>
+                  {unavailable.map((remediation) => (
                     <p
-                      key={source.kind}
+                      key={remediation}
                       className="text-xs text-muted-foreground break-words"
                     >
-                      {source.remediation}
+                      {remediation}
                     </p>
                   ))}
                 </div>
@@ -1633,7 +1643,7 @@ function ProgressStage({
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <p className="text-sm font-medium" data-testid="clone-phase">
-            {job?.phase ?? "Starting"}
+            {displayClonePhase(job?.phase)}
           </p>
           {!job?.done && (
             <p className="mt-0.5 text-xs text-muted-foreground">
@@ -1670,6 +1680,13 @@ function ProgressStage({
             Retry
           </Button>
         </>
+      )}
+      {job?.done && !job.error && !job.repo_id && (
+        <ProbeFailure
+          message="The clone finished without a repository."
+          busy={false}
+          onRetry={onRetry}
+        />
       )}
       {completed && (
         <div className="rounded-lg border border-success-border bg-success-background p-3">

--- a/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCatalogStore.ts
@@ -60,6 +60,7 @@ type CodeCatalogState = {
   workspaces: CodeWorkspaceSnapshot[];
   sessionsByWorkspace: Record<string, CodeSessionSnapshot>;
   doctor: HarnessDoctorReport | null;
+  doctorError: string | null;
   modelsByHarness: Partial<Record<HarnessKind, CodeModelOption[]>>;
   /**
    * Each engine's own effort ladder, which is what a code session runs on
@@ -199,6 +200,7 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
   workspaces: [],
   sessionsByWorkspace: {},
   doctor: null,
+  doctorError: null,
   modelsByHarness: {},
   effortsByHarness: {},
   loaded: false,
@@ -252,15 +254,14 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
         client
           .getHarnessDoctor()
           .then((doctor) => {
-            if (requestIsCurrent(context)) set({ doctor });
+            if (requestIsCurrent(context)) set({ doctor, doctorError: null });
           })
-          .catch(() => {
+          .catch((error) => {
             if (!requestIsCurrent(context)) return;
-            // Home waits on a settled report. An empty one leaves the loading
-            // empty and shows the install section instead of spinning forever.
-            if (get().doctor === null) {
-              set({ doctor: { harnesses: [] } });
-            }
+            set({
+              doctorError:
+                error instanceof Error ? error.message : String(error),
+            });
           }),
       ];
       for (const kind of HARNESS_KINDS) {
@@ -281,7 +282,7 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     const context = requestContext(client);
     if (!requestIsCurrent(context)) return;
     const doctor = await client.refreshHarnessDoctor();
-    if (requestIsCurrent(context)) set({ doctor });
+    if (requestIsCurrent(context)) set({ doctor, doctorError: null });
   },
   // The memoized read, for picking up an engine a download just put on disk.
   // `refreshDoctor` is the doctor's own button: it drops every memoized probe
@@ -291,7 +292,7 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
     const context = requestContext(client);
     if (!requestIsCurrent(context)) return;
     const doctor = await client.getHarnessDoctor();
-    if (requestIsCurrent(context)) set({ doctor });
+    if (requestIsCurrent(context)) set({ doctor, doctorError: null });
   },
   ensureHarnessModels: (client, kind) =>
     loadHarnessModels(client, kind, get, false),
@@ -374,6 +375,7 @@ export const useCodeCatalogStore = create<CodeCatalogStore>()((set, get) => ({
       workspaces: [],
       sessionsByWorkspace: {},
       doctor: null,
+      doctorError: null,
       modelsByHarness: {},
       effortsByHarness: {},
       loaded: false,

--- a/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeCenterTabs.tsx
@@ -57,6 +57,7 @@ import { AttentionBadge } from "./AttentionBadge";
 import { editorStripDropId, editorTabDragId } from "./editorDrag";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import { FOCUS_RING_TIGHT, HOVER_TINT } from "./interactive";
+import { MAX_WORKSPACE_TERMINALS } from "./workspace/layout";
 
 /** Ids the strip and the two center panels agree on, so tabs name panels. */
 export const CHAT_PANEL_ID = "code-center-panel-chat";
@@ -399,6 +400,11 @@ export function CodeCenterTabs({
             <DropdownMenuItem
               disabled={!canNewTerminal}
               onSelect={onNewTerminal}
+              title={
+                canNewTerminal
+                  ? undefined
+                  : `Up to ${MAX_WORKSPACE_TERMINALS} terminals per workspace`
+              }
             >
               <SquareTerminal />
               New terminal

--- a/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeComposer.tsx
@@ -109,6 +109,7 @@ export function PermissionModePicker({
   pending,
   onChange,
   scopeKey = "code-create",
+  posture,
 }: {
   value: PermissionMode;
   availableModes?: readonly PermissionMode[];
@@ -117,6 +118,7 @@ export function PermissionModePicker({
   pending?: boolean;
   onChange?: (mode: PermissionMode) => void;
   scopeKey?: string;
+  posture?: string;
 }) {
   const locked = !onChange;
   const menu = (
@@ -134,29 +136,41 @@ export function PermissionModePicker({
       }}
     />
   );
+  let control: ReactNode;
   if (pending) {
-    return (
+    control = (
       <WithTooltip label="Saving session settings">
         <span className="inline-flex" aria-busy="true">
           {menu}
         </span>
       </WithTooltip>
     );
-  }
-  if (unavailableReason) {
-    return (
+  } else if (unavailableReason) {
+    control = (
       <WithTooltip label={unavailableReason}>
         <span className="inline-flex">{menu}</span>
       </WithTooltip>
     );
+  } else if (!locked) {
+    control = menu;
+  } else {
+    // Disabled buttons drop pointer events, so the tooltip has to sit on a
+    // wrapper the reader can still hover and focus.
+    control = (
+      <WithTooltip label={SESSION_PERMISSION_MODE_LOCKED}>
+        <span className="inline-flex">{menu}</span>
+      </WithTooltip>
+    );
   }
-  if (!locked) return menu;
-  // Disabled buttons drop pointer events, so the tooltip has to sit on a
-  // wrapper the reader can still hover and focus.
   return (
-    <WithTooltip label={SESSION_PERMISSION_MODE_LOCKED}>
-      <span className="inline-flex">{menu}</span>
-    </WithTooltip>
+    <span className="flex min-w-0 flex-col items-end">
+      {control}
+      {posture && (
+        <span className="text-muted-foreground text-xs whitespace-nowrap">
+          {posture}
+        </span>
+      )}
+    </span>
   );
 }
 
@@ -662,6 +676,7 @@ export function CodeComposer({
   disabled,
   running,
   permissionMode,
+  permissionPosture,
   availableModes = MODES,
   unavailableReason,
   harness,
@@ -694,6 +709,7 @@ export function CodeComposer({
   disabled?: boolean;
   running: boolean;
   permissionMode: PermissionMode;
+  permissionPosture?: string;
   availableModes?: readonly PermissionMode[];
   /** Why no permission mode can start this session. */
   unavailableReason?: string;
@@ -1191,6 +1207,7 @@ export function CodeComposer({
             pending={settingsPending}
             onChange={onModeChange}
             scopeKey={sessionId ?? "code-create"}
+            posture={permissionPosture}
           />
         }
         contextUsage={contextUsage}

--- a/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeDeliveryPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "./delivery/views";
 import {
   deliveryRefreshErrors,
+  DeliveryRetryContext,
   PartialErrorBanner,
   RepositoryRefreshWarning,
 } from "./delivery/status";
@@ -464,42 +465,46 @@ function CodeDeliveryBody({
         />
       )}
 
-      {surface === "pull_requests" ? (
-        <PullRequestsSurface
-          repositories={repositories}
-          capability={capability}
-          loadingRepositories={repositoriesLoading}
-          repositoryLoaded={repositorySnapshot !== null}
-          repositoryError={repositoryError}
-          onRetryRepositories={() => void loadRepositories(true, true)}
-          filters={prFilters}
-          grouping={pullRequestGrouping}
-          target={
-            routeRepository && search.pr
-              ? { repository: routeRepository, number: search.pr }
-              : undefined
-          }
-        />
-      ) : (
-        <RunsSurface
-          repositories={repositories}
-          capability={capability}
-          loadingRepositories={repositoriesLoading}
-          repositoryLoaded={repositorySnapshot !== null}
-          repositoryError={repositoryError}
-          onRetryRepositories={() => void loadRepositories(true, true)}
-          filters={runFilters}
-          target={
-            routeRepository && search.runKind && search.runId
-              ? {
-                  repository: routeRepository,
-                  kind: search.runKind,
-                  id: search.runId,
-                }
-              : undefined
-          }
-        />
-      )}
+      <DeliveryRetryContext.Provider
+        value={() => void loadRepositories(true, true)}
+      >
+        {surface === "pull_requests" ? (
+          <PullRequestsSurface
+            repositories={repositories}
+            capability={capability}
+            loadingRepositories={repositoriesLoading}
+            repositoryLoaded={repositorySnapshot !== null}
+            repositoryError={repositoryError}
+            onRetryRepositories={() => void loadRepositories(true, true)}
+            filters={prFilters}
+            grouping={pullRequestGrouping}
+            target={
+              routeRepository && search.pr
+                ? { repository: routeRepository, number: search.pr }
+                : undefined
+            }
+          />
+        ) : (
+          <RunsSurface
+            repositories={repositories}
+            capability={capability}
+            loadingRepositories={repositoriesLoading}
+            repositoryLoaded={repositorySnapshot !== null}
+            repositoryError={repositoryError}
+            onRetryRepositories={() => void loadRepositories(true, true)}
+            filters={runFilters}
+            target={
+              routeRepository && search.runKind && search.runId
+                ? {
+                    repository: routeRepository,
+                    kind: search.runKind,
+                    id: search.runId,
+                  }
+                : undefined
+            }
+          />
+        )}
+      </DeliveryRetryContext.Provider>
 
       <DeliveryRepositoriesDialog
         open={repositoriesDialogOpen}

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { act, cleanup, screen, within } from "@testing-library/react";
+import { act, cleanup, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
@@ -227,22 +228,44 @@ describe("CodeHome", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("leaves the loading empty when the doctor request fails", async () => {
+  it("keeps Add repo available and retries when the engine check fails", async () => {
+    const refreshHarnessDoctor = vi.fn(async () => READY_DOCTOR);
     await renderHome(
       app({
         getHarnessDoctor: vi.fn(async () => {
           throw new Error("doctor unavailable");
         }),
+        refreshHarnessDoctor,
       }),
     );
 
     expect(
-      await screen.findByRole("heading", { name: "Set up a coding engine" }),
+      await screen.findByText(
+        "The coding engine check did not answer: doctor unavailable",
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("Start with a repository"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      screen.getByRole("heading", { name: "Start with a repository" }),
+    ).toBeInTheDocument();
+    const main = document.querySelector(".main");
+    expect(main).not.toBeNull();
+    expect(
+      within(main as HTMLElement).getByRole("button", { name: "Add repo" }),
+    ).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Re-check" }));
+    expect(refreshHarnessDoctor).toHaveBeenCalledOnce();
+  });
+
+  it("offers Try again when the repository catalog fails", async () => {
+    const listCodeRepos = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("catalog unavailable"))
+      .mockResolvedValueOnce([]);
+    await renderHome(app({ listCodeRepos }));
+
+    expect(await screen.findByText("catalog unavailable")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() => expect(listCodeRepos).toHaveBeenCalledTimes(2));
   });
 
   it("lists repos as soon as the catalog loads, without waiting for the doctor", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeHome.tsx
@@ -49,6 +49,7 @@ function CodeHomeBody() {
   const { client } = useApp();
   const startNewWorkspace = useCodeUiStore((state) => state.startNewWorkspace);
   const doctor = useCodeCatalogStore((state) => state.doctor);
+  const doctorError = useCodeCatalogStore((state) => state.doctorError);
   const repos = useCodeCatalogStore((state) => state.repos);
   const loaded = useCodeCatalogStore((state) => state.loaded);
   const error = useCodeCatalogStore((state) => state.error);
@@ -73,7 +74,8 @@ function CodeHomeBody() {
   const showDoctor = Boolean(doctor && !usable);
   // Repos resolve before the doctor. Until one of the three settled
   // bodies can render, keep this slot filled so the empty state does not pop in.
-  const showLoading = !showRepos && !showEmpty && !showDoctor && !error;
+  const showLoading =
+    !showRepos && !showEmpty && !showDoctor && !doctorError && !error;
 
   async function install(kind: HarnessKind) {
     try {
@@ -97,6 +99,8 @@ function CodeHomeBody() {
     setRefreshing(true);
     try {
       await refreshDoctor(client);
+    } catch {
+      // The existing warning remains the useful result of a failed re-check.
     } finally {
       setRefreshing(false);
     }
@@ -118,7 +122,32 @@ function CodeHomeBody() {
           </p>
         </header>
       )}
-      {error && <p className="text-sm text-critical">{error}</p>}
+      {error && (
+        <div className="notice-surface notice-critical flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm">
+          <span>{error}</span>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => void refresh(client)}
+          >
+            Try again
+          </Button>
+        </div>
+      )}
+      {doctorError && (
+        <div className="notice-surface notice-warning flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm">
+          <span>The coding engine check did not answer: {doctorError}</span>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => void onRefresh()}
+          >
+            {refreshing ? "Re-checking…" : "Re-check"}
+          </Button>
+        </div>
+      )}
       {showLoading && (
         <Empty role="status">
           <EmptyHeader>
@@ -144,6 +173,11 @@ function CodeHomeBody() {
             installs={installs}
           />
         </section>
+      )}
+      {doctorError && repos.length === 0 && (
+        <div className="flex flex-1 items-center">
+          <CodeRepoEmptyState onAddRepo={() => setAddOpen(true)} />
+        </div>
       )}
       {showEmpty && (
         <div className="flex flex-1 items-center">
@@ -264,7 +298,7 @@ export function CodeRepoEmptyState({ onAddRepo }: { onAddRepo: () => void }) {
       >
         {CODE_ONBOARDING_STEPS.map(({ icon: Icon, title, description }) => (
           <li key={title} className="relative flex gap-4 pb-7 last:pb-0">
-            <span className="z-10 grid size-9 shrink-0 place-items-center rounded-full border border-border-subtle bg-background text-muted-foreground shadow-xs">
+            <span className="z-10 grid size-9 shrink-0 place-items-center rounded-full border border-border-subtle bg-background text-muted-foreground">
               <Icon aria-hidden="true" className="size-4" strokeWidth={1.75} />
             </span>
             <span className="min-w-0 pt-0.5">

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.dom.test.tsx
@@ -791,6 +791,11 @@ describe("NewWorkspaceDialog", () => {
     expect(
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeEnabled();
+    expect(
+      screen.getByText(
+        "This engine's permission system is off; every action runs without asking",
+      ),
+    ).toBeVisible();
 
     fireEvent.keyDown(screen.getByRole("dialog"), {
       key: "Enter",

--- a/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/NewWorkspaceDialog.tsx
@@ -77,6 +77,7 @@ import { startFirstSession } from "./startWorkspaceSession";
 import { HARNESS_ICONS } from "./HarnessPicker";
 import {
   createPermissionModes,
+  createPermissionModePosture,
   defaultCreatePermissionMode,
   effortLadder,
   gatewayCodeModels,
@@ -1281,6 +1282,14 @@ export function NewWorkspaceDialog({
                     />
                   </span>
                 </WithTooltip>
+                {selectedHarness && (
+                  <p className="text-muted-foreground px-2 text-xs whitespace-nowrap">
+                    {createPermissionModePosture(
+                      postedMode,
+                      selectedHarness.caps,
+                    )}
+                  </p>
+                )}
                 {selectedHarness?.relaunch_composes_permission_mode ===
                   false && (
                   <p className="text-muted-foreground px-2 text-xs">

--- a/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/RepositorySettings.tsx
@@ -291,7 +291,9 @@ export function RepositorySettings({
             </label>
             <p className="text-xs text-muted-foreground">
               Runs after a worktree is created or restored. Tidebreak sets
-              TIDEBREAK_REPO_ROOT and TIDEBREAK_WORKSPACE_NAME.
+              TIDEBREAK_REPO_ROOT and TIDEBREAK_WORKSPACE_NAME. A failure leaves
+              the workspace in Setup failed. Fix the script, then pick Retry
+              setup; the checkout is kept.
             </p>
           </div>
           <div className="flex min-w-0 flex-col gap-1.5">

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.dom.test.tsx
@@ -177,6 +177,11 @@ describe("StartSessionPrompt", () => {
       screen.getByRole("button", { name: "Permissions: Allow all" }),
     ).toBeInTheDocument();
     expect(
+      screen.getByText(
+        "This engine's permission system is off; every action runs without asking",
+      ),
+    ).toBeVisible();
+    expect(
       screen.getByRole("combobox", { name: "Harness" }).closest("form"),
     ).toHaveClass("chat-composer");
     const field = screen.getByRole("textbox", { name: "Message" });

--- a/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/StartSessionPrompt.tsx
@@ -28,6 +28,7 @@ import {
   CREATE_PERMISSION_MODE_FIXED,
   HARNESS_LABELS,
   createPermissionModes,
+  createPermissionModePosture,
   defaultCreatePermissionMode,
   effortLadder,
   gatewayCodeModels,
@@ -404,6 +405,11 @@ export function StartSessionPrompt({
           disabled={starting || !selected || !installed || policyBlocksStart}
           running={starting}
           permissionMode={mode}
+          permissionPosture={
+            selected
+              ? createPermissionModePosture(mode, selected.caps)
+              : undefined
+          }
           availableModes={availableModes}
           unavailableReason={
             policyBlocksStart ? PERMISSION_MODE_POLICY_BLOCKED : undefined

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.dom.test.tsx
@@ -171,6 +171,35 @@ describe("Create PR", () => {
       "Ship this branch to `main`.",
     );
   });
+
+  it("disables creation with the GitHub remediation when the capability is unavailable", () => {
+    const remediation = "Install GitHub CLI and sign in.";
+    render(
+      <WorkspaceWorkflowControl
+        client={{
+          startCodeWatch: vi.fn(),
+          stopCodeWatch: vi.fn(),
+          writeCodeCheckLogs: vi.fn(),
+          mergeCodePr: vi.fn(),
+          markCodePrReady: vi.fn(),
+          pushCodeWorkspace: vi.fn(),
+          createCodePullRequest: vi.fn(),
+        }}
+        workspaceId="ws-1"
+        branchName="topic"
+        baseRef="main"
+        resource={{
+          ...resource(),
+          data: { ...dirtyLocal, gh_found: false, remediation },
+        }}
+        onOpenSourceControl={vi.fn()}
+      />,
+    );
+
+    const create = screen.getByRole("button", { name: "Create PR" });
+    expect(create).toBeDisabled();
+    expect(create).toHaveAttribute("title", remediation);
+  });
 });
 
 describe("Fix checks", () => {

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceWorkflowControl.tsx
@@ -136,6 +136,10 @@ export function WorkspaceWorkflowControl({
     model.pr && resource.mutationError?.includes("Refresh workspace status")
       ? `Pull request #${model.pr.number} changed`
       : model.title;
+  const githubUnavailable = resource.data?.gh_found === false;
+  const githubRemediation = githubUnavailable
+    ? resource.data?.remediation || "Install and connect the GitHub CLI."
+    : undefined;
 
   // Republish the primary action for the command palette, which leads with it.
   // Cleared on unmount so the palette never offers a step for a workspace the
@@ -398,6 +402,10 @@ export function WorkspaceWorkflowControl({
         onOpenSourceControl();
         return;
       case "compose_pr":
+        if (githubRemediation) {
+          toast.error(githubRemediation);
+          return;
+        }
         setDetailsOpen(false);
         if (!runComposerPrompt(workspaceId, composePrPrompt(baseRef))) {
           toast.error("Another agent action is already running");
@@ -435,6 +443,10 @@ export function WorkspaceWorkflowControl({
         }
         return;
       case "create_pr":
+        if (githubRemediation) {
+          toast.error(githubRemediation);
+          return;
+        }
         try {
           const next = await resource.runMutation("create_pr", async () => {
             const created = await client.createCodePullRequest(workspaceId);
@@ -633,7 +645,12 @@ export function WorkspaceWorkflowControl({
             variant="ghost"
             size="sm"
             className="h-control shrink-0 rounded-none border-l border-border-subtle bg-foreground px-2.5 text-background hover:bg-foreground/90 hover:text-background"
-            disabled={disabled || model.stage === "loading"}
+            disabled={
+              disabled ||
+              model.stage === "loading" ||
+              ((primary === "compose_pr" || primary === "create_pr") &&
+                githubUnavailable)
+            }
             aria-busy={busy !== null || agentActionRunning || attachingLogs}
             onClick={() => void run(primary)}
             title={
@@ -641,7 +658,9 @@ export function WorkspaceWorkflowControl({
                 ? "Commit and push your changes to this pull request."
                 : primary === "watch_and_fix"
                   ? "Ask the agent in this conversation to monitor the PR and fix actionable failures."
-                  : undefined
+                  : primary === "compose_pr" || primary === "create_pr"
+                    ? githubRemediation
+                    : undefined
             }
           >
             {busy !== null || agentActionRunning || attachingLogs ? (
@@ -668,7 +687,16 @@ export function WorkspaceWorkflowControl({
                 <DropdownMenuItem
                   key={action}
                   disabled={
-                    disabled && action !== "open_pr" && action !== "open_source"
+                    (disabled &&
+                      action !== "open_pr" &&
+                      action !== "open_source") ||
+                    ((action === "compose_pr" || action === "create_pr") &&
+                      githubUnavailable)
+                  }
+                  title={
+                    action === "compose_pr" || action === "create_pr"
+                      ? githubRemediation
+                      : undefined
                   }
                   onSelect={() => void run(action)}
                 >

--- a/crates/tidebreak-desktop/ui/src/code/delivery/status.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/delivery/status.tsx
@@ -18,6 +18,9 @@ import { cn } from "@/lib/utils";
 import { humanize, runTone } from "./helpers";
 import { relativeTime } from "../PullRequestDetail";
 import { STATUS_CHIP, STATUS_TEXT } from "../statusTone";
+import { createContext, useContext } from "react";
+
+export const DeliveryRetryContext = createContext<(() => void) | null>(null);
 
 /**
  * How many rows there are, how old they are, and a way to reread them.
@@ -122,9 +125,13 @@ export function RepositoryRefreshWarning({
 
 export function GitHubUnavailable({
   capability,
+  onRetry,
 }: {
   capability: CodeGitHubCapability;
+  onRetry?: () => void;
 }) {
+  const contextRetry = useContext(DeliveryRetryContext);
+  const retry = onRetry ?? contextRetry;
   return (
     <Empty className="min-h-80">
       <EmptyHeader>
@@ -134,6 +141,11 @@ export function GitHubUnavailable({
         <EmptyTitle>GitHub is not connected</EmptyTitle>
         <EmptyDescription>{capability.remediation}</EmptyDescription>
       </EmptyHeader>
+      {retry && (
+        <Button type="button" variant="outline" onClick={retry}>
+          Try again
+        </Button>
+      )}
     </Empty>
   );
 }

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -118,6 +118,20 @@ export const PERMISSION_MODE_POSTURES: Record<PermissionMode, string> = {
   allow: "Runs every tool without asking",
 };
 
+/** Create-time posture, strengthened where the engine will not ask at all. */
+export function createPermissionModePosture(
+  mode: PermissionMode,
+  caps: ModeCaps,
+): string {
+  if (mode === "allow") {
+    return "This engine's permission system is off; every action runs without asking";
+  }
+  if (mode === "auto" && caps.structured_approvals !== "supported") {
+    return "This engine has no approval channel; every action proceeds without asking";
+  }
+  return PERMISSION_MODE_POSTURES[mode];
+}
+
 /** The header chip's tooltip: the posture, named and spelled out. */
 export function sessionPermissionModeTooltip(mode: PermissionMode): string {
   return `Permissions: ${PERMISSION_MODE_LABELS[mode]}\n${PERMISSION_MODE_POSTURES[mode]}`;

--- a/crates/tidebreak-desktop/ui/src/code/useAddRepoInline.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useAddRepoInline.ts
@@ -26,6 +26,14 @@ import {
 
 const CLONE_POLL_INTERVAL_MS = 1_500;
 
+export function displayClonePhase(phase?: string | null): string {
+  if (!phase || phase === "starting") return "Starting";
+  if (phase === "done") return "Clone complete";
+  return phase
+    .replace(/[_-]+/g, " ")
+    .replace(/^./, (letter) => letter.toUpperCase());
+}
+
 /** What the inline add-repo field is doing, and what it needs to finish. */
 export type AddRepoInlineState = {
   value: string;
@@ -367,7 +375,7 @@ export function useAddRepoInline({
     blocked,
     busy,
     error,
-    phase: jobId ? (job?.phase ?? "Starting") : null,
+    phase: jobId ? displayClonePhase(job?.phase) : null,
     percent: jobId ? (job?.percent ?? null) : null,
     defaultsProbeFailed: defaultsProbeFailed && !seededDestination,
     defaultsBusy,

--- a/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/NewWorkspace.stories.tsx
@@ -321,6 +321,9 @@ type Story = StoryObj<typeof meta>;
  */
 export const Default: Story = {};
 
+/** The autonomous default states its bypass posture before any interaction. */
+export const AllowPostureOnOpen: Story = {};
+
 /** A clipboard image stays attached instead of inserting its local path. */
 export const PastedImage: Story = {};
 

--- a/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StartSession.stories.tsx
@@ -216,6 +216,9 @@ type Story = StoryObj<typeof meta>;
 /** Four engines, each with its honest mode list. */
 export const AllEngines: Story = {};
 
+/** The autonomous default states its bypass posture before any interaction. */
+export const AllowPostureOnOpen: Story = {};
+
 export const PastedTextBeforeSession: Story = {
   args: {
     pastedText: `Session report\n${"x".repeat(1_000)}`,


### PR DESCRIPTION
## Summary
1. State the selected permission posture under both create controls on open, with explicit Allow and unsupervised Auto wording, DOM coverage, and stories for both dialogs.
2. Preserve harness doctor failures as a distinct catalog state and show a warning with Re-check while keeping Add repo available.
3. Replace the Code home catalog error line with a notice and Try again action.
4. Disable both prompt-driven and direct Create PR actions when the workspace reports GitHub unavailable, using the remediation as the tooltip.
5. Add Try again to the GitHub unavailable delivery state and reload repository capability with a forced, notifying refresh.
6. Group unavailable repository sources under “Not available on this machine” and de-duplicate identical remediation text.
7. Map clone phase tokens through one exported display helper used by the palette, inline component, and inline hook.
8. Show “The clone finished without a repository.” with Retry when a completed palette clone has no error or repository id.
9. Explain setup-script failure state, recovery, and checkout retention in repository settings.
10. Explain the per-workspace terminal cap in the disabled New terminal item title.
11. Remove the resting shadow from Code home onboarding step markers.

## Skipped
None. Each reported condition was present after rebasing the checkpoint onto `origin/main` at `10c10674`.

## Checks
- `pnpm install --frozen-lockfile`: Done in 23.4s using pnpm v10.18.3
- `pnpm exec biome format --write src`: Formatted 926 files in 915ms. No fixes applied.
- `pnpm exec biome format src`: Checked 926 files in 903ms. No fixes applied.
- `pnpm lint`: Checked 926 files in 994ms. No fixes applied.
- `pnpm test`: Test Files 287 passed (287); Tests 2535 passed (2535); Duration 202.96s.
- `pnpm build`: ✓ built in 7.45s
- `pnpm storybook:build`: Storybook build completed successfully
