### PR TITLE
fix(harness): honor allowed_read_roots on every engine and publish codex/opencode pid transitions

### DIFF
--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -591,12 +591,8 @@ impl ClaudeSession {
             argv.push("--resume".into());
             argv.push(resume);
         }
+        crate::require_absolute_read_roots(&self.spec.allowed_read_roots)?;
         for root in &self.spec.allowed_read_roots {
-            if !root.is_absolute() {
-                return Err(HarnessError::AllowedReadRootNotAbsolute(
-                    root.to_string_lossy().into_owned(),
-                ));
-            }
             argv.push("--add-dir".into());
             argv.push(root.to_string_lossy().into_owned());
         }

--- a/crates/tidebreak-harness/src/codex/mod.rs
+++ b/crates/tidebreak-harness/src/codex/mod.rs
@@ -4,6 +4,11 @@
 //! `codex app-server --stdio` JSON-RPC child per session. Chosen over `codex exec --json` because the
 //! installed version's app-server handshake is stable and is the richer
 //! approval channel (`item/commandExecution/requestApproval`).
+//!
+//! `SessionSpec.allowed_read_roots` are required to be absolute and then left
+//! ungranted. Codex's sandbox does not restrict reads, so the engine can read
+//! those paths without a protocol field; they are never sent as
+//! `writableRoots`, which would grant write access the contract does not allow.
 
 pub mod parse;
 pub mod session;

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -873,26 +873,25 @@ pub(crate) fn thread_start_policy(mode: PermissionMode) -> (&'static str, &'stat
 /// takes: `sandboxPolicy` is a tagged object there, not the plain mode string
 /// `thread/start` accepts. Both fields apply to this turn and every later one,
 /// which is what lets a mode switch land without a new child.
+///
+/// `allowed_read_roots` are validated as absolute and then ignored as a Codex
+/// grant. Codex's sandbox (Seatbelt on macOS, Landlock/seccomp on Linux,
+/// `workspace-write` mode) restricts writes and network, not reads: files
+/// outside the writable roots are already readable. Passing those paths as
+/// `writableRoots` would grant write access the `SessionSpec` contract does
+/// not allow, so they are never sent. `workspace-write` keeps the workspace
+/// cwd as the only writable root.
 pub(crate) fn turn_start_policy(
     mode: PermissionMode,
     allowed_read_roots: &[PathBuf],
 ) -> Result<(Value, &'static str), HarnessError> {
     crate::require_absolute_read_roots(allowed_read_roots)?;
     let (sandbox, approval) = thread_start_policy(mode);
-    let mut sandbox = match sandbox {
+    let sandbox = match sandbox {
         "read-only" => json!({ "type": "readOnly" }),
         "danger-full-access" => json!({ "type": "dangerFullAccess" }),
         _ => json!({ "type": "workspaceWrite" }),
     };
-    if !allowed_read_roots.is_empty() {
-        // Codex app-server `sandboxPolicy` has no read-roots field. `writableRoots`
-        // is the closest equivalent (0.147.0): extra paths are writable as well
-        // as readable.
-        sandbox["writableRoots"] = json!(allowed_read_roots
-            .iter()
-            .map(|root| root.to_string_lossy().into_owned())
-            .collect::<Vec<_>>());
-    }
     Ok((sandbox, approval))
 }
 

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -1,6 +1,7 @@
 //! Long-lived `codex app-server --stdio` child.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -15,6 +16,7 @@ use tokio::time::{timeout, Instant};
 use tracing::warn;
 
 use crate::browser_channel::apply_child_env_tokio;
+use crate::child::ChildPid;
 use crate::codex::parse::CodexStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::{
@@ -67,7 +69,7 @@ pub struct CodexSession {
     /// Detail from an engine error saying the resumed thread is gone.
     resume_lost: Mutex<Option<String>>,
     child: AsyncMutex<Option<ProcessTreeChild>>,
-    child_pid: AtomicU32,
+    pid: ChildPid,
     stdin: Mutex<Option<Arc<AsyncMutex<ChildStdin>>>>,
     stdout: Mutex<Option<Arc<AsyncMutex<StdoutReader>>>>,
     parser: Arc<Mutex<CodexStreamParser>>,
@@ -201,7 +203,7 @@ impl CodexSession {
             thread_ran_a_turn: AtomicBool::new(false),
             resume_lost: Mutex::new(None),
             child: AsyncMutex::new(None),
-            child_pid: AtomicU32::new(0),
+            pid: ChildPid::new(),
             stdin: Mutex::new(None),
             stdout: Mutex::new(None),
             parser: Arc::new(Mutex::new(CodexStreamParser::new())),
@@ -757,7 +759,7 @@ impl CodexSession {
         let mut slot = self.child.lock().await;
         *self.stdin.lock().expect("codex stdin") = None;
         *self.stdout.lock().expect("codex stdout") = None;
-        self.child_pid.store(0, Ordering::SeqCst);
+        self.pid.clear();
         if let Some(mut child) = slot.take() {
             child.interrupt(PROCESS_INTERRUPT_GRACE).await?;
         }
@@ -871,15 +873,27 @@ pub(crate) fn thread_start_policy(mode: PermissionMode) -> (&'static str, &'stat
 /// takes: `sandboxPolicy` is a tagged object there, not the plain mode string
 /// `thread/start` accepts. Both fields apply to this turn and every later one,
 /// which is what lets a mode switch land without a new child.
-#[must_use]
-pub(crate) fn turn_start_policy(mode: PermissionMode) -> (Value, &'static str) {
+pub(crate) fn turn_start_policy(
+    mode: PermissionMode,
+    allowed_read_roots: &[PathBuf],
+) -> Result<(Value, &'static str), HarnessError> {
+    crate::require_absolute_read_roots(allowed_read_roots)?;
     let (sandbox, approval) = thread_start_policy(mode);
-    let sandbox = match sandbox {
+    let mut sandbox = match sandbox {
         "read-only" => json!({ "type": "readOnly" }),
         "danger-full-access" => json!({ "type": "dangerFullAccess" }),
         _ => json!({ "type": "workspaceWrite" }),
     };
-    (sandbox, approval)
+    if !allowed_read_roots.is_empty() {
+        // Codex app-server `sandboxPolicy` has no read-roots field. `writableRoots`
+        // is the closest equivalent (0.147.0): extra paths are writable as well
+        // as readable.
+        sandbox["writableRoots"] = json!(allowed_read_roots
+            .iter()
+            .map(|root| root.to_string_lossy().into_owned())
+            .collect::<Vec<_>>());
+    }
+    Ok((sandbox, approval))
 }
 
 impl CodexSession {
@@ -890,6 +904,7 @@ impl CodexSession {
     /// turn's own request goes out. The child slot is held across the whole
     /// ensure, so two callers cannot race two spawns.
     pub(super) async fn ensure_child(&self) -> Result<(), HarnessError> {
+        crate::require_absolute_read_roots(&self.spec.allowed_read_roots)?;
         let mut slot = self.child.lock().await;
         if let Some(child) = slot.as_mut() {
             if matches!(child.try_wait(), Ok(None)) {
@@ -897,7 +912,7 @@ impl CodexSession {
             }
             // The process is gone; drop the handles that pointed at it.
             *slot = None;
-            self.child_pid.store(0, Ordering::SeqCst);
+            self.pid.clear();
             *self.stdin.lock().expect("codex stdin") = None;
             *self.stdout.lock().expect("codex stdout") = None;
         }
@@ -942,8 +957,7 @@ impl CodexSession {
                 stdout,
                 lines: StreamLineBuffer::new(),
             })));
-        self.child_pid
-            .store(child.id().unwrap_or(0), Ordering::SeqCst);
+        self.pid.set(child.id());
         *slot = Some(child);
         tokio::spawn(async move {
             let _ = drain_capped(stderr, MAX_STDERR_BYTES).await;
@@ -955,7 +969,7 @@ impl CodexSession {
             if let Some(mut child) = slot.take() {
                 let _ = child.terminate().await;
             }
-            self.child_pid.store(0, Ordering::SeqCst);
+            self.pid.clear();
             *self.stdin.lock().expect("codex stdin") = None;
             *self.stdout.lock().expect("codex stdout") = None;
             return Err(err);
@@ -1333,10 +1347,15 @@ impl HarnessSession for CodexSession {
             params["serviceTier"] = json!(FAST_SERVICE_TIER);
         }
         let posture = self.pending_posture();
-        if let Some(posture) = posture {
-            let (sandbox, approval) = turn_start_policy(posture.mode);
+        if posture.is_some() || !self.spec.allowed_read_roots.is_empty() {
+            let mode = posture
+                .map(|generation| generation.mode)
+                .unwrap_or_else(|| self.permission_mode());
+            let (sandbox, approval) = turn_start_policy(mode, &self.spec.allowed_read_roots)?;
             params["sandboxPolicy"] = sandbox;
-            params["approvalPolicy"] = json!(approval);
+            if posture.is_some() {
+                params["approvalPolicy"] = json!(approval);
+            }
         }
         let id = match self.request("turn/start", params).await {
             Ok(id) => id,
@@ -1425,7 +1444,7 @@ impl HarnessSession for CodexSession {
     }
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
-        if self.child_pid.load(Ordering::SeqCst) == 0 {
+        if self.pid.get().is_none() {
             // No child means nothing is running: a stop aimed at a parked
             // session must not cost it anything (decision 0064).
             return Ok(());
@@ -1485,10 +1504,11 @@ impl HarnessSession for CodexSession {
     }
 
     fn child_pid(&self) -> Option<i64> {
-        match self.child_pid.load(Ordering::SeqCst) {
-            0 => None,
-            pid => Some(i64::from(pid)),
-        }
+        self.pid.get()
+    }
+
+    fn child_pid_changes(&self) -> Option<tokio::sync::watch::Receiver<Option<i64>>> {
+        Some(self.pid.subscribe())
     }
 
     fn unrecognized_events(&self) -> u64 {
@@ -1504,7 +1524,7 @@ impl HarnessSession for CodexSession {
         let mut slot = self.child.lock().await;
         *self.stdin.lock().expect("codex stdin") = None;
         *self.stdout.lock().expect("codex stdout") = None;
-        self.child_pid.store(0, Ordering::SeqCst);
+        self.pid.clear();
         if let Some(mut child) = slot.take() {
             let _ = child.terminate().await;
         }

--- a/crates/tidebreak-harness/src/codex/session/tests.rs
+++ b/crates/tidebreak-harness/src/codex/session/tests.rs
@@ -56,6 +56,28 @@ fn permission_mode_mapping_matches_0033() {
 }
 
 #[test]
+fn turn_policy_carries_allowed_read_roots_as_writable_roots() {
+    let root = PathBuf::from("/tmp/tidebreak-private");
+    let (sandbox, _) =
+        turn_start_policy(PermissionMode::Auto, std::slice::from_ref(&root)).unwrap();
+    assert_eq!(sandbox["type"], "workspaceWrite");
+    assert_eq!(
+        sandbox["writableRoots"],
+        serde_json::json!([root.to_string_lossy()])
+    );
+}
+
+#[test]
+fn turn_policy_refuses_a_relative_read_root() {
+    let err =
+        turn_start_policy(PermissionMode::Auto, &[PathBuf::from("relative/private")]).unwrap_err();
+    assert!(matches!(
+        err,
+        HarnessError::AllowedReadRootNotAbsolute(root) if root == "relative/private"
+    ));
+}
+
+#[test]
 fn thread_loads_allow_a_longer_inactivity_window_than_initialization() {
     assert!(THREAD_LOAD_TIMEOUT > HANDSHAKE_TIMEOUT);
     assert_eq!(THREAD_LOAD_TIMEOUT, Duration::from_secs(120));
@@ -762,6 +784,35 @@ async fn a_parked_thread_is_resumed_on_the_next_turn() {
     assert_eq!(session.resume_ref().as_deref(), Some("THREAD-1"));
 }
 
+/// A park/respawn inside `run_turn` must publish the new pid so a crash
+/// mid-wake cannot orphan the replacement child.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_respawn_publishes_a_pid_transition() {
+    let dir = tempfile::tempdir().unwrap();
+    let binary = dir.path().join("codex");
+    write_app_server(&binary, FAKE_RESUMABLE_APP_SERVER);
+
+    let session = CodexSession::new(spec_for(dir.path(), &binary, None));
+    assert!(
+        session.child_pid_changes().is_some(),
+        "an adapter that owns a child must stream its pid"
+    );
+    let rx = session.child_pid_changes().expect("pid stream");
+
+    session.run_turn(turn("one")).await.unwrap();
+    let first = session.child_pid().expect("the child outlives its turn");
+    assert_eq!(*rx.borrow(), Some(first));
+
+    session.park().await.unwrap();
+    assert_eq!(*rx.borrow(), None);
+
+    session.run_turn(turn("two")).await.unwrap();
+    let second = session.child_pid().expect("the wake turn spawned a child");
+    assert_ne!(first, second);
+    assert_eq!(*rx.borrow(), Some(second));
+}
+
 /// Codex never persisted a thread that ran no turn, so waking one must
 /// start clean. Resuming it would fence the session on "thread not
 /// found" — the fake's own answer catches a wrong ensure here.
@@ -832,6 +883,47 @@ async fn rejected_turn_start_keeps_posture_pending() {
     for request in requests {
         assert_eq!(request["params"]["sandboxPolicy"]["type"], "readOnly");
         assert_eq!(request["params"]["approvalPolicy"], "untrusted");
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn allowed_read_roots_reach_turn_start_sandbox_policy() {
+    let dir = tempfile::tempdir().unwrap();
+    let binary = dir.path().join("codex");
+    write_app_server(&binary, FAKE_POSTURE_APP_SERVER);
+    let private = dir.path().join("private");
+    std::fs::create_dir_all(&private).unwrap();
+    let mut spec = spec_for(dir.path(), &binary, None);
+    spec.allowed_read_roots = vec![private.clone()];
+    spec.extra_env.push((
+        "FAKE_CODEX_TURNS".into(),
+        dir.path()
+            .join("turns.ndjson")
+            .to_string_lossy()
+            .into_owned(),
+    ));
+    let session = CodexSession::new(spec);
+    session
+        .set_permission_mode(PermissionMode::Plan)
+        .await
+        .unwrap();
+
+    session.run_turn(turn("first")).await.unwrap();
+    session.run_turn(turn("second")).await.unwrap();
+
+    let requests = std::fs::read_to_string(dir.path().join("turns.ndjson")).unwrap();
+    let requests = requests
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(requests.len(), 2);
+    for request in requests {
+        assert_eq!(request["params"]["sandboxPolicy"]["type"], "readOnly");
+        assert_eq!(
+            request["params"]["sandboxPolicy"]["writableRoots"],
+            json!([private.to_string_lossy()])
+        );
     }
 }
 

--- a/crates/tidebreak-harness/src/codex/session/tests.rs
+++ b/crates/tidebreak-harness/src/codex/session/tests.rs
@@ -56,15 +56,28 @@ fn permission_mode_mapping_matches_0033() {
 }
 
 #[test]
-fn turn_policy_carries_allowed_read_roots_as_writable_roots() {
-    let root = PathBuf::from("/tmp/tidebreak-private");
+fn turn_policy_does_not_put_allowed_read_roots_in_writable_roots() {
+    let root = std::env::temp_dir().join("tidebreak-private");
     let (sandbox, _) =
         turn_start_policy(PermissionMode::Auto, std::slice::from_ref(&root)).unwrap();
     assert_eq!(sandbox["type"], "workspaceWrite");
-    assert_eq!(
-        sandbox["writableRoots"],
-        serde_json::json!([root.to_string_lossy()])
-    );
+    match sandbox.get("writableRoots") {
+        None => {}
+        Some(roots) => {
+            let roots = roots.as_array().expect("writableRoots is an array");
+            let root_str = root.to_string_lossy();
+            assert!(
+                !roots
+                    .iter()
+                    .any(|value| value.as_str() == Some(root_str.as_ref())),
+                "allowed_read_roots must not appear in writableRoots: {roots:?}"
+            );
+            assert!(
+                roots.is_empty(),
+                "workspace-write must not gain extra writable roots; got {roots:?}"
+            );
+        }
+    }
 }
 
 #[test]
@@ -920,9 +933,16 @@ async fn allowed_read_roots_reach_turn_start_sandbox_policy() {
     assert_eq!(requests.len(), 2);
     for request in requests {
         assert_eq!(request["params"]["sandboxPolicy"]["type"], "readOnly");
-        assert_eq!(
-            request["params"]["sandboxPolicy"]["writableRoots"],
-            json!([private.to_string_lossy()])
+        let writable = request["params"]["sandboxPolicy"].get("writableRoots");
+        let private_str = private.to_string_lossy();
+        assert!(
+            writable.is_none()
+                || !writable
+                    .and_then(|value| value.as_array())
+                    .into_iter()
+                    .flatten()
+                    .any(|value| value.as_str() == Some(private_str.as_ref())),
+            "allowed_read_roots must not appear in writableRoots: {writable:?}"
         );
     }
 }

--- a/crates/tidebreak-harness/src/grok/mod.rs
+++ b/crates/tidebreak-harness/src/grok/mod.rs
@@ -4,6 +4,11 @@
 //! 1.0.13 ACP channel carries native approvals, cancellation, and session
 //! loading over stdin/stdout. Other versions retain the print fallback
 //! without claiming a verified Auto posture.
+//!
+//! Grok print/ACP protocols have no extra-read-root flag. `allowed_read_roots`
+//! are still required to be absolute so a relative private path cannot slip
+//! through; the engine then runs without additional read scoping rather than
+//! dropping the field silently.
 
 pub mod parse;
 pub mod session;

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -117,6 +117,10 @@ impl GrokSession {
         } else {
             (None, session_id.as_deref())
         };
+        // Grok print/ACP protocols have no extra-read-root flag. Roots are
+        // still required to be absolute so a relative private path cannot
+        // slip through; the engine then runs without additional read scoping.
+        crate::require_absolute_read_roots(&self.spec.allowed_read_roots)?;
         compose_print_plan(PrintLaunch {
             binary: self.spec.binary.as_deref().ok_or(HarnessError::NotFound)?,
             extra_argv: &self.spec.extra_argv,
@@ -862,6 +866,48 @@ where
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    struct Discard;
+
+    #[async_trait]
+    impl crate::HarnessEventSink for Discard {
+        async fn emit(&self, _event: HarnessEvent) {}
+    }
+
+    #[test]
+    fn allowed_read_roots_must_be_absolute() {
+        let session = GrokSession::new(
+            SessionSpec {
+                owner: tidebreak_core::OwnerId::local(),
+                session_id: tidebreak_core::SessionId::new(),
+                worktree: std::path::PathBuf::from("/workspace"),
+                allowed_read_roots: vec![std::path::PathBuf::from("relative/private")],
+                permission_mode: PermissionMode::Auto,
+                model: None,
+                reasoning_effort: None,
+                fast_mode: false,
+                resume_ref: None,
+                extra_argv: Vec::new(),
+                extra_env: Vec::new(),
+                relay_key_env: None,
+                env: Vec::new(),
+                approval: None,
+                binary: Some(std::path::PathBuf::from("/usr/bin/grok")),
+                sink: std::sync::Arc::new(Discard),
+                browser: None,
+                native: None,
+                apps: None,
+            },
+            "1.0.5".into(),
+        );
+        let err = session
+            .compose_plan(std::path::Path::new("/tmp/prompt.txt"), None, None)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            HarnessError::AllowedReadRootNotAbsolute(root) if root == "relative/private"
+        ));
+    }
 
     #[test]
     fn grok_1_0_5_never_receives_the_removed_xhigh_token() {

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -865,6 +865,13 @@ pub struct SessionSpec {
     /// Worktree the engine should use as its working directory.
     pub worktree: PathBuf,
     /// Absolute directory roots that engine tools may read outside the worktree.
+    ///
+    /// Claude honors these as `--add-dir`. Codex maps them onto sandbox
+    /// `writableRoots` — the app-server protocol has no read-only extra-roots
+    /// field, so those paths are writable as well as readable. OpenCode and
+    /// Grok have no equivalent scoping: adapters still require every root to
+    /// be absolute and then launch without extra read restriction, rather
+    /// than dropping the field silently.
     pub allowed_read_roots: Vec<PathBuf>,
     /// Permission mode. Adapters refuse a mode they cannot honor.
     pub permission_mode: PermissionMode,
@@ -914,6 +921,22 @@ pub struct SessionSpec {
     /// Connected-apps channel wiring: the loopback MCP bridge over every
     /// server Tidebreak has mounted. `None` advertises no connected apps.
     pub apps: Option<AppsChannelSpec>,
+}
+
+/// Refuse a relative extra-read root.
+///
+/// Every adapter calls this before launch so a private path cannot slip
+/// through as cwd-relative, including engines that cannot otherwise scope
+/// reads to these roots.
+pub(crate) fn require_absolute_read_roots(roots: &[PathBuf]) -> Result<(), HarnessError> {
+    for root in roots {
+        if !root.is_absolute() {
+            return Err(HarnessError::AllowedReadRootNotAbsolute(
+                root.to_string_lossy().into_owned(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Receives normalized events as the engine stream is parsed.

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -866,12 +866,12 @@ pub struct SessionSpec {
     pub worktree: PathBuf,
     /// Absolute directory roots that engine tools may read outside the worktree.
     ///
-    /// Claude honors these as `--add-dir`. Codex maps them onto sandbox
-    /// `writableRoots` — the app-server protocol has no read-only extra-roots
-    /// field, so those paths are writable as well as readable. OpenCode and
-    /// Grok have no equivalent scoping: adapters still require every root to
-    /// be absolute and then launch without extra read restriction, rather
-    /// than dropping the field silently.
+    /// Claude honors these as `--add-dir`. Codex does not receive a grant for
+    /// them: its sandbox restricts writes and network, not reads, so the engine
+    /// can already read those paths, and they are never passed as
+    /// `writableRoots` (no write access). OpenCode and Grok have no extra-read
+    /// flag: adapters still require every root to be absolute and then launch
+    /// without extra read restriction, rather than dropping the field silently.
     pub allowed_read_roots: Vec<PathBuf>,
     /// Permission mode. Adapters refuse a mode they cannot honor.
     pub permission_mode: PermissionMode,

--- a/crates/tidebreak-harness/src/opencode/mod.rs
+++ b/crates/tidebreak-harness/src/opencode/mod.rs
@@ -5,6 +5,11 @@
 //! over `opencode run --format json` because the installed version's serve
 //! API is real — sessions, messages, `/event`, and a permission reply
 //! surface — and the prompt stays off argv.
+//!
+//! OpenCode serve has no extra-read-root flag. `allowed_read_roots` are still
+//! required to be absolute so a relative private path cannot slip through; the
+//! engine then runs without additional read scoping rather than dropping the
+//! field silently.
 
 pub mod parse;
 pub mod session;

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -2,7 +2,6 @@
 
 use std::net::TcpListener;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -16,6 +15,7 @@ use tokio::time::timeout;
 use tracing::warn;
 
 use crate::browser_channel::apply_child_env_tokio;
+use crate::child::ChildPid;
 use crate::launch::{validate_launch_plan, LaunchPlan};
 use crate::opencode::parse::OpencodeStreamParser;
 use crate::{
@@ -44,7 +44,7 @@ pub struct OpencodeSession {
     spec: SessionSpec,
     resume_ref: Mutex<Option<String>>,
     child: AsyncMutex<Option<ProcessTreeChild>>,
-    child_pid: AtomicU32,
+    pid: ChildPid,
     /// Loopback base of the current child. Each spawn binds a fresh port, so
     /// this is per-child state; empty until the first spawn.
     base_url: Mutex<String>,
@@ -138,7 +138,7 @@ impl OpencodeSession {
             spec,
             resume_ref: Mutex::new(resume_ref),
             child: AsyncMutex::new(None),
-            child_pid: AtomicU32::new(0),
+            pid: ChildPid::new(),
             base_url: Mutex::new(String::new()),
             client: reqwest::Client::new(),
             parser: Mutex::new(OpencodeStreamParser::new()),
@@ -523,6 +523,10 @@ impl OpencodeSession {
     /// child slot is held across the whole ensure, so two callers cannot race
     /// two spawns.
     pub(super) async fn ensure_child(&self) -> Result<(), HarnessError> {
+        // OpenCode serve has no extra-read-root flag. Absolute roots are still
+        // required so a relative private path cannot slip through; the engine
+        // then runs without additional read scoping.
+        crate::require_absolute_read_roots(&self.spec.allowed_read_roots)?;
         let mut slot = self.child.lock().await;
         let stream_failure = {
             let events = self.events.lock().await;
@@ -539,7 +543,7 @@ impl OpencodeSession {
             if let Some(mut child) = slot.take() {
                 let _ = child.terminate().await;
             }
-            self.child_pid.store(0, Ordering::SeqCst);
+            self.pid.clear();
             warn!(failure = %failure, "replacing opencode child after event stream failure");
         }
         if let Some(child) = slot.as_mut() {
@@ -547,7 +551,7 @@ impl OpencodeSession {
                 return Ok(());
             }
             *slot = None;
-            self.child_pid.store(0, Ordering::SeqCst);
+            self.pid.clear();
         }
         let port = pick_loopback_port()?;
         let plan = compose_serve_plan(ServeLaunch {
@@ -584,9 +588,7 @@ impl OpencodeSession {
         let stderr = child
             .take_stderr()
             .ok_or_else(|| HarnessError::Other("engine child has no stderr".into()))?;
-        if let Some(pid) = child.id() {
-            self.child_pid.store(pid, Ordering::SeqCst);
-        }
+        self.pid.set(child.id());
         *slot = Some(child);
         tokio::spawn(async move {
             let _ = drain_capped(stdout, MAX_STDERR_BYTES).await;
@@ -610,7 +612,7 @@ impl OpencodeSession {
             if let Some(mut child) = slot.take() {
                 let _ = child.terminate().await;
             }
-            self.child_pid.store(0, Ordering::SeqCst);
+            self.pid.clear();
             *self.events.lock().await = None;
             let _ = timeout(Duration::from_secs(1), stderr_task).await;
             let stderr = {
@@ -723,7 +725,7 @@ impl OpencodeSession {
 
     async fn retire_child(&self) {
         let mut slot = self.child.lock().await;
-        self.child_pid.store(0, Ordering::SeqCst);
+        self.pid.clear();
         *self.events.lock().await = None;
         if let Some(mut child) = slot.take() {
             let _ = child.terminate().await;
@@ -964,7 +966,7 @@ impl HarnessSession for OpencodeSession {
     }
 
     async fn interrupt(&self) -> Result<(), HarnessError> {
-        if self.child_pid.load(Ordering::SeqCst) == 0 {
+        if self.pid.get().is_none() {
             // No child means nothing is running: a stop aimed at a parked
             // session must not cost it anything (decision 0064).
             return Ok(());
@@ -990,7 +992,7 @@ impl HarnessSession for OpencodeSession {
         };
         child.interrupt(Duration::from_secs(2)).await?;
         *slot = None;
-        self.child_pid.store(0, Ordering::SeqCst);
+        self.pid.clear();
         Ok(())
     }
 
@@ -999,8 +1001,11 @@ impl HarnessSession for OpencodeSession {
     }
 
     fn child_pid(&self) -> Option<i64> {
-        let pid = self.child_pid.load(Ordering::SeqCst);
-        (pid != 0).then_some(i64::from(pid))
+        self.pid.get()
+    }
+
+    fn child_pid_changes(&self) -> Option<tokio::sync::watch::Receiver<Option<i64>>> {
+        Some(self.pid.subscribe())
     }
 
     fn unrecognized_events(&self) -> u64 {
@@ -1014,7 +1019,7 @@ impl HarnessSession for OpencodeSession {
     /// respawns a server and reopens it.
     async fn park(&self) -> Result<(), HarnessError> {
         let mut slot = self.child.lock().await;
-        self.child_pid.store(0, Ordering::SeqCst);
+        self.pid.clear();
         *self.events.lock().await = None;
         if let Some(mut child) = slot.take() {
             let _ = child.terminate().await;
@@ -1156,6 +1161,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn allowed_read_roots_must_be_absolute() {
+        let mut session = unit_session();
+        session.spec.allowed_read_roots = vec![std::path::PathBuf::from("relative/private")];
+        let err = session.ensure_child().await.unwrap_err();
+        assert!(matches!(
+            err,
+            HarnessError::AllowedReadRootNotAbsolute(root) if root == "relative/private"
+        ));
+    }
+
+    /// A park/respawn must publish the new pid the same way Claude and Grok do.
+    #[tokio::test]
+    async fn a_respawn_publishes_a_pid_transition() {
+        let session = unit_session();
+        assert!(
+            session.child_pid_changes().is_some(),
+            "an adapter that owns a child must stream its pid"
+        );
+        let rx = session.child_pid_changes().expect("pid stream");
+        session.pid.set(Some(11));
+        assert_eq!(*rx.borrow(), Some(11));
+
+        session.park().await.unwrap();
+        assert_eq!(session.child_pid(), None);
+        assert_eq!(*rx.borrow(), None);
+
+        session.pid.set(Some(22));
+        assert_eq!(*rx.borrow(), Some(22));
+    }
+
+    #[tokio::test]
     async fn sse_queue_applies_event_count_backpressure() {
         let (sender, stream) = sse_event_channel(2, 1_024);
         sender.send("one".into()).await.unwrap();
@@ -1275,7 +1311,7 @@ mod tests {
         let session = unit_session();
         let (_sender, stream) = sse_event_channel(2, 1_024);
         *session.events.lock().await = Some(stream);
-        session.child_pid.store(42, Ordering::SeqCst);
+        session.pid.set(Some(42));
 
         session.retire_child().await;
 
@@ -1289,7 +1325,7 @@ mod tests {
         let session = Arc::new(unit_session());
         let (_sender, stream) = sse_event_channel(2, 1_024);
         *session.events.lock().await = Some(Arc::clone(&stream));
-        session.child_pid.store(42, Ordering::SeqCst);
+        session.pid.set(Some(42));
         let receiver = stream.receiver.lock().await;
 
         timeout(Duration::from_secs(1), session.retire_child())
@@ -1309,7 +1345,7 @@ mod tests {
         let (sender, stream) = sse_event_channel(2, 1_024);
         sender.fail("recorded stream failure".into()).await;
         *session.events.lock().await = Some(stream);
-        session.child_pid.store(42, Ordering::SeqCst);
+        session.pid.set(Some(42));
 
         let error = session.ensure_child().await.unwrap_err();
 


### PR DESCRIPTION
## What was wrong

`SessionSpec.allowed_read_roots` is contract, but only Claude honored it (`--add-dir`). Codex, OpenCode, and Grok ignored the field while `ci_logs` assumed every engine could read the private root. Separately, Codex and OpenCode parked and respawned inside `run_turn` without implementing `child_pid_changes`, so the session row's pid stayed stale for the whole wake turn.

## What changed

- **Claude:** still passes `--add-dir`; absolute-root checks go through a shared helper.
- **Codex:** requires `allowed_read_roots` to be absolute and does **not** pass them to the engine. Codex's sandbox restricts writes and network, not reads, so those paths are already readable; they are never sent as `writableRoots` (no write grant). Relative roots fail with `AllowedReadRootNotAbsolute`. `ChildPid` streams spawn/park/respawn.
- **OpenCode and Grok:** protocols have no extra-read-root flag. Adapters require every root to be absolute and then launch without extra read scoping, rather than dropping the field. OpenCode also streams pid transitions through `ChildPid`.

Closes #3335

## Checks

- `cargo fmt --all` — applied
- `cargo test -p tidebreak-harness` — focused Codex turn-policy, pid-transition, OpenCode pid/roots, Grok/Claude absolute-root tests passed (8). Full crate run had one unrelated flake: `child::unix_process_tree_tests::cancelling_output_collection_kills_a_pipe_owning_descendant`.
- `cargo clippy -p tidebreak-harness --all-targets --no-deps -- -D warnings` — passed for `tidebreak-harness`. Full `cargo clippy -p tidebreak-harness --all-targets -- -D warnings` does not compile `tidebreak-core` under `-D warnings` (pre-existing unused items in that crate, outside this change).
