### PR TITLE
feat(code): serve connected apps to every external engine over a loopback MCP bridge

### DIFF
--- a/crates/tidebreak-harness/src/claude/browser.rs
+++ b/crates/tidebreak-harness/src/claude/browser.rs
@@ -72,11 +72,12 @@ pub fn merged_mcp_config_json(
     approval: Option<&crate::ApprovalChannelSpec>,
     browser: Option<&BrowserChannelSpec>,
     native: Option<&NativeChannelSpec>,
+    apps: Option<&crate::AppsChannelSpec>,
 ) -> Result<Option<String>, crate::HarnessError> {
-    if approval.is_none() && browser.is_none() && native.is_none() {
+    if approval.is_none() && browser.is_none() && native.is_none() && apps.is_none() {
         return Ok(None);
     }
-    if let (Some(channel), None, None) = (approval, browser, native) {
+    if let (Some(channel), None, None, None) = (approval, browser, native, apps) {
         // Existing behavior: approval-only config.
         return Ok(Some(
             channel.mcp_config_json(crate::claude::approvals::APPROVAL_MCP_SERVER),
@@ -110,6 +111,14 @@ pub fn merged_mcp_config_json(
             native_mcp_config_entry(spec.bridge_command())?,
         );
     }
+    if let Some(spec) = apps {
+        // Connected-apps entry (HTTP with bearer): every MCP server
+        // Tidebreak has mounted, served from the loopback bridge.
+        servers.insert(
+            crate::AppsChannelSpec::MCP_SERVER.into(),
+            spec.claude_mcp_config_entry(),
+        );
+    }
     Ok(Some(
         serde_json::json!({ "mcpServers": servers }).to_string(),
     ))
@@ -126,8 +135,9 @@ pub fn launch_args_for_mcp_channels(
     approval: Option<&crate::ApprovalChannelSpec>,
     browser: Option<&BrowserChannelSpec>,
     native: Option<&NativeChannelSpec>,
+    apps: Option<&crate::AppsChannelSpec>,
 ) -> Result<Option<Vec<String>>, crate::HarnessError> {
-    let Some(config) = merged_mcp_config_json(approval, browser, native)? else {
+    let Some(config) = merged_mcp_config_json(approval, browser, native, apps)? else {
         return Ok(None);
     };
     let mut flags = vec!["--mcp-config".into(), config];
@@ -176,7 +186,7 @@ mod tests {
 
     #[test]
     fn neither_channel_produces_no_flags() {
-        assert!(launch_args_for_mcp_channels(None, None, None)
+        assert!(launch_args_for_mcp_channels(None, None, None, None)
             .unwrap()
             .is_none());
     }
@@ -184,7 +194,7 @@ mod tests {
     #[test]
     fn approval_only_matches_existing_behavior() {
         let channel = approval_channel();
-        let flags = launch_args_for_mcp_channels(Some(&channel), None, None)
+        let flags = launch_args_for_mcp_channels(Some(&channel), None, None, None)
             .unwrap()
             .unwrap();
         let existing =
@@ -195,7 +205,7 @@ mod tests {
     #[test]
     fn browser_only_emits_stdio_config_without_prompt_tool() {
         let browser = browser_channel();
-        let flags = launch_args_for_mcp_channels(None, Some(&browser), None)
+        let flags = launch_args_for_mcp_channels(None, Some(&browser), None, None)
             .unwrap()
             .unwrap();
         assert_eq!(flags[0], "--mcp-config");
@@ -216,7 +226,7 @@ mod tests {
     fn both_channels_merge_into_one_config() {
         let approval = approval_channel();
         let browser = browser_channel();
-        let flags = launch_args_for_mcp_channels(Some(&approval), Some(&browser), None)
+        let flags = launch_args_for_mcp_channels(Some(&approval), Some(&browser), None, None)
             .unwrap()
             .unwrap();
         // Exactly one --mcp-config flag.
@@ -236,8 +246,8 @@ mod tests {
     fn browser_config_carries_no_secrets() {
         let browser = browser_channel();
         for flags in [
-            launch_args_for_mcp_channels(None, Some(&browser), None),
-            launch_args_for_mcp_channels(Some(&approval_channel()), Some(&browser), None),
+            launch_args_for_mcp_channels(None, Some(&browser), None, None),
+            launch_args_for_mcp_channels(Some(&approval_channel()), Some(&browser), None, None),
         ] {
             let flags = flags.unwrap().unwrap();
             let config: serde_json::Value = serde_json::from_str(&flags[1]).unwrap();
@@ -265,7 +275,7 @@ mod tests {
             PathBuf::from("/tmp/with spaces/cap.json"),
             PathBuf::from("/Applications/Tidebreak.app/Contents/bin/tidebreak"),
         );
-        let flags = launch_args_for_mcp_channels(None, Some(&browser), None)
+        let flags = launch_args_for_mcp_channels(None, Some(&browser), None, None)
             .unwrap()
             .unwrap();
         let config: serde_json::Value = serde_json::from_str(&flags[1]).unwrap();
@@ -295,7 +305,7 @@ mod tests {
     #[test]
     fn native_only_emits_stdio_config_without_prompt_tool() {
         let native = native_channel();
-        let flags = launch_args_for_mcp_channels(None, None, Some(&native))
+        let flags = launch_args_for_mcp_channels(None, None, Some(&native), None)
             .unwrap()
             .unwrap();
         assert_eq!(flags[0], "--mcp-config");
@@ -315,9 +325,10 @@ mod tests {
         let approval = approval_channel();
         let browser = browser_channel();
         let native = native_channel();
-        let flags = launch_args_for_mcp_channels(Some(&approval), Some(&browser), Some(&native))
-            .unwrap()
-            .unwrap();
+        let flags =
+            launch_args_for_mcp_channels(Some(&approval), Some(&browser), Some(&native), None)
+                .unwrap()
+                .unwrap();
         assert_eq!(flags.iter().filter(|f| **f == "--mcp-config").count(), 1);
         let config: serde_json::Value = serde_json::from_str(&flags[1]).unwrap();
         assert!(config["mcpServers"].get("tb-approvals").is_some());
@@ -329,7 +340,7 @@ mod tests {
     #[test]
     fn native_config_carries_no_secrets() {
         let native = native_channel();
-        let flags = launch_args_for_mcp_channels(None, None, Some(&native))
+        let flags = launch_args_for_mcp_channels(None, None, Some(&native), None)
             .unwrap()
             .unwrap();
         let config_str = flags[1].clone();
@@ -351,9 +362,41 @@ mod tests {
             PathBuf::from("/tmp/tidebreak-browser-cap.json"),
             PathBuf::from(OsString::from_vec(b"/tmp/tidebreak-\xff".to_vec())),
         );
-        let error = launch_args_for_mcp_channels(None, Some(&browser), None)
+        let error = launch_args_for_mcp_channels(None, Some(&browser), None, None)
             .expect_err("non-UTF-8 bridge paths must fail closed");
 
         assert!(error.to_string().contains("must be valid UTF-8"));
+    }
+
+    #[test]
+    fn apps_channel_joins_the_merged_config_as_an_http_server() {
+        let apps = crate::AppsChannelSpec {
+            mcp_endpoint_url: "http://127.0.0.1:9999/code/mcp/connected-apps".into(),
+            token: "apps-token".into(),
+        };
+        let flags = launch_args_for_mcp_channels(None, None, None, Some(&apps))
+            .unwrap()
+            .expect("an apps channel alone still mounts a server");
+        assert_eq!(flags[0], "--mcp-config");
+        assert!(
+            !flags.contains(&"--permission-prompt-tool".to_string()),
+            "no approval channel, no permission-prompt flag"
+        );
+        let config: serde_json::Value = serde_json::from_str(&flags[1]).unwrap();
+        let entry = &config["mcpServers"]["tb-apps"];
+        assert_eq!(entry["type"], "http");
+        assert_eq!(
+            entry["url"],
+            "http://127.0.0.1:9999/code/mcp/connected-apps"
+        );
+        assert_eq!(entry["headers"]["Authorization"], "Bearer apps-token");
+
+        let with_approval =
+            launch_args_for_mcp_channels(Some(&approval_channel()), None, None, Some(&apps))
+                .unwrap()
+                .unwrap();
+        let config: serde_json::Value = serde_json::from_str(&with_approval[1]).unwrap();
+        assert!(config["mcpServers"].get("tb-approvals").is_some());
+        assert!(config["mcpServers"].get("tb-apps").is_some());
     }
 }

--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -583,6 +583,7 @@ impl ClaudeSession {
             self.spec.approval.as_ref(),
             self.spec.browser.as_ref(),
             self.spec.native.as_ref(),
+            self.spec.apps.as_ref(),
         )? {
             argv.extend(flags);
         }
@@ -1486,6 +1487,7 @@ mod tests {
             sink,
             browser: None,
             native: None,
+            apps: None,
         })
     }
 
@@ -1661,6 +1663,7 @@ done
             sink: Arc::new(Discard),
             browser: None,
             native: None,
+            apps: None,
         });
         let plan = session.compose_plan_for(None, None).unwrap();
         let index = plan.argv.iter().position(|arg| arg == "--effort").unwrap();
@@ -1867,6 +1870,7 @@ done
             sink: Arc::new(Discard),
             browser: Some(browser),
             native: None,
+            apps: None,
         });
         let plan = session.compose_plan_for(None, None).unwrap();
         assert_eq!(
@@ -1925,6 +1929,7 @@ done
             sink: Arc::new(Discard),
             browser: None,
             native: None,
+            apps: None,
         });
         let plan = session.compose_plan_for(None, None).unwrap();
         let index = plan

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -1235,6 +1235,7 @@ requires_openai_auth = true
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         assert!(!plan

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -779,6 +779,7 @@ impl CodexSession {
 /// the child: the provider config the spawn wiring emits reads the session
 /// relay key through `env_key={relay_key_env}`, so stripping it would leave
 /// a hosted session with no credential at all.
+#[allow(clippy::too_many_arguments)] // one optional channel per argument, mirroring SessionSpec
 pub(crate) fn compose_app_server_plan(
     binary: &std::path::Path,
     extra_argv: &[String],
@@ -786,6 +787,7 @@ pub(crate) fn compose_app_server_plan(
     extra_env: &[(String, String)],
     browser: Option<&BrowserChannelSpec>,
     native: Option<&crate::NativeChannelSpec>,
+    apps: Option<&crate::AppsChannelSpec>,
     relay_key_env: Option<&str>,
 ) -> Result<LaunchPlan, HarnessError> {
     let mut argv = vec![
@@ -812,10 +814,24 @@ pub(crate) fn compose_app_server_plan(
             format!("mcp_servers.tb-native={{command={escaped},args=[\"computer-mcp\"],env_vars=[\"TIDEBREAK_NATIVE_CAPFILE\"]}}"),
         );
     }
+    if let Some(spec) = apps {
+        argv.push("-c".into());
+        argv.push(spec.codex_config_override());
+    }
     let mut env = extra_env.to_vec();
     env.retain(|(key, _)| {
         !BrowserChannelSpec::is_reserved_env_key_except(key, relay_key_env) && key != "PWD"
     });
+    if let Some(spec) = apps {
+        // The bearer rides the environment (`bearer_token_env_var`), never
+        // argv. Settings cannot set this name: the retain above already
+        // dropped every reserved `TIDEBREAK_` key, so this push is the only
+        // source.
+        env.push((
+            crate::AppsChannelSpec::TOKEN_ENV.to_owned(),
+            spec.token.clone(),
+        ));
+    }
     let plan = LaunchPlan {
         argv,
         cwd: cwd.to_path_buf(),
@@ -892,6 +908,7 @@ impl CodexSession {
             &self.spec.extra_env,
             self.spec.browser.as_ref(),
             self.spec.native.as_ref(),
+            self.spec.apps.as_ref(),
             self.spec.relay_key_env.as_deref(),
         )?;
         let mut command = Command::new(&plan.argv[0]);

--- a/crates/tidebreak-harness/src/codex/session/tests.rs
+++ b/crates/tidebreak-harness/src/codex/session/tests.rs
@@ -11,6 +11,7 @@ fn app_server_plan_is_clean() {
         None,
         None,
         None,
+        None,
     )
     .unwrap();
     assert_eq!(plan.argv, ["/usr/bin/codex", "app-server", "--stdio"]);
@@ -24,6 +25,7 @@ fn extra_bypass_flag_is_rejected() {
         &["--dangerously-bypass-approvals-and-sandbox".into()],
         std::path::Path::new("/workspace"),
         &[],
+        None,
         None,
         None,
         None,
@@ -281,6 +283,7 @@ fn unit_session(sink: Arc<dyn crate::HarnessEventSink>) -> CodexSession {
         sink,
         browser: None,
         native: None,
+        apps: None,
     })
 }
 
@@ -590,6 +593,7 @@ fn spec_for(
         sink: Arc::new(SilentSink),
         browser: None,
         native: None,
+        apps: None,
     }
 }
 
@@ -1331,6 +1335,7 @@ fn native_present_appends_exactly_one_trusted_config_override() {
         None,
         Some(&spec),
         None,
+        None,
     )
     .unwrap();
     let overrides: Vec<_> = plan
@@ -1368,6 +1373,7 @@ fn browser_and_native_each_get_their_own_override() {
         Some(&browser),
         Some(&native),
         None,
+        None,
     )
     .unwrap();
     assert!(plan
@@ -1390,6 +1396,7 @@ fn browser_absent_produces_same_argv_as_before() {
         None,
         None,
         None,
+        None,
     )
     .unwrap();
     assert_eq!(plan.argv, ["/usr/bin/codex", "app-server", "--stdio"]);
@@ -1407,6 +1414,7 @@ fn browser_present_appends_exactly_one_trusted_config_override() {
         std::path::Path::new("/workspace"),
         &[],
         Some(&spec),
+        None,
         None,
         None,
     )
@@ -1443,6 +1451,7 @@ fn browser_override_is_after_extra_argv() {
         Some(&spec),
         None,
         None,
+        None,
     )
     .unwrap();
     let browser_idx = plan.argv.iter().position(|arg| arg == "-c").unwrap();
@@ -1463,6 +1472,7 @@ fn browser_capfile_path_is_never_in_argv() {
         std::path::Path::new("/workspace"),
         &[],
         Some(&spec),
+        None,
         None,
         None,
     )
@@ -1486,6 +1496,7 @@ fn browser_env_key_is_stripped_from_plan_even_when_browser_is_some() {
         std::path::Path::new("/workspace"),
         &[("TIDEBREAK_BROWSER_CAPFILE".into(), "/evil/cap.json".into())],
         Some(&spec),
+        None,
         None,
         None,
     )
@@ -1512,6 +1523,7 @@ fn session_relay_key_survives_the_reserved_namespace_strip() {
             ("TIDEBREAK_LLM_KEY".into(), "tbreak_hl_test".into()),
             ("TIDEBREAK_BROWSER_CAPFILE".into(), "/evil/cap.json".into()),
         ],
+        None,
         None,
         None,
         Some("TIDEBREAK_LLM_KEY"),
@@ -1541,6 +1553,7 @@ fn relay_key_is_stripped_when_no_relay_is_wired() {
         None,
         None,
         None,
+        None,
     )
     .unwrap();
     assert!(plan.env.is_empty(), "{:?}", plan.env);
@@ -1558,6 +1571,7 @@ fn bridge_command_with_spaces_remains_one_command_value() {
         std::path::Path::new("/workspace"),
         &[],
         Some(&spec),
+        None,
         None,
         None,
     )
@@ -1584,6 +1598,7 @@ fn bridge_command_with_backslashes_is_escaped() {
         std::path::Path::new("/workspace"),
         &[],
         Some(&spec),
+        None,
         None,
         None,
     )
@@ -1615,6 +1630,7 @@ fn bridge_command_with_embedded_quote_is_escaped() {
         Some(&spec),
         None,
         None,
+        None,
     )
     .unwrap();
     let override_idx = plan.argv.iter().position(|arg| arg == "-c").unwrap();
@@ -1643,6 +1659,7 @@ fn non_utf8_bridge_command_is_rejected_instead_of_changed() {
         std::path::Path::new("/workspace"),
         &[],
         Some(&spec),
+        None,
         None,
         None,
     )
@@ -1909,4 +1926,47 @@ async fn duplicate_mcp_elicitation_rejects_stale_approval_before_server_resoluti
         .any(|event| matches!(event,
         HarnessEvent::ApprovalResolved { harness_ref, decision: ApprovalDecision::Deny { .. } }
         if harness_ref.call_id == "call_fixture")));
+}
+
+#[test]
+fn apps_channel_mounts_an_http_server_with_the_bearer_in_the_environment() {
+    let apps = crate::AppsChannelSpec {
+        mcp_endpoint_url: "http://127.0.0.1:9999/code/mcp/connected-apps".into(),
+        token: "apps-token".into(),
+    };
+    let plan = compose_app_server_plan(
+        std::path::Path::new("/usr/bin/codex"),
+        &[],
+        std::path::Path::new("/workspace"),
+        &[("TIDEBREAK_APPS_TOKEN".into(), "from-settings".into())],
+        None,
+        None,
+        Some(&apps),
+        None,
+    )
+    .unwrap();
+    let overrides: Vec<_> = plan
+        .argv
+        .iter()
+        .filter(|arg| arg.starts_with("mcp_servers.tb-apps="))
+        .collect();
+    assert_eq!(
+        overrides,
+        [&"mcp_servers.tb-apps={url=\"http://127.0.0.1:9999/code/mcp/connected-apps\",bearer_token_env_var=\"TIDEBREAK_APPS_TOKEN\"}".to_string()]
+    );
+    assert!(
+        !plan.argv.iter().any(|arg| arg.contains("apps-token")),
+        "the bearer never appears in argv"
+    );
+    let tokens: Vec<_> = plan
+        .env
+        .iter()
+        .filter(|(key, _)| key == "TIDEBREAK_APPS_TOKEN")
+        .collect();
+    assert_eq!(
+        tokens,
+        [&("TIDEBREAK_APPS_TOKEN".to_string(), "apps-token".to_string())],
+        "the adapter's token is the only source; settings cannot supply one"
+    );
+    validate_launch_plan(&plan).unwrap();
 }

--- a/crates/tidebreak-harness/src/grok/acp.rs
+++ b/crates/tidebreak-harness/src/grok/acp.rs
@@ -321,7 +321,7 @@ impl GrokSession {
             ));
         }
         let resume = self.resume_ref.lock().expect("grok resume").clone();
-        let mut params = json!({"cwd":self.spec.worktree,"mcpServers":[],"_meta":{"yoloMode":false,"autoMode":false}});
+        let mut params = json!({"cwd":self.spec.worktree,"mcpServers":acp_mcp_servers(self.spec.apps.as_ref()),"_meta":{"yoloMode":false,"autoMode":false}});
         let method = if let Some(id) = &resume {
             params["sessionId"] = json!(id);
             "session/load"
@@ -735,6 +735,17 @@ fn map_update(update: &Value) -> Option<Value> {
         | "current_mode_update"
         | "config_option_update" => None,
         _ => Some(json!({"type":format!("acp/{kind}")})),
+    }
+}
+
+/// The `mcpServers` an ACP `session/new` or `session/load` request carries:
+/// the connected-apps bridge when the server wired one, else none. Grok
+/// mounts the bridge the same way it would any HTTP MCP server, so every
+/// app Tidebreak serves reaches it too.
+pub(crate) fn acp_mcp_servers(apps: Option<&crate::AppsChannelSpec>) -> Value {
+    match apps {
+        Some(spec) => json!([spec.acp_mcp_server()]),
+        None => json!([]),
     }
 }
 

--- a/crates/tidebreak-harness/src/grok/acp_tests.rs
+++ b/crates/tidebreak-harness/src/grok/acp_tests.rs
@@ -254,6 +254,7 @@ fn session(dir: &Path, mode: PermissionMode, duplicate: bool) -> (Arc<GrokSessio
         sink: sink.clone(),
         browser: None,
         native: None,
+        apps: None,
     };
     (Arc::new(GrokSession::new(spec, "1.0.13".into())), sink)
 }
@@ -883,4 +884,22 @@ async fn acp_queued_approval_observes_stop_before_interrupt_gets_the_lock() {
         .unwrap()
         .iter()
         .any(|event| { matches!(event, HarnessEvent::TurnCompleted { .. }) }));
+}
+
+#[test]
+fn acp_session_requests_carry_the_apps_bridge_as_an_http_server() {
+    assert_eq!(acp_mcp_servers(None), json!([]));
+    let apps = crate::AppsChannelSpec {
+        mcp_endpoint_url: "http://127.0.0.1:9999/code/mcp/connected-apps".into(),
+        token: "apps-token".into(),
+    };
+    let servers = acp_mcp_servers(Some(&apps));
+    assert_eq!(servers[0]["name"], "tb-apps");
+    assert_eq!(servers[0]["type"], "http");
+    assert_eq!(
+        servers[0]["url"],
+        "http://127.0.0.1:9999/code/mcp/connected-apps"
+    );
+    assert_eq!(servers[0]["headers"][0]["name"], "Authorization");
+    assert_eq!(servers[0]["headers"][0]["value"], "Bearer apps-token");
 }

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -1506,6 +1506,7 @@ exit 0
                     sink,
                     browser: None,
                     native: None,
+                    apps: None,
                 },
                 "1.0.5".into(),
             )

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -526,6 +526,91 @@ pub trait ApprovalCompleter: Send + Sync {
     ) -> Result<(), HarnessError>;
 }
 
+/// Loopback connected-apps wiring supplied by the server layer.
+///
+/// The server serves every MCP server Tidebreak has mounted — the gateway
+/// endpoints an organization entitles plus locally configured servers — as
+/// one HTTP MCP server at `mcp_endpoint_url`, authenticated by `token`. An
+/// external engine mounts it as [`Self::MCP_SERVER`], so the tools the
+/// in-process engine already sees reach every harness the same way. This
+/// crate does not implement the endpoint.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AppsChannelSpec {
+    /// Loopback MCP endpoint URL.
+    pub mcp_endpoint_url: String,
+    /// Session-scoped token. Never logged.
+    pub token: String,
+}
+
+impl std::fmt::Debug for AppsChannelSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppsChannelSpec")
+            .field("mcp_endpoint_url", &self.mcp_endpoint_url)
+            .field("token", &"<redacted>")
+            .finish()
+    }
+}
+
+impl AppsChannelSpec {
+    /// The MCP server name every adapter mounts the bridge under.
+    pub const MCP_SERVER: &'static str = "tb-apps";
+    /// Environment variable carrying the bearer for engines that read MCP
+    /// credentials from the environment (Codex).
+    pub const TOKEN_ENV: &'static str = "TIDEBREAK_APPS_TOKEN";
+
+    /// The `Authorization` header value the bridge expects.
+    #[must_use]
+    pub fn authorization_header(&self) -> String {
+        format!("Bearer {}", self.token)
+    }
+
+    /// One `mcpServers` entry for Claude Code's `--mcp-config`.
+    #[must_use]
+    pub fn claude_mcp_config_entry(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "http",
+            "url": self.mcp_endpoint_url,
+            "headers": { "Authorization": self.authorization_header() },
+        })
+    }
+
+    /// One `mcp` entry for OpenCode's config document.
+    #[must_use]
+    pub fn opencode_mcp_config_entry(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "remote",
+            "url": self.mcp_endpoint_url,
+            "headers": { "Authorization": self.authorization_header() },
+        })
+    }
+
+    /// One `mcpServers` element for an ACP `session/new` request.
+    #[must_use]
+    pub fn acp_mcp_server(&self) -> serde_json::Value {
+        serde_json::json!({
+            "name": Self::MCP_SERVER,
+            "type": "http",
+            "url": self.mcp_endpoint_url,
+            "headers": [
+                { "name": "Authorization", "value": self.authorization_header() }
+            ],
+        })
+    }
+
+    /// The Codex `-c mcp_servers.tb-apps=…` override. The bearer travels
+    /// through [`Self::TOKEN_ENV`], never argv.
+    #[must_use]
+    pub fn codex_config_override(&self) -> String {
+        let url = serde_json::to_string(&self.mcp_endpoint_url)
+            .expect("a string always serializes as JSON");
+        format!(
+            "mcp_servers.{}={{url={url},bearer_token_env_var=\"{}\"}}",
+            Self::MCP_SERVER,
+            Self::TOKEN_ENV
+        )
+    }
+}
+
 /// Loopback approval-channel wiring supplied by the server layer.
 ///
 /// The server must serve a permission-prompt tool at `mcp_endpoint_url`
@@ -826,6 +911,9 @@ pub struct SessionSpec {
     /// has produced a session-private capability file. `None` preserves the
     /// existing behavior: no native tools are advertised or injected.
     pub native: Option<NativeChannelSpec>,
+    /// Connected-apps channel wiring: the loopback MCP bridge over every
+    /// server Tidebreak has mounted. `None` advertises no connected apps.
+    pub apps: Option<AppsChannelSpec>,
 }
 
 /// Receives normalized events as the engine stream is parsed.

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -445,6 +445,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -292,6 +292,7 @@ pub(crate) struct ServeLaunch<'a> {
     pub port: u16,
     pub browser: Option<&'a BrowserChannelSpec>,
     pub native: Option<&'a crate::NativeChannelSpec>,
+    pub apps: Option<&'a crate::AppsChannelSpec>,
     /// The exact host-wired key used by shell tools to borrow forge credentials.
     pub relay_key_env: Option<&'a str>,
 }
@@ -307,6 +308,7 @@ pub(crate) fn compose_serve_plan(launch: ServeLaunch<'_>) -> Result<LaunchPlan, 
         port,
         browser,
         native,
+        apps,
         relay_key_env,
     } = launch;
     let mut argv = vec![
@@ -336,7 +338,7 @@ pub(crate) fn compose_serve_plan(launch: ServeLaunch<'_>) -> Result<LaunchPlan, 
         .iter()
         .rev()
         .find(|(key, _)| env_key_eq(key, OPENCODE_CONFIG_CONTENT));
-    if browser.is_some() || native.is_some() {
+    if browser.is_some() || native.is_some() || apps.is_some() {
         // Snapshot-only config takes the merge path only when a channel is
         // present. With no channel, apply_child_env_tokio already preserves
         // the snapshot unchanged, so plan.env must not copy it or reject it
@@ -352,6 +354,12 @@ pub(crate) fn compose_serve_plan(launch: ServeLaunch<'_>) -> Result<LaunchPlan, 
             entries.push((
                 NATIVE_MCP_SERVER,
                 native_mcp_config_json(spec.bridge_command())?,
+            ));
+        }
+        if let Some(spec) = apps {
+            entries.push((
+                crate::AppsChannelSpec::MCP_SERVER,
+                spec.opencode_mcp_config_entry(),
             ));
         }
         let existing_config = effective_existing_config_str(snapshot_env, extra_env)?;
@@ -551,6 +559,7 @@ impl OpencodeSession {
             port,
             browser: self.spec.browser.as_ref(),
             native: self.spec.native.as_ref(),
+            apps: None,
             relay_key_env: self.spec.relay_key_env.as_deref(),
         })?;
         let mut command = Command::new(&plan.argv[0]);
@@ -1132,6 +1141,7 @@ mod tests {
             sink: std::sync::Arc::new(Discard),
             browser: None,
             native: None,
+            apps: None,
         })
     }
 
@@ -1327,6 +1337,7 @@ mod tests {
                 port: 1234,
                 browser: None,
                 native: None,
+                apps: None,
                 relay_key_env,
             })
             .unwrap();
@@ -1372,6 +1383,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1401,6 +1413,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap_err();
@@ -1418,6 +1431,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap_err();
@@ -1532,6 +1546,7 @@ mod tests {
             port: 4096,
             browser: Some(&spec),
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1559,6 +1574,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1641,6 +1657,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: Some(&native),
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1681,6 +1698,7 @@ mod tests {
             port: 4096,
             browser: Some(&browser),
             native: Some(&native),
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1710,6 +1728,7 @@ mod tests {
             port: 4096,
             browser: Some(&spec),
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1742,6 +1761,7 @@ mod tests {
             port: 4096,
             browser: Some(&spec),
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1827,6 +1847,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1884,6 +1905,7 @@ mod tests {
             port: 4096,
             browser: Some(&spec),
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1931,6 +1953,7 @@ mod tests {
             port: 4096,
             browser: Some(&spec),
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -1972,6 +1995,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -2003,6 +2027,7 @@ mod tests {
             port: 4096,
             browser: Some(&spec),
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -2048,6 +2073,7 @@ mod tests {
             port: 4096,
             browser: Some(&spec),
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap_err();
@@ -2074,6 +2100,7 @@ mod tests {
             port: 4096,
             browser: None,
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap();
@@ -2108,6 +2135,7 @@ mod tests {
             port: 4096,
             browser: Some(&spec),
             native: None,
+            apps: None,
             relay_key_env: None,
         })
         .unwrap_err();
@@ -2116,5 +2144,39 @@ mod tests {
             message.contains("not valid UTF-8"),
             "non-UTF-8 bridge path must fail clearly: {message}"
         );
+    }
+
+    #[test]
+    fn apps_channel_is_a_remote_mcp_entry_in_the_config_overlay() {
+        let apps = crate::AppsChannelSpec {
+            mcp_endpoint_url: "http://127.0.0.1:9999/code/mcp/connected-apps".into(),
+            token: "apps-token".into(),
+        };
+        let plan = compose_serve_plan(ServeLaunch {
+            binary: std::path::Path::new("/usr/bin/opencode"),
+            extra_argv: &[],
+            cwd: std::path::Path::new("/workspace"),
+            snapshot_env: &[],
+            extra_env: &[],
+            port: 4096,
+            browser: None,
+            native: None,
+            apps: Some(&apps),
+            relay_key_env: None,
+        })
+        .unwrap();
+        let (_, overlay) = plan
+            .env
+            .iter()
+            .find(|(key, _)| key == OPENCODE_CONFIG_CONTENT)
+            .expect("an apps channel alone produces the config overlay");
+        let config: serde_json::Value = serde_json::from_str(overlay).unwrap();
+        let entry = &config["mcp"]["tb-apps"];
+        assert_eq!(entry["type"], "remote");
+        assert_eq!(
+            entry["url"],
+            "http://127.0.0.1:9999/code/mcp/connected-apps"
+        );
+        assert_eq!(entry["headers"]["Authorization"], "Bearer apps-token");
     }
 }

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -1288,6 +1288,10 @@ pub fn app(state: AppState) -> Router {
             "/code/mcp/approval-prompt",
             post(routes::code::approval_prompt),
         )
+        .route(
+            "/code/mcp/connected-apps",
+            post(routes::code::connected_apps),
+        )
         .with_state(frame_state);
 
     let root = Router::new()

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -38,6 +38,7 @@ mod usage;
 mod workspaces;
 
 pub(crate) use crate::code::approval_bridge::approval_prompt;
+pub(crate) use crate::code::apps_bridge::connected_apps;
 pub(crate) use access::{
     add_session_access, list_session_access, revoke_session_access, set_session_visibility,
 };

--- a/crates/tidebreak-server-api/src/tests.rs
+++ b/crates/tidebreak-server-api/src/tests.rs
@@ -42,6 +42,7 @@ mod app_library;
 mod chat_titling;
 mod code;
 mod code_approvals;
+mod code_apps_bridge;
 mod code_archive;
 mod code_attachments;
 mod code_browser;

--- a/crates/tidebreak-server-api/src/tests/code_apps_bridge.rs
+++ b/crates/tidebreak-server-api/src/tests/code_apps_bridge.rs
@@ -1,0 +1,80 @@
+//! External engines inherit Tidebreak's connected apps through the loopback
+//! MCP bridge.
+
+use super::code::*;
+
+use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+use tidebreak_core::CapLevel;
+
+/// A session on an external engine is handed the bridge, and the bridge
+/// answers that session's token with the mounted MCP tools. Without the
+/// channel a Codex or Claude Code chat has no connected apps at all.
+#[tokio::test]
+async fn an_external_engine_session_mounts_the_connected_apps_bridge() {
+    let adapter = ScriptedAdapter::new(plain_text_script()).with_approvals(CapLevel::Supported);
+    let (router, token, runtime, dir) = code_app_with(adapter.clone()).await;
+    let addr = serve(router).await;
+    runtime.start(format!("http://{addr}")).await.unwrap();
+    let client = reqwest::Client::new();
+    let repo = init_git_repo(dir.path());
+    let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
+    let created = client
+        .post(format!(
+            "http://{addr}/code/workspaces/{}/sessions",
+            json_id(&workspace)
+        ))
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "harness": "claude_code",
+            "permission_mode": "ask",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), reqwest::StatusCode::CREATED);
+
+    let launched = adapter.launched_apps();
+    assert_eq!(launched.len(), 1, "one launch");
+    let apps = launched[0]
+        .clone()
+        .expect("an external engine is always handed the connected-apps bridge");
+    assert_eq!(
+        apps.mcp_endpoint_url,
+        format!("http://{addr}/code/mcp/connected-apps")
+    );
+
+    let listed = client
+        .post(&apps.mcp_endpoint_url)
+        .bearer_auth(&apps.token)
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(listed.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = listed.json().await.unwrap();
+    assert!(
+        body["result"]["tools"].is_array(),
+        "the bridge lists the MCP runtime's tools: {body}"
+    );
+
+    // The install token is not a bridge token: only the session-scoped
+    // bearer the worker was handed reaches the apps.
+    let refused = client
+        .post(&apps.mcp_endpoint_url)
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), reqwest::StatusCode::UNAUTHORIZED);
+}

--- a/crates/tidebreak-server/src/code/apps_bridge.rs
+++ b/crates/tidebreak-server/src/code/apps_bridge.rs
@@ -1,0 +1,483 @@
+//! Loopback MCP bridge that serves Tidebreak's connected apps to external
+//! engines.
+//!
+//! The in-process engine reads every mounted MCP server — the gateway
+//! endpoints an organization entitles plus locally configured servers —
+//! straight from the [`crate::mcp_config::McpRuntime`] snapshot. Claude
+//! Code, Codex, OpenCode, and Grok run as children and cannot, so without
+//! this bridge a chat or code session on one of them has no connected apps
+//! at all. The bridge closes that gap: an external engine mounts
+//! `POST /code/mcp/connected-apps` as one HTTP MCP server named
+//! [`AppsChannelSpec::MCP_SERVER`], authenticated with a session-scoped
+//! bearer (not the install token), and sees the same tools the in-process
+//! engine sees.
+//!
+//! Tool names drop the runtime's `mcp__` prefix, so a tool the in-process
+//! engine calls `mcp__primary__github__proxy_api` is advertised here as
+//! `primary__github__proxy_api`; the engine's own namespacing puts the
+//! server name back in front. Gateway bearers, attestation contexts, and
+//! reconnects stay inside Tidebreak: the child only ever holds the loopback
+//! token.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use tidebreak_core::{OwnerId, SessionId, SessionLifecycle, ToolCtx, ToolRegistry};
+use tidebreak_harness::AppsChannelSpec;
+
+use crate::error::ServerError;
+use crate::extract::Json;
+use crate::state::AppState;
+
+/// The runtime prefix every mounted MCP tool carries.
+const MCP_PREFIX: &str = "mcp__";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AppsTokenSubject {
+    owner: OwnerId,
+    session_id: SessionId,
+    spawn_epoch: i64,
+}
+
+/// Session-scoped bearers for the connected-apps bridge.
+#[derive(Default)]
+pub struct AppsBridge {
+    tokens: Mutex<HashMap<String, AppsTokenSubject>>,
+    by_session: Mutex<HashMap<SessionId, String>>,
+}
+
+impl AppsBridge {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Mint a worker-scoped token. Every older token for the session dies.
+    pub fn issue_token(&self, owner: &OwnerId, session_id: SessionId, spawn_epoch: i64) -> String {
+        let token = format!("cap_apps_{}", Uuid::new_v4());
+        let mut by_session = self.by_session.lock().expect("apps tokens");
+        let mut tokens = self.tokens.lock().expect("apps tokens");
+        Self::revoke_session_locked(&mut by_session, &mut tokens, session_id);
+        by_session.insert(session_id, token.clone());
+        tokens.insert(
+            token.clone(),
+            AppsTokenSubject {
+                owner: owner.clone(),
+                session_id,
+                spawn_epoch,
+            },
+        );
+        token
+    }
+
+    fn subject_for_token(&self, token: &str) -> Option<AppsTokenSubject> {
+        self.tokens.lock().expect("apps tokens").get(token).cloned()
+    }
+
+    /// Revoke one worker's bearer.
+    pub fn revoke_session(&self, session_id: SessionId) {
+        let mut by_session = self.by_session.lock().expect("apps tokens");
+        let mut tokens = self.tokens.lock().expect("apps tokens");
+        Self::revoke_session_locked(&mut by_session, &mut tokens, session_id);
+    }
+
+    fn revoke_session_locked(
+        by_session: &mut HashMap<SessionId, String>,
+        tokens: &mut HashMap<String, AppsTokenSubject>,
+        session_id: SessionId,
+    ) {
+        by_session.remove(&session_id);
+        tokens.retain(|_, subject| subject.session_id != session_id);
+    }
+}
+
+impl crate::code::CodeRuntime {
+    /// The connected-apps channel for one external-engine worker: a fresh
+    /// session-scoped bearer over the loopback bridge. `None` when the
+    /// server has no loopback listener yet, which is the only state where
+    /// there is nothing to mount.
+    pub(super) fn apps_channel(
+        &self,
+        owner: &OwnerId,
+        session_id: SessionId,
+        spawn_epoch: i64,
+    ) -> Option<AppsChannelSpec> {
+        self.apps.revoke_session(session_id);
+        let base = self.loopback_base.lock().expect("loopback base").clone()?;
+        let token = self.apps.issue_token(owner, session_id, spawn_epoch);
+        Some(AppsChannelSpec {
+            mcp_endpoint_url: format!("{base}/code/mcp/connected-apps"),
+            token,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    jsonrpc: Option<String>,
+    id: Option<Value>,
+    method: Option<String>,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<Value>,
+}
+
+/// `POST /code/mcp/connected-apps` — an external engine's HTTP MCP client.
+pub async fn connected_apps(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Result<Json<Value>, ServerError>,
+) -> Response {
+    let Json(value) = match body {
+        Ok(json) => json,
+        Err(err) => return err.into_response(),
+    };
+    let Some(runtime) = state.code.as_deref() else {
+        return ServerError::internal("code mode is not configured on this server").into_response();
+    };
+    let Some(token) = bearer_token(&headers) else {
+        return ServerError::unauthorized("missing connected-apps token").into_response();
+    };
+    let Some(subject) = runtime.apps.subject_for_token(token) else {
+        return ServerError::unauthorized("unknown connected-apps token").into_response();
+    };
+    let request: JsonRpcRequest = match serde_json::from_value(value) {
+        Ok(request) => request,
+        Err(err) => {
+            return json_rpc_error(None, -32700, format!("parse error: {err}")).into_response();
+        }
+    };
+    if request.jsonrpc.as_deref().is_some_and(|v| v != "2.0") {
+        return json_rpc_error(request.id, -32600, "jsonrpc must be 2.0".into()).into_response();
+    }
+    // Every method rides a token that names one live worker. Refuse the
+    // whole surface, not just calls, once that worker is gone: a replaced
+    // or ended session must not keep listing an owner's apps.
+    let session =
+        match tidebreak_core::db::code::get_session_all_owners(&runtime.db, subject.session_id)
+            .await
+        {
+            Ok(Some(session)) => session,
+            Ok(None) => {
+                return ServerError::not_found(format!("session {} not found", subject.session_id))
+                    .into_response()
+            }
+            Err(err) => return ServerError::from(err).into_response(),
+        };
+    if session.owner != subject.owner || session.spawn_epoch != subject.spawn_epoch {
+        return ServerError::conflict_kind(
+            "apps_worker_replaced",
+            "the worker that issued this connected-apps token is no longer attached",
+        )
+        .into_response();
+    }
+    if session.lifecycle == SessionLifecycle::Ended {
+        return ServerError::conflict_kind("session_ended", "session has ended").into_response();
+    }
+    let registry = state.mcp.snapshot();
+    // Connected apps run under the session as the chat context: gateway
+    // call bearers are minted against it, exactly as for the in-process
+    // engine.
+    let ctx = ToolCtx::without_private_scratch(subject.session_id, None);
+    dispatch(&registry, &ctx, request).await.into_response()
+}
+
+/// Answer one JSON-RPC request against the current MCP snapshot. Pure over
+/// its inputs so the projection and call paths are testable without a
+/// listener.
+async fn dispatch(registry: &ToolRegistry, ctx: &ToolCtx, request: JsonRpcRequest) -> Response {
+    match request.method.as_deref() {
+        Some("initialize") => json_rpc_ok(
+            request.id,
+            json!({
+                "protocolVersion": request.params
+                    .get("protocolVersion")
+                    .and_then(Value::as_str)
+                    .unwrap_or("2025-11-25"),
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": AppsChannelSpec::MCP_SERVER, "version": "0.0.1" },
+            }),
+        )
+        .into_response(),
+        Some("notifications/initialized") => StatusCode::ACCEPTED.into_response(),
+        Some("ping") => json_rpc_ok(request.id, json!({})).into_response(),
+        Some("tools/list") => {
+            json_rpc_ok(request.id, json!({ "tools": advertised_tools(registry) })).into_response()
+        }
+        Some("tools/call") => call_tool(registry, ctx, request.id, request.params)
+            .await
+            .into_response(),
+        Some(other) => {
+            json_rpc_error(request.id, -32601, format!("Method not found: {other}")).into_response()
+        }
+        None => json_rpc_error(request.id, -32600, "missing method".into()).into_response(),
+    }
+}
+
+/// Every mounted MCP tool, advertised without the runtime's `mcp__` prefix.
+/// Built-in and client tools are not connected apps and stay out.
+fn advertised_tools(registry: &ToolRegistry) -> Vec<Value> {
+    registry
+        .specs()
+        .into_iter()
+        .filter_map(|spec| {
+            let name = spec.name.strip_prefix(MCP_PREFIX)?;
+            Some(json!({
+                "name": name,
+                "description": spec.description,
+                "inputSchema": spec.input_schema,
+            }))
+        })
+        .collect()
+}
+
+async fn call_tool(
+    registry: &ToolRegistry,
+    ctx: &ToolCtx,
+    id: Option<Value>,
+    params: Value,
+) -> Json<JsonRpcResponse> {
+    let name = params.get("name").and_then(Value::as_str).unwrap_or("");
+    let mounted = format!("{MCP_PREFIX}{name}");
+    let Some(tool) = registry.server_tool(&mounted) else {
+        return tool_result(id, format!("unknown tool {name}"), None, true);
+    };
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    match tool.execute(ctx, arguments).await {
+        Ok(output) => tool_result(id, output.content, output.data, output.is_error),
+        Err(error) => tool_result(id, error.to_string(), None, true),
+    }
+}
+
+fn tool_result(
+    id: Option<Value>,
+    text: String,
+    data: Option<Value>,
+    is_error: bool,
+) -> Json<JsonRpcResponse> {
+    let mut result = json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": is_error,
+    });
+    if let Some(data) = data {
+        result["structuredContent"] = data;
+    }
+    json_rpc_ok(id, result)
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let value = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    value.strip_prefix("Bearer ").map(str::trim)
+}
+
+fn json_rpc_ok(id: Option<Value>, result: Value) -> Json<JsonRpcResponse> {
+    Json(JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: Some(result),
+        error: None,
+    })
+}
+
+fn json_rpc_error(id: Option<Value>, code: i64, message: String) -> Json<JsonRpcResponse> {
+    Json(JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: None,
+        error: Some(json!({ "code": code, "message": message })),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use tidebreak_core::{AgentError, ApprovalClass, Tool, ToolOutput, ToolSpec};
+
+    /// A mounted MCP tool that echoes its arguments and records the chat it
+    /// ran under.
+    struct Echo {
+        name: &'static str,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl Tool for Echo {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: self.name.into(),
+                description: "echo".into(),
+                input_schema: json!({ "type": "object" }),
+            }
+        }
+
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::Sensitive
+        }
+
+        async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput, AgentError> {
+            if self.fail {
+                return Err(AgentError::msg("upstream refused"));
+            }
+            Ok(
+                ToolOutput::text(format!("chat={} args={args}", ctx.chat_id))
+                    .with_data(json!({ "echoed": args })),
+            )
+        }
+    }
+
+    fn registry() -> ToolRegistry {
+        ToolRegistry::new()
+            .with(Box::new(Echo {
+                name: "mcp__primary__github__proxy_api",
+                fail: false,
+            }))
+            .with(Box::new(Echo {
+                name: "mcp__docs__lookup",
+                fail: true,
+            }))
+            .with(Box::new(Echo {
+                name: "web_search",
+                fail: false,
+            }))
+    }
+
+    async fn body(response: Response) -> Value {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn request(method: &str, params: Value) -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: Some("2.0".into()),
+            id: Some(json!(1)),
+            method: Some(method.into()),
+            params,
+        }
+    }
+
+    #[tokio::test]
+    async fn tools_list_advertises_only_mounted_mcp_tools_without_the_prefix() {
+        let registry = registry();
+        let ctx = ToolCtx::without_private_scratch(SessionId::new(), None);
+        let response = dispatch(&registry, &ctx, request("tools/list", json!({}))).await;
+        let names: Vec<String> = body(response).await["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap().to_owned())
+            .collect();
+        assert_eq!(names, ["docs__lookup", "primary__github__proxy_api"]);
+    }
+
+    #[tokio::test]
+    async fn tools_call_runs_the_mounted_tool_under_the_session_context() {
+        let registry = registry();
+        let session = SessionId::new();
+        let ctx = ToolCtx::without_private_scratch(session, None);
+        let response = dispatch(
+            &registry,
+            &ctx,
+            request(
+                "tools/call",
+                json!({ "name": "primary__github__proxy_api", "arguments": { "operation_id": "getIssue" } }),
+            ),
+        )
+        .await;
+        let result = body(response).await["result"].clone();
+        assert_eq!(result["isError"], json!(false));
+        assert_eq!(
+            result["content"][0]["text"],
+            json!(format!(
+                "chat={session} args={{\"operation_id\":\"getIssue\"}}"
+            ))
+        );
+        assert_eq!(
+            result["structuredContent"]["echoed"]["operation_id"],
+            json!("getIssue")
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_failures_and_unknown_names_are_tool_errors_not_transport_errors() {
+        let registry = registry();
+        let ctx = ToolCtx::without_private_scratch(SessionId::new(), None);
+        let failed = body(
+            dispatch(
+                &registry,
+                &ctx,
+                request(
+                    "tools/call",
+                    json!({ "name": "docs__lookup", "arguments": {} }),
+                ),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(failed["result"]["isError"], json!(true));
+        assert_eq!(
+            failed["result"]["content"][0]["text"],
+            json!("upstream refused")
+        );
+
+        // A built-in tool is not a connected app even though it is registered.
+        let hidden = body(
+            dispatch(
+                &registry,
+                &ctx,
+                request(
+                    "tools/call",
+                    json!({ "name": "web_search", "arguments": {} }),
+                ),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(hidden["result"]["isError"], json!(true));
+        assert_eq!(
+            hidden["result"]["content"][0]["text"],
+            json!("unknown tool web_search")
+        );
+    }
+
+    #[test]
+    fn a_new_token_replaces_the_session_s_old_one() {
+        let bridge = AppsBridge::new();
+        let owner = OwnerId::local();
+        let session = SessionId::new();
+        let first = bridge.issue_token(&owner, session, 1);
+        let second = bridge.issue_token(&owner, session, 2);
+        assert!(bridge.subject_for_token(&first).is_none());
+        assert_eq!(
+            bridge.subject_for_token(&second).map(|s| s.spawn_epoch),
+            Some(2)
+        );
+        bridge.revoke_session(session);
+        assert!(bridge.subject_for_token(&second).is_none());
+    }
+}

--- a/crates/tidebreak-server/src/code/mod.rs
+++ b/crates/tidebreak-server/src/code/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod approval_bridge;
 pub mod approval_sweep;
+pub mod apps_bridge;
 pub mod attention;
 pub mod browser_channel;
 pub mod browser_runtime;

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -1287,6 +1287,7 @@ mod tests {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -1656,6 +1657,7 @@ mod tests {
                 sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
                 browser: None,
                 native: None,
+                apps: None,
             })
             .await
             .unwrap();

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -57,6 +57,7 @@ use tidebreak_harness::{
 };
 
 use super::approval_bridge::ApprovalBridge;
+use super::apps_bridge::AppsBridge;
 use super::browser_channel::{BrowserSubject, BrowserTokenRegistry};
 use super::bus::CodeEventBus;
 use super::checkpoint::{
@@ -182,6 +183,8 @@ pub struct CodeRuntime {
     pub clone_parent_default: Option<PathBuf>,
     pub blobs: Arc<dyn tidebreak_core::BlobStore>,
     pub approvals: Arc<ApprovalBridge>,
+    /// Session-scoped bearers for the loopback connected-apps bridge.
+    pub apps: Arc<AppsBridge>,
     pub browser_tokens: BrowserTokenRegistry,
     /// The session-native capability registry used by harness bridges.
     pub native_tokens: NativeTokenRegistry,
@@ -231,7 +234,7 @@ pub struct CodeRuntime {
     /// Live fan-out for adapter-grant revocations, so an event stream
     /// holding a revoked grant drops immediately (docs/slack-sessions.md).
     pub grant_revocations: Arc<super::grants::GrantRevocations>,
-    loopback_base: Mutex<Option<String>>,
+    pub(in crate::code) loopback_base: Mutex<Option<String>>,
     /// Memoized harness probes, one per kind. See [`CodeRuntime::probe`].
     probes: Mutex<HashMap<HarnessKind, HarnessProbe>>,
     /// Last pin-install failure per kind. Cleared on a successful install.
@@ -490,6 +493,7 @@ impl CodeRuntime {
             worktree_root_default,
             clone_parent_default: None,
             approvals: ApprovalBridge::new(),
+            apps: AppsBridge::new(),
             browser_tokens,
             browser_runtime,
             browser_bridge_command,
@@ -664,6 +668,7 @@ impl CodeRuntime {
             worktree_root_default: None,
             clone_parent_default: None,
             approvals: ApprovalBridge::new(),
+            apps: AppsBridge::new(),
             browser_tokens,
             browser_runtime,
             browser_bridge_command,

--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -121,6 +121,7 @@ impl CodeRuntime {
         self.browser_tokens.revoke(session_id);
         self.native_tokens.revoke(session_id);
         self.approvals.revoke_session(session_id);
+        self.apps.revoke_session(session_id);
         if let Some(relay) = &self.harness_llm {
             relay.revoke(session_id);
         }

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -249,6 +249,15 @@ impl CodeRuntime {
             )
         };
 
+        // Every external engine inherits the connected apps the in-process
+        // engine already sees, through the loopback bridge. The in-process
+        // engine reads the MCP runtime directly and needs no channel.
+        let apps = if session.harness_kind.is_in_process() {
+            None
+        } else {
+            self.apps_channel(&attached.owner, attached.id, attached.spawn_epoch)
+        };
+
         // Mint a browser channel only when both halves are present: the
         // native BrowserRuntime (the desktop adapter) and the trusted
         // bridge executable (the CLI sidecar). If either is absent, browser
@@ -426,6 +435,7 @@ impl CodeRuntime {
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
             browser,
             native,
+            apps,
         };
         let mut attached = attached;
         let engine = match adapter.launch(spec).await {

--- a/crates/tidebreak-server/src/code/session_worker/tests.rs
+++ b/crates/tidebreak-server/src/code/session_worker/tests.rs
@@ -262,6 +262,7 @@ async fn a_stale_local_worker_leaves_sandbox_queue_rows_for_the_remote_driver() 
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -378,6 +379,7 @@ async fn an_engine_observed_decision_settles_its_own_approval_row() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -521,6 +523,7 @@ async fn a_send_over_an_internal_turn_waiting_on_a_client_is_refused() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -632,6 +635,7 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -787,6 +791,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
                 sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
                 browser: None,
                 native: None,
+                apps: None,
             })
             .await
             .unwrap();
@@ -858,6 +863,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
                 sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
                 browser: None,
                 native: None,
+                apps: None,
             })
             .await
             .unwrap();
@@ -976,6 +982,7 @@ async fn a_decision_on_the_running_leg_resumes_the_park() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -1096,6 +1103,7 @@ async fn an_interrupt_closes_a_parked_turn() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -1198,6 +1206,7 @@ async fn a_confirmed_setting_reservation_wins_over_an_already_queued_idle_turn()
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -1314,6 +1323,7 @@ async fn a_queued_turn_uses_a_later_setting_committed_before_promotion() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();
@@ -1989,6 +1999,7 @@ async fn an_update_quiesce_refuses_new_turns_until_resumed() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            apps: None,
         })
         .await
         .unwrap();

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -155,6 +155,9 @@ pub struct ScriptedAdapter {
     /// Approval endpoint each launch was handed, `None` when it was handed no
     /// channel at all. Lets a test see how a session was wired.
     launched_approvals: Arc<std::sync::Mutex<Vec<Option<String>>>>,
+    /// Connected-apps channel each launch was handed, `None` when it was
+    /// handed none.
+    launched_apps: Arc<std::sync::Mutex<Vec<Option<tidebreak_harness::AppsChannelSpec>>>>,
     /// Files to materialize in the worktree at the start of each turn.
     writes: Vec<ScriptedWrite>,
     /// Sleep once at the start of each turn, so a caller can observe Running
@@ -203,6 +206,7 @@ impl ScriptedAdapter {
             approval_ack_delay: Duration::ZERO,
             probes: Arc::new(AtomicU64::new(0)),
             launched_approvals: Arc::new(std::sync::Mutex::new(Vec::new())),
+            launched_apps: Arc::new(std::sync::Mutex::new(Vec::new())),
             authenticated: Arc::new(std::sync::Mutex::new(Some(true))),
             writes: Vec::new(),
             turn_delay: Duration::ZERO,
@@ -220,6 +224,15 @@ impl ScriptedAdapter {
     #[cfg(any(test, feature = "test-support"))]
     pub fn launched_approvals(&self) -> Vec<Option<String>> {
         self.launched_approvals
+            .lock()
+            .expect("scripted launches")
+            .clone()
+    }
+
+    /// The connected-apps channel each launched session was given, in order.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn launched_apps(&self) -> Vec<Option<tidebreak_harness::AppsChannelSpec>> {
+        self.launched_apps
             .lock()
             .expect("scripted launches")
             .clone()
@@ -517,6 +530,10 @@ impl HarnessAdapter for ScriptedAdapter {
                     .as_ref()
                     .map(|channel| channel.mcp_endpoint_url.clone()),
             );
+        self.launched_apps
+            .lock()
+            .expect("scripted launches")
+            .push(spec.apps.clone());
         Ok(Box::new(ScriptedSession {
             sink: spec.sink,
             events: self.events.clone(),
@@ -1008,6 +1025,7 @@ mod tests {
             sink,
             browser: None,
             native: None,
+            apps: None,
         }
     }
 

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -279,6 +279,7 @@ impl HarnessEngine {
                 sink: self.sink.clone(),
                 browser: None,
                 native: None,
+                apps: None,
             })
             .await
             .map_err(|error| EngineError {

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -95,6 +95,7 @@ crates/tidebreak-server/src/code/   (the spine, not the whole directory)
   recovery.rs, worktree_orphans.rs   boot recovery, fencing, orphan probe, reap
   attention.rs       server-side attention computation, digest publication
   approval_bridge.rs the loopback approval-prompt endpoint glue and decision routing
+  apps_bridge.rs     the loopback connected-apps MCP bridge external engines mount as `tb-apps`
   gh.rs              gh CLI shell-out for repository and pull-request operations
   pr_fetch.rs        pull-request and checks reads through gh
   forge_rest.rs      brokered forge REST operations and auto-merge GraphQL mutation
@@ -314,6 +315,18 @@ Process models the trait absorbs:
   capabilities honestly `Unsupported` or `Unknown` where its surface does not
   carry them.
 
+Every external engine also mounts Tidebreak's connected apps. The server
+serves every MCP server it has mounted — the gateway endpoints an
+organization entitles plus locally configured servers — as one HTTP MCP
+server at `/code/mcp/connected-apps`, and each adapter wires it in as
+`tb-apps` with a session-scoped token: Claude Code through `--mcp-config`,
+Codex through an `mcp_servers` override with the bearer in
+`TIDEBREAK_APPS_TOKEN`, opencode through its config overlay, Grok through the
+ACP `mcpServers` list. The in-process engine reads the MCP runtime directly,
+so a chat sees the same tools on every engine. Gateway bearers and
+attestation stay inside the server; the child only ever holds the loopback
+token.
+
 Session-long children spawn lazily on the first turn, and an idle session's
 child is parked — stopped, then respawned and resumed by the next turn
 ([`0064`](decisions/0064-idle-engine-children-are-parked.md)). Resident
@@ -523,6 +536,7 @@ WS              /code/updates                        digests, restated on connec
 GET             /code/approvals?state=pending
 POST            /code/approvals/{id}/decision        {decision: approve | deny | approve_with_grant | answers | plan_decision, ...}
 POST            /code/mcp/approval-prompt            loopback approval endpoint (0033)
+POST            /code/mcp/connected-apps             loopback MCP bridge over every mounted MCP server, for external engines
 
 GET             /code/workspaces/{id}/files          changed files vs base, per-turn filter
 GET             /code/workspaces/{id}/diff?turn=&file=   bounded unified diff


### PR DESCRIPTION
## Why

Chats and code sessions on Claude Code, Codex, OpenCode, and Grok had no connected apps. Only the in-process engine read the MCP runtime, so the gateway endpoints an organization entitles, and any locally configured MCP server, never reached a harness child. Brandon hit this in chat: the model reported no connected apps. Most chats on this desktop run on Codex or Claude Code, so the common path had nothing.

## What

- The server serves every mounted MCP server as one HTTP MCP server at `POST /code/mcp/connected-apps`, authenticated by a session-scoped bearer the worker receives at launch (`crates/tidebreak-server/src/code/apps_bridge.rs`). Tool names drop the runtime's `mcp__` prefix. Gateway bearers, attestation contexts, and reconnects stay inside the server; the child only holds the loopback token, which dies with the worker like the approval token.
- `SessionSpec` gains `apps: Option<AppsChannelSpec>`. Each adapter mounts it as `tb-apps`: Claude Code through `--mcp-config`, Codex through an `mcp_servers` override with the bearer in `TIDEBREAK_APPS_TOKEN` (never argv), OpenCode through its config overlay, Grok through the ACP `mcpServers` list.
- The in-process engine is unchanged: it reads the MCP runtime directly.

## Tests

- Adapter config emission for all four engines.
- Bridge list and call paths against a fake mounted tool, including tool errors and hidden built-in tools.
- End-to-end: a session launch on an external engine mounts the bridge, `tools/list` answers with the session token, and the install token is refused.

Ran `cargo test -p tidebreak-harness` (400 pass; the one failure is `interactive_profile_env_is_captured_and_stripped`, which fails on this Mac on `main`), the `apps_bridge`, `session_worker`, `recover`, and `code_apps_bridge` filters, clippy with `-D warnings` on the touched crates, and `cargo fmt --check`.

## Out of scope

Sandbox and Slack sessions still get no MCP mounts: a delegated sandbox session cannot mint gateway MCP bearers and the loopback is unreachable from a sandbox. That needs gateway-side work.
