### PR TITLE
feat(mobile): show app version, OTA bundle, and an update check in Settings

### DIFF
--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -1,8 +1,141 @@
+import * as Application from "expo-application";
 import { useRouter } from "expo-router";
+import * as Updates from "expo-updates";
+import { useCallback, useEffect, useState } from "react";
 import { Pressable, Text, View } from "react-native";
+import { Button } from "../src/components/Controls";
 import { Screen, Body } from "../src/components/Screen";
 import { tokenStore } from "../src/session/runtime";
 import { useSessionStore } from "../src/session/store";
+
+/** One labelled fact about this installation. */
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <View className="flex-row items-baseline justify-between gap-3">
+      <Text className="text-sm text-muted-foreground">{label}</Text>
+      <Text
+        className="flex-1 text-right text-sm text-foreground"
+        numberOfLines={1}
+        ellipsizeMode="middle"
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Whether this build can take an over-the-air update at all. Dev builds ship
+ * with expo-updates disabled, so without this the card would offer a check
+ * that can never succeed and report every dev launch as an error.
+ */
+const OTA_SUPPORTED = Updates.isEnabled && !__DEV__;
+
+type OtaState =
+  | "unsupported"
+  | "checking"
+  | "downloading"
+  | "current"
+  | "ready"
+  | "error";
+
+const OTA_STATUS: Record<OtaState, string> = {
+  unsupported: "Over-the-air updates are off in this build.",
+  checking: "Checking for a newer bundle…",
+  downloading: "Downloading a newer bundle…",
+  current: "Running the latest bundle for this build.",
+  ready: "A newer bundle is downloaded. Restart to run it.",
+  error: "Could not reach the update server.",
+};
+
+/**
+ * The app's own identity: the binary you installed and the JS bundle running
+ * inside it.
+ *
+ * Both rows are needed to answer "am I on the latest?". OTAs are routed by
+ * channel and a fingerprint runtime version that any native change
+ * invalidates (app.config.ts), so a build can sit on the newest bundle its
+ * fingerprint allows while a newer bundle exists for a newer binary — the
+ * version alone cannot say that, and the bundle id alone cannot either. The
+ * check runs on open so the answer is already on screen, and the button
+ * applies whatever it fetched.
+ */
+function AboutThisApp() {
+  const [ota, setOta] = useState<OtaState>(
+    OTA_SUPPORTED ? "checking" : "unsupported",
+  );
+
+  const check = useCallback(async () => {
+    if (!OTA_SUPPORTED) {
+      return;
+    }
+    setOta("checking");
+    try {
+      const result = await Updates.checkForUpdateAsync();
+      // A rollback directive is also something to apply, and the check
+      // reports it as isAvailable: false — testing availability alone would
+      // call a pending rollback "up to date".
+      if (!result.isAvailable && !result.isRollBackToEmbedded) {
+        setOta("current");
+        return;
+      }
+      setOta("downloading");
+      await Updates.fetchUpdateAsync();
+      setOta("ready");
+    } catch {
+      setOta("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    void check();
+  }, [check]);
+
+  const appVersion = Application.nativeApplicationVersion ?? "—";
+  const buildNumber = Application.nativeBuildVersion;
+  // The build number is the EAS remote counter, not a repo value, so it is
+  // the half of the version that actually distinguishes two shipped binaries.
+  const version = buildNumber ? `${appVersion} (${buildNumber})` : appVersion;
+
+  // The trailing 8 characters, not the leading 8. EAS update ids are UUIDv7,
+  // so the leading hex digits are the top bits of a millisecond clock: any
+  // two updates you actually want to tell apart share a prefix that reads as
+  // identical at a glance. The last 8 are pure random bits, which is what
+  // makes them scannable.
+  const bundle = !OTA_SUPPORTED
+    ? "—"
+    : Updates.isEmbeddedLaunch
+      ? "Embedded"
+      : (Updates.updateId?.slice(-8) ?? "—");
+
+  const busy = ota === "checking" || ota === "downloading";
+
+  return (
+    <View className="rounded-xl border border-border bg-background p-4 gap-2">
+      <Text className="text-xs uppercase tracking-wide text-muted-foreground">
+        About this app
+      </Text>
+      <Fact label="Version" value={version} />
+      <Fact label="OTA bundle" value={bundle} />
+      <Text className="pt-1 text-xs text-muted-foreground">
+        {OTA_STATUS[ota]}
+      </Text>
+      {ota === "unsupported" ? null : ota === "ready" ? (
+        <Button
+          label="Restart to apply"
+          onPress={() => void Updates.reloadAsync()}
+        />
+      ) : (
+        <Button
+          busy={busy}
+          label={ota === "error" ? "Try again" : "Check for updates"}
+          variant="secondary"
+          onPress={() => void check()}
+        />
+      )}
+    </View>
+  );
+}
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -43,6 +176,7 @@ export default function SettingsScreen() {
           </Text>
         ) : null}
       </View>
+      <AboutThisApp />
       <Body>
         Sign out clears the rotating refresh token and every cached access
         token from the secure store.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@tanstack/react-query": "5.90.21",
     "expo": "55.0.30",
+    "expo-application": "55.0.19",
     "expo-constants": "55.0.17",
     "expo-crypto": "55.0.19",
     "expo-linking": "55.0.17",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       expo:
         specifier: 55.0.30
         version: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.0(react@19.2.8))(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-application:
+        specifier: 55.0.19
+        version: 55.0.19(expo@55.0.30)
       expo-constants:
         specifier: 55.0.17
         version: 55.0.17(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))
@@ -2357,6 +2360,11 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  expo-application@55.0.19:
+    resolution: {integrity: sha512-RFer4T46/OaIkNQEweA9PQj6xlXKor71IPNydWxlupx/XG05Yv/269HJJ3Q9zejdY9M7R3jTeTlAYYmXwbLBgA==}
+    peerDependencies:
+      expo: '*'
 
   expo-asset@55.0.20:
     resolution: {integrity: sha512-BpybBESZj8WxW/WXuQhiY8D1azkJtxLuteIfprokJw0uU5r/g7cD+vzrzKJSlE4hhUlKeUGsoKzSK0nSJJ2sMQ==}
@@ -7064,6 +7072,10 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   expect-type@1.4.0: {}
+
+  expo-application@55.0.19(expo@55.0.30):
+    dependencies:
+      expo: 55.0.30(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.12)(expo-router@55.0.18)(react-dom@19.2.0(react@19.2.8))(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8))(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
 
   expo-asset@55.0.20(expo@55.0.30)(react-native@0.83.1(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.7)(react@19.2.8))(react@19.2.8)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Mirrors Tidewatch's "About this app" settings card into Tidebreak mobile.

## What changed

- New **About this app** card at the bottom of the Settings screen:
  - **Version** — the installed binary's version plus the EAS remote build number (`0.1.0 (12)`), the half that actually distinguishes two shipped binaries.
  - **OTA bundle** — the trailing 8 characters of the running EAS update id (UUIDv7 leading digits are clock bits, so the tail is the scannable part), or `Embedded` when running the bundle baked into the binary.
  - A status line plus a **Check for updates** button. The check also runs when the screen opens, so the answer is usually already there.
- The check downloads whatever it finds and flips the button to **Restart to apply** (`Updates.reloadAsync`). A pending rollback-to-embedded counts as something to apply, not "up to date".
- Dev builds ship with expo-updates disabled, so the card states OTA is off and hides the button instead of offering a check that can only error.
- Adds `expo-application` (pinned `55.0.19`, the SDK 55 match) for the native version and build number.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (105 passing) in `mobile/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)