### PR TITLE
fix(code): one-query open-turn lookup, envelope every route rejection, and close external-route gaps

### DIFF
--- a/crates/tidebreak-cli/src/api/code.rs
+++ b/crates/tidebreak-cli/src/api/code.rs
@@ -33,8 +33,8 @@ pub use tidebreak_server::wire::{
 
 use super::client::{Client, EventSocket};
 
-/// Result of `POST /sessions/{id}/turns`: the turn that ran on `200`, or
-/// the follow-up the server parked on `202`. The server answers with one of
+/// Result of `POST /sessions/{id}/turns`: the turn that ran or the follow-up
+/// the server parked, both on `202`. The server answers with one of
 /// two snapshots rather than a tagged union, so this is the one code-mode
 /// shape the client composes itself. Both arms reject unknown keys, so a
 /// snapshot that matches neither fails rather than folding into the other.

--- a/crates/tidebreak-core/src/db/ops/code/incarnation.rs
+++ b/crates/tidebreak-core/src/db/ops/code/incarnation.rs
@@ -264,9 +264,9 @@ pub async fn record_incarnation_spend(
     owner: &OwnerId,
     id: CodeIncarnationId,
     spend_microusd: i64,
-) -> Result<()> {
+) -> Result<bool> {
     let now = database_now(&store.conn).await?;
-    entities::code_session_incarnation::Entity::update_many()
+    let result = entities::code_session_incarnation::Entity::update_many()
         .col_expr(
             entities::code_session_incarnation::Column::SpendMicrousd,
             sea_orm::sea_query::Expr::value(spend_microusd),
@@ -280,7 +280,7 @@ pub async fn record_incarnation_spend(
         .exec(&store.conn)
         .await
         .map_err(store_err)?;
-    Ok(())
+    Ok(result.rows_affected == 1)
 }
 
 /// What one sandbox event writes besides its journal rows.

--- a/crates/tidebreak-core/src/db/ops/code/turn.rs
+++ b/crates/tidebreak-core/src/db/ops/code/turn.rs
@@ -320,8 +320,18 @@ pub async fn get_open_turn(
     owner: &OwnerId,
     session_id: SessionId,
 ) -> Result<Option<Turn>> {
-    let turns = list_turns(store, owner, session_id).await?;
-    Ok(turns.into_iter().rev().find(|turn| turn.status.is_open()))
+    let row = entities::turn::Entity::find()
+        .filter(entities::turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::turn::Column::SessionId.eq(session_id.0))
+        .filter(
+            entities::turn::Column::Status
+                .is_in(TurnStatus::LIVE.iter().map(|status| status.as_str())),
+        )
+        .order_by_desc(entities::turn::Column::Ordinal)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?;
+    row.map(turn_from_row).transpose()
 }
 
 /// Next 1-based ordinal for a new turn on one of the owner's sessions.

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -12,13 +12,14 @@ use crate::db::code::{
     cancel_permission_mode_change, claim_approval, clear_session_harness_resume_ref,
     confirm_permission_mode_change, delete_queued_turn, delete_session_queued_turns,
     discard_permission_mode_change, enqueue_queued_turn, fence_permission_mode_change,
-    get_approval, get_repo, get_repo_by_root_path, get_session, get_turn, get_workspace,
-    insert_approval, insert_approval_for_worker, insert_repo, insert_session, insert_turn,
-    insert_workspace, list_approvals, list_events, list_pending_permission_mode_changes,
-    list_queued_turns, list_repos, list_sessions, list_turn_metrics, list_turns, mark_repo_removed,
-    promote_queued_turn, queue_paused, queued_turn_head, recover_interrupted_session,
-    replace_session_attention, replace_session_execution_settings, save_session, save_turn,
-    save_workspace, search_repo_transcripts, set_active_workspace_pull_request, set_queue_paused,
+    get_approval, get_open_turn, get_repo, get_repo_by_root_path, get_session, get_turn,
+    get_workspace, insert_approval, insert_approval_for_worker, insert_repo, insert_session,
+    insert_turn, insert_workspace, list_approvals, list_events,
+    list_pending_permission_mode_changes, list_queued_turns, list_repos, list_sessions,
+    list_turn_metrics, list_turns, mark_repo_removed, promote_queued_turn, queue_paused,
+    queued_turn_head, recover_interrupted_session, replace_session_attention,
+    replace_session_execution_settings, save_session, save_turn, save_workspace,
+    search_repo_transcripts, set_active_workspace_pull_request, set_queue_paused,
     set_session_harness_resume_ref, set_session_subagents, set_turn_narrative, set_turn_rewrite,
     set_workspace_title_if, settle_approval_claim, update_queued_turn, ClaimedApprovalSettlement,
     CodeTranscriptSearchSource, JournalError, SessionExecutionSettings, MAX_REPLAY_EVENTS,
@@ -397,6 +398,38 @@ async fn seed_owner(
     .await
     .unwrap();
     (session_id, turn_id)
+}
+
+#[tokio::test]
+async fn turn_open_lookup_ignores_closed_turns() {
+    let (_dir, store, session_id, first_id) = seeded_session().await;
+    let owner = OwnerId::local();
+    let mut first = get_turn(&store, &owner, first_id).await.unwrap().unwrap();
+    first.status = TurnStatus::Completed;
+    first.ended_at = Some(now());
+    assert!(save_turn(&store, &owner, &first).await.unwrap());
+
+    for (ordinal, status) in [(2, TurnStatus::Failed), (3, TurnStatus::Interrupted)] {
+        let mut closed = first.clone();
+        closed.id = TurnId::new();
+        closed.ordinal = ordinal;
+        closed.status = status;
+        insert_turn(&store, &owner, &closed).await.unwrap();
+    }
+    let open_id = TurnId::new();
+    let mut open = first;
+    open.id = open_id;
+    open.ordinal = 4;
+    open.status = TurnStatus::Waiting;
+    open.ended_at = None;
+    insert_turn(&store, &owner, &open).await.unwrap();
+
+    let found = get_open_turn(&store, &owner, session_id)
+        .await
+        .unwrap()
+        .expect("open turn");
+    assert_eq!(found.id, open_id);
+    assert_eq!(found.status, TurnStatus::Waiting);
 }
 
 async fn claimed_trigger_delivery(
@@ -5437,9 +5470,11 @@ async fn reincarnation_counts_up_and_the_ledger_sums_across_incarnations() {
     crate::db::code::activate_incarnation(&store, &owner, first.id, "sandbox-1")
         .await
         .unwrap();
-    crate::db::code::record_incarnation_spend(&store, &owner, first.id, 1_500_000)
-        .await
-        .unwrap();
+    assert!(
+        crate::db::code::record_incarnation_spend(&store, &owner, first.id, 1_500_000)
+            .await
+            .unwrap()
+    );
     crate::db::code::stop_incarnation(&store, &owner, first.id, Some("completed"))
         .await
         .unwrap();
@@ -5453,9 +5488,11 @@ async fn reincarnation_counts_up_and_the_ledger_sums_across_incarnations() {
     crate::db::code::activate_incarnation(&store, &owner, second.id, "sandbox-2")
         .await
         .unwrap();
-    crate::db::code::record_incarnation_spend(&store, &owner, second.id, 700_000)
-        .await
-        .unwrap();
+    assert!(
+        crate::db::code::record_incarnation_spend(&store, &owner, second.id, 700_000)
+            .await
+            .unwrap()
+    );
 
     assert_eq!(
         crate::db::code::session_spend_microusd(&store, &owner, session)
@@ -5470,6 +5507,19 @@ async fn reincarnation_counts_up_and_the_ledger_sums_across_incarnations() {
     assert_eq!(latest.incarnation, 2);
     // The predecessor's journaled gate is on its own row, not the latest.
     assert!(!latest.terminal_events_journaled);
+}
+
+#[tokio::test]
+async fn recording_spend_reports_a_missing_incarnation() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let missing = crate::code::CodeIncarnationId::new();
+
+    assert!(
+        !crate::db::code::record_incarnation_spend(&store, &owner, missing, 1)
+            .await
+            .unwrap()
+    );
 }
 
 /// The sweep reads exactly the intents whose spawn outcome nothing recorded:

--- a/crates/tidebreak-server-api/src/routes/code/analytics.rs
+++ b/crates/tidebreak-server-api/src/routes/code/analytics.rs
@@ -5,7 +5,6 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use axum::extract::Query;
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::Deserialize;
 use tidebreak_core::{
@@ -14,7 +13,7 @@ use tidebreak_core::{
 
 use crate::code::ScopedCode;
 use crate::error::ServerError;
-use crate::extract::Json;
+use crate::extract::{Json, Query};
 
 use super::types::{
     CodeAnalyticsDay, CodeAnalyticsHarness, CodeAnalyticsModel, CodeAnalyticsPricingCoverage,

--- a/crates/tidebreak-server-api/src/routes/code/approvals.rs
+++ b/crates/tidebreak-server-api/src/routes/code/approvals.rs
@@ -1,11 +1,10 @@
-use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
 use crate::code::runtime::ApprovalDecisionRequest;
 use crate::code::ScopedCode;
 use crate::error::ServerError;
-use crate::extract::{Json, Path};
+use crate::extract::{Json, Path, Query};
 use tidebreak_core::ApprovalId;
 
 use super::types::{ApprovalDecision, ApprovalDecisionBody, ApprovalSnapshot, ListApprovalsQuery};

--- a/crates/tidebreak-server-api/src/routes/code/delivery.rs
+++ b/crates/tidebreak-server-api/src/routes/code/delivery.rs
@@ -1,11 +1,10 @@
 //! Cross-repository GitHub delivery routes.
 
-use axum::extract::Query;
 use serde::Deserialize;
 
 use crate::code::ScopedCode;
 use crate::error::ServerError;
-use crate::extract::Json;
+use crate::extract::{Json, Query};
 
 use super::types::{
     CodeDeliveryActionResult, CodeDeliveryPullRequestActionBody, CodeDeliveryPullRequestDetail,

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -480,7 +480,7 @@ pub async fn external_get_or_create(
 }
 
 #[derive(serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+// Same tolerance as `ExternalSessionBody`: older adapters send channel fields.
 pub struct ExternalBindingBody {
     pub external_key: String,
     #[serde(default)]

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -89,7 +89,68 @@ async fn require_bound(
     Ok(runtime)
 }
 
+async fn existing_session_identity(
+    runtime: &crate::code::runtime::CodeRuntime,
+    owner: &tidebreak_core::OwnerId,
+    acts_as: tidebreak_core::ActsAs,
+) -> Result<crate::code::runtime::ExternalActsAsView, ServerError> {
+    use tidebreak_server_core::obo_gateway::{
+        GitForgeAttribution, GitForgeAttributionRequest, GitForgeError,
+    };
+
+    let mut view = crate::code::runtime::ExternalActsAsView {
+        acts_as,
+        acting_login: None,
+        app_name: None,
+        connect_url: None,
+    };
+    let Some(lender) = runtime.git_credentials() else {
+        return Ok(view);
+    };
+    if acts_as == tidebreak_core::ActsAs::Person {
+        match lender
+            .git_forge_identity(owner, GitForgeAttributionRequest::Person)
+            .await
+        {
+            Ok(identity) => {
+                view.app_name = Some(identity.app_name).filter(|name| !name.is_empty());
+                if let GitForgeAttribution::Person { login, .. } = identity.attribution {
+                    view.acting_login = Some(login);
+                    return Ok(view);
+                }
+            }
+            Err(GitForgeError::NotConnected { connect_url }) => {
+                view.connect_url = connect_url;
+            }
+            Err(GitForgeError::PersonNotOffered | GitForgeError::NoGitForge) => {}
+            Err(GitForgeError::Unavailable(detail)) => {
+                return Err(ServerError::bad_gateway_kind(
+                    "forge_unavailable",
+                    format!("the forge is temporarily unavailable; retry ({detail})"),
+                ));
+            }
+            Err(_) => {
+                return Err(ServerError::bad_gateway_kind(
+                    "forge_unavailable",
+                    "the forge could not answer who this session acts as; retry",
+                ));
+            }
+        }
+    }
+    if let Ok(identity) = lender
+        .git_forge_identity(owner, GitForgeAttributionRequest::Installation)
+        .await
+    {
+        view.app_name = Some(identity.app_name).filter(|name| !name.is_empty());
+        if let GitForgeAttribution::Bot { bot_login } = identity.attribution {
+            view.acting_login = bot_login;
+        }
+    }
+    Ok(view)
+}
+
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalSessionBody {
     /// The channel's durable conversation identity, opaque here.
     pub external_key: String,
@@ -299,6 +360,7 @@ pub async fn external_get_or_create(
         let session = runtime
             .get_session(&grant.owner, binding.session_id)
             .await?;
+        let identity = existing_session_identity(&runtime, &grant.owner, session.acts_as()).await?;
         let ended = session.lifecycle == tidebreak_core::SessionLifecycle::Ended;
         if !ended {
             repair_original_context(&runtime, &grant, &binding, body.channel_id.as_deref()).await?;
@@ -310,9 +372,9 @@ pub async fn external_get_or_create(
                 session_id: binding.session_id,
                 binding_id: (!ended).then_some(binding.id),
                 acts_as: session.acts_as(),
-                acting_login: None,
-                app_name: None,
-                connect_url: None,
+                acting_login: identity.acting_login.clone(),
+                app_name: identity.app_name.clone(),
+                connect_url: identity.connect_url.clone(),
             }),
         ));
     }
@@ -417,6 +479,7 @@ pub async fn external_get_or_create(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalBindingBody {
     pub external_key: String,
     #[serde(default)]
@@ -512,6 +575,7 @@ pub async fn external_bindings(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalMessageBody {
     pub text: String,
     /// The channel's delivery id; replays of it answer from the first row.
@@ -536,6 +600,7 @@ pub struct ExternalMessageBody {
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalActor {
     pub external_identity: String,
     pub display: String,
@@ -642,11 +707,13 @@ pub async fn external_messages(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalAccessBody {
     pub contributors: Vec<ExternalContributor>,
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalContributor {
     pub external_identity: String,
 }
@@ -793,6 +860,7 @@ pub async fn external_reap(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalRotateBody {
     pub refresh: String,
 }
@@ -833,6 +901,7 @@ pub async fn external_rotate(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalDecisionActor {
     pub external_identity: String,
     #[serde(default)]
@@ -840,6 +909,7 @@ pub struct ExternalDecisionActor {
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExternalDecisionBody {
     pub decision: ApprovalDecision,
     #[serde(default)]

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -150,7 +150,8 @@ async fn existing_session_identity(
 }
 
 #[derive(serde::Deserialize)]
-#[serde(deny_unknown_fields)]
+// Older adapters still send `channel_id` and `set_by` (decision 0096 kept the
+// per-channel confirms for them), so this body tolerates unknown fields.
 pub struct ExternalSessionBody {
     /// The channel's durable conversation identity, opaque here.
     pub external_key: String,

--- a/crates/tidebreak-server-api/src/routes/code/git.rs
+++ b/crates/tidebreak-server-api/src/routes/code/git.rs
@@ -60,6 +60,11 @@ pub async fn list_workspace_pull_requests(
     Path(id): Path<WorkspaceId>,
 ) -> Result<Json<CodeWorkspacePullRequests>, ServerError> {
     let facts = code.workspace_pull_requests(id).await?;
+    let fetched_at = facts
+        .iter()
+        .map(|(fact, _)| fact.last_seen_at)
+        .max()
+        .unwrap_or_else(chrono::Utc::now);
     let items = facts
         .into_iter()
         .map(|(fact, relation)| CodeWorkspacePullRequestFact {
@@ -83,10 +88,7 @@ pub async fn list_workspace_pull_requests(
             last_seen_at: fact.last_seen_at,
         })
         .collect();
-    Ok(Json(CodeWorkspacePullRequests {
-        items,
-        fetched_at: chrono::Utc::now(),
-    }))
+    Ok(Json(CodeWorkspacePullRequests { items, fetched_at }))
 }
 
 pub async fn refresh_workspace_pr(

--- a/crates/tidebreak-server-api/src/routes/code/grants.rs
+++ b/crates/tidebreak-server-api/src/routes/code/grants.rs
@@ -100,6 +100,7 @@ pub async fn list_grants(code: ScopedCode) -> Result<Json<Vec<CodeGrantSnapshot>
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RevokeGrantBody {
     #[serde(default)]
     pub reason: Option<String>,
@@ -130,6 +131,7 @@ pub async fn revoke_grant(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RevokeWorkspaceBody {
     pub channel_kind: String,
     pub workspace_identity: String,
@@ -155,6 +157,7 @@ pub async fn revoke_workspace_grants(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConnectStartBody {
     pub channel_kind: String,
     pub external_identity: String,
@@ -240,6 +243,7 @@ pub async fn connect_view(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConnectApproveBody {
     pub csrf: String,
 }
@@ -316,6 +320,7 @@ pub async fn connect_complete(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceGrantStartBody {
     pub channel_kind: String,
     pub workspace_identity: String,
@@ -379,6 +384,7 @@ pub async fn view_workspace_grant(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceApproveBody {
     pub csrf: String,
 }
@@ -396,6 +402,7 @@ pub async fn approve_workspace_grant(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConfirmRepositoryBody {
     pub repository: String,
 }

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -118,10 +118,11 @@ pub(crate) use types::{
     SessionSnapshot, SetCodeWorktreeRootBody, SetSessionVisibilityBody, TurnSnapshot,
     UpdateCodeTriggerBody, UpdateNotice, WorkspaceTitleProposal,
 };
-#[allow(unused_imports)] // Compatibility exports keep these route paths stable.
+#[cfg(test)]
+#[allow(unused_imports)]
 pub(crate) use types::{
-    CodeCloneDefaults, CodeCloneJobSnapshot, CodeGithubRepositories, CodeGithubRepository,
-    CodeHarnessInstallSnapshot, CodeRepoSource, CodeRepoSources, CodeWorktreeRoot,
+    CodeCloneDefaults, CodeCloneJobSnapshot, CodeGithubRepositories, CodeHarnessInstallSnapshot,
+    CodeRepoSource, CodeRepoSources, CodeWorktreeRoot,
 };
 pub(crate) use updates::code_updates;
 pub(crate) use usage::subscription_usage;

--- a/crates/tidebreak-server-api/src/routes/code/session_events.rs
+++ b/crates/tidebreak-server-api/src/routes/code/session_events.rs
@@ -345,9 +345,7 @@ async fn send_frame(
     socket: &mut WebSocket,
     frame: &SequencedEventFrame,
 ) -> Result<(), axum::Error> {
-    let Ok(json) = serde_json::to_string(frame) else {
-        return Ok(());
-    };
+    let json = serde_json::to_string(frame).map_err(axum::Error::new)?;
     socket.send(Message::Text(json.into())).await
 }
 

--- a/crates/tidebreak-server-api/src/routes/code/sessions.rs
+++ b/crates/tidebreak-server-api/src/routes/code/sessions.rs
@@ -317,7 +317,7 @@ pub async fn post_queue_send_now(
 pub async fn fork_session(
     code: ScopedCode,
     Path(id): Path<SessionId>,
-    body: axum::body::Bytes,
+    RawBytes(body): RawBytes,
 ) -> Result<(StatusCode, Json<CodeForkTranscript>), ServerError> {
     let at_turn = if body.is_empty() {
         None

--- a/crates/tidebreak-server-api/src/routes/code/triggers.rs
+++ b/crates/tidebreak-server-api/src/routes/code/triggers.rs
@@ -4,15 +4,14 @@
 //! request, so every route here is repository-scoped rather than
 //! workspace-scoped (decision record 60).
 
-use axum::extract::Path;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::Json;
 use tidebreak_core::{CodeTriggerId, RepoId};
 
 use super::types::{CodeTriggerSnapshot, CreateCodeTriggerBody, UpdateCodeTriggerBody};
 use crate::code::ScopedCode;
 use crate::error::ServerError;
+use crate::extract::{Json, Path};
 
 pub async fn list_repo_triggers(
     code: ScopedCode,

--- a/crates/tidebreak-server-api/src/routes/code/updates.rs
+++ b/crates/tidebreak-server-api/src/routes/code/updates.rs
@@ -152,7 +152,37 @@ async fn stream_updates(
                         break;
                     }
                 }
-                Err(RecvError::Lagged(_)) => {}
+                Err(RecvError::Lagged(_)) => {
+                    let workspaces = match tidebreak_core::db::code::list_workspaces(&runtime.db, &owner, None).await {
+                        Ok(workspaces) => workspaces,
+                        Err(_) => break,
+                    };
+                    let mut failed = false;
+                    for workspace in workspaces {
+                        for terminal in state.terminals.list(workspace.id) {
+                            if !terminal.ended
+                                && send_notice(
+                                    &mut socket,
+                                    &UpdateNotice::TerminalActivity {
+                                        workspace_id: workspace.id,
+                                        terminal_id: terminal.id,
+                                    },
+                                )
+                                .await
+                                .is_err()
+                            {
+                                failed = true;
+                                break;
+                            }
+                        }
+                        if failed {
+                            break;
+                        }
+                    }
+                    if failed {
+                        break;
+                    }
+                }
                 Err(RecvError::Closed) => break,
             },
         }
@@ -178,8 +208,6 @@ async fn send_snapshot(
 }
 
 async fn send_notice(socket: &mut WebSocket, notice: &UpdateNotice) -> Result<(), axum::Error> {
-    let Ok(json) = serde_json::to_string(notice) else {
-        return Ok(());
-    };
+    let json = serde_json::to_string(notice).map_err(axum::Error::new)?;
     socket.send(Message::Text(json.into())).await
 }

--- a/crates/tidebreak-server-api/src/routes/code/usage.rs
+++ b/crates/tidebreak-server-api/src/routes/code/usage.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tidebreak_core::OwnerId;
 use tidebreak_harness::{filter_child_env, probe_shell, HostEnv, ProbeCapture};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -129,7 +129,7 @@ where
         Ok(Some(provider)) => CodeSubscriptionUsage {
             source: UsageSource::Direct,
             providers: vec![provider],
-            diagnostics: Vec::new(),
+            diagnostics,
         },
         Ok(None) => {
             diagnostics.push("Codex returned no subscription usage.".into());
@@ -157,17 +157,48 @@ async fn collect_modelctl() -> Result<Option<CodeSubscriptionUsage>, String> {
         .map_err(|error| error.to_string())?;
     let mut command = command_from_probe(&probe);
     command.args(["--json", "usage"]);
-    let output = timeout(COMMAND_TIMEOUT, command.output())
-        .await
-        .map_err(|_| "usage command timed out".to_owned())?
+    let mut child = command
+        .spawn()
         .map_err(|error| format!("could not run usage command: {error}"))?;
-    if !output.status.success() {
-        return Err(bounded_text(&output.stderr, 320));
+    let stdout = child.stdout.take().ok_or("usage command has no stdout")?;
+    let stderr = child.stderr.take().ok_or("usage command has no stderr")?;
+    let collect = async {
+        let stdout_read = async {
+            let mut bytes = Vec::new();
+            stdout
+                .take((MAX_JSON_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)
+                .await
+                .map_err(|error| format!("could not read usage response: {error}"))?;
+            Ok::<_, String>(bytes)
+        };
+        let stderr_read = async {
+            let mut bytes = Vec::new();
+            stderr
+                .take(321)
+                .read_to_end(&mut bytes)
+                .await
+                .map_err(|error| format!("could not read usage error: {error}"))?;
+            Ok::<_, String>(bytes)
+        };
+        let (stdout, stderr, status) = tokio::try_join!(stdout_read, stderr_read, async {
+            child
+                .wait()
+                .await
+                .map_err(|error| format!("could not wait for usage command: {error}"))
+        })?;
+        Ok::<_, String>((stdout, stderr, status))
+    };
+    let (stdout, stderr, status) = timeout(COMMAND_TIMEOUT, collect)
+        .await
+        .map_err(|_| "usage command timed out".to_owned())??;
+    if !status.success() {
+        return Err(bounded_text(&stderr, 320));
     }
-    if output.stdout.len() > MAX_JSON_BYTES {
+    if stdout.len() > MAX_JSON_BYTES {
         return Err("usage response was too large".into());
     }
-    let raw: ModelctlUsage = serde_json::from_slice(&output.stdout)
+    let raw: ModelctlUsage = serde_json::from_slice(&stdout)
         .map_err(|error| format!("could not decode usage response: {error}"))?;
     Ok(Some(normalize_modelctl(raw)))
 }
@@ -443,8 +474,10 @@ fn codex_window(limit_id: &str, limit_label: &str, slot: &str, window: CodexWind
 }
 
 fn format_window_duration(minutes: i64) -> String {
-    if minutes % 10_080 == 0 {
-        format!("Weekly ({}d)", minutes / 1_440)
+    if minutes <= 0 {
+        format!("{minutes}m")
+    } else if minutes == 10_080 {
+        "Weekly (7d)".to_owned()
     } else if minutes % 1_440 == 0 {
         format!("{}d", minutes / 1_440)
     } else if minutes % 60 == 0 {
@@ -549,7 +582,17 @@ mod tests {
 
         assert_eq!(report.source, UsageSource::Direct);
         assert_eq!(report.providers, vec![direct]);
-        assert!(report.diagnostics.is_empty());
+        assert_eq!(
+            report.diagnostics,
+            vec!["Model Gateway usage is unavailable."]
+        );
+    }
+
+    #[test]
+    fn duration_labels_handle_zero_and_multiple_weeks() {
+        assert_eq!(format_window_duration(0), "0m");
+        assert_eq!(format_window_duration(10_080), "Weekly (7d)");
+        assert_eq!(format_window_duration(20_160), "14d");
     }
 
     #[test]

--- a/crates/tidebreak-server-api/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server-api/src/routes/code/workspaces.rs
@@ -198,6 +198,19 @@ pub async fn search_workspace(
     Query(query): Query<WorkspaceSearchQuery>,
 ) -> Result<Json<CodeWorkspaceSearch>, ServerError> {
     if query.history {
+        if query
+            .include
+            .as_deref()
+            .is_some_and(|value| !value.is_empty())
+            || query
+                .exclude
+                .as_deref()
+                .is_some_and(|value| !value.is_empty())
+        {
+            return Err(ServerError::bad_request(
+                "history search does not support path include or exclude filters",
+            ));
+        }
         let history_query = query.query.trim();
         if history_query.chars().count()
             > tidebreak_core::db::code::MAX_TRANSCRIPT_SEARCH_QUERY_CHARS

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -2186,6 +2186,18 @@ async fn an_external_machine_session_acts_as_the_connected_person() {
     assert_eq!(body["acting_login"], "mira");
     assert_eq!(body["app_name"], "Acme Forge");
     assert!(body.get("connect_url").is_none());
+    let existing = client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({ "external_key": "T1/C-id/1.1", "repo_id": repo_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(existing.status(), reqwest::StatusCode::OK);
+    let existing_body: serde_json::Value = existing.json().await.unwrap();
+    assert_eq!(existing_body["acting_login"], "mira");
+    assert_eq!(existing_body["app_name"], "Acme Forge");
+    assert!(existing_body.get("connect_url").is_none());
     let session_id = bound_session_id(&runtime, &owner, "T1/C-id/1.1").await;
     let session = runtime.get_session(&owner, session_id).await.unwrap();
     assert_eq!(session.acts_as(), tidebreak_core::ActsAs::Person);

--- a/crates/tidebreak-server-api/src/wire.rs
+++ b/crates/tidebreak-server-api/src/wire.rs
@@ -47,7 +47,7 @@
 //! event frame on `/sessions/{id}/events`, and the notices on
 //! `/updates`. They follow the strictness above. The one shape a client
 //! composes itself is the response to `POST /sessions/{id}/turns`, which
-//! is a [`TurnSnapshot`] on `200` and a [`QueuedTurn`] on `202`.
+//! is a [`TurnSnapshot`] or [`QueuedTurn`], both on `202`.
 //!
 //! # Limits
 //!


### PR DESCRIPTION
1. Replaced `get_open_turn` with one owner/session/status query ordered by descending ordinal and added a regression test; caller audit found no reads of `attachments`, so the lookup does not load them.
2. Made `record_incarnation_spend` return `Result<bool>` from `rows_affected` and asserted both updated and missing-row outcomes. Skipped caller logging/propagation because every production caller is outside the explicitly permitted file set (`crates/tidebreak-code-remote/src/driver.rs` and `crates/tidebreak-server/src/code/remote/service.rs`).
3. Restored `acting_login`, `app_name`, and `connect_url` from forge identity on the existing-binding early return and extended the connected-person regression.
4. Made session-event frames and update notices return serialization errors so their sockets disconnect and resync.
5. On terminal-bus lag, emits a parsed `terminal_activity` notice for every open terminal in the owner’s workspaces.
6. Refuses `history=true` combined with non-empty include/exclude path filters as a 400 naming the unsupported combination.
7. Derives pull-request `fetched_at` from the newest durable `last_seen_at` (falling back to now only for an empty list); no wire-shape change was needed.
8. Switched triggers Path/Json, analytics/approvals/delivery Query, and fork-session raw bytes to the stable crate extractors; the existing body cap remains and RawBytes maps 413 into the error envelope.
9. Added `deny_unknown_fields` to every listed external and grant body; no intentional-extra-field test was found for these body types.
10. Preserved Codex fallback diagnostics, bounded modelctl stdout while reading, and fixed zero/multi-week duration labels with tests.
11. Test-gated the compatibility exports, removed the stability comment, and removed the unused `CodeGithubRepository` export.
12. Corrected server-wire and CLI docs: both turn-response variants use 202.

Skipped
- Item 2 caller logging/propagation only: the production callers are outside the user-authorized file list; the database operation now exposes the boolean and its tests consume it.
- Wire regeneration/mobile copy: skipped because item 7 kept the Rust/TypeScript wire shape unchanged; the generated-binding assertions passed.

Checks run
- `cargo fmt --all --check` — finished successfully (no output).
- `cargo clippy -p tidebreak-server -p tidebreak-core -p tidebreak-cli --all-targets --locked -- -D warnings` — `Finished dev profile [unoptimized + debuginfo] target(s) in 3m 07s`.
- `cargo test -p tidebreak-core --locked code::turn` — `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 924 filtered out`.
- `cargo test -p tidebreak-core --locked incarnation` — `test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 920 filtered out`.
- `cargo test -p tidebreak-server --locked code_external` — compilation succeeded; interrupted after unrelated loopback tests timed out connecting to their local server.
- `cargo test -p tidebreak-server --locked code_grants` — `test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 690 filtered out`.
- `cargo test -p tidebreak-server --locked code_ws` — `test result: FAILED. 0 passed; 6 failed`; all six failures were TCP connect timeouts to per-test 127.0.0.1 servers.
- `cargo test -p tidebreak-server --locked code_usage` — `test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 690 filtered out`.
- `cargo test -p tidebreak-server --locked wire` — 31 matching wire tests passed; one unrelated `code_internal::a_conversation_without_a_workspace_runs_on_the_code_wire` match failed on a 127.0.0.1 TCP connect timeout, yielding `test result: FAILED. 31 passed; 1 failed`.

No CI result is claimed.