### PR TITLE
fix(exec): report truncated output honestly across container backends and stabilize receipt replay

### DIFF
--- a/crates/tidebreak-code-execution/src/daytona.rs
+++ b/crates/tidebreak-code-execution/src/daytona.rs
@@ -10,7 +10,9 @@ use tidebreak_core::{ExecDegradation, SecretProvider};
 use tidebreak_egress::{EgressEnforcement, EgressPolicy};
 
 use crate::credential::SecretCredential;
-use crate::http::{decode_bounded_json, download_bounded_file, multipart_file};
+use crate::http::{
+    decode_bounded_json, decode_bounded_json_truncated, download_bounded_file, multipart_file,
+};
 use crate::output::{Capture, StreamKind};
 use crate::remote::{
     connect_remote_workspace, create_remote_workspace, destroy_remote_workspace, execute_remote,
@@ -38,6 +40,9 @@ const DAYTONA_START_TIMEOUT: Duration = Duration::from_secs(60);
 const DAYTONA_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const DAYTONA_TRANSPORT_GRACE: Duration = Duration::from_secs(10);
 const MAX_DAYTONA_RESPONSE_BYTES: usize = 1024 * 1024;
+/// Execute bodies can exceed the management cap; keep a complete JSON document
+/// so a large `result` still yields an exit code, then [`Capture`] truncates.
+const MAX_DAYTONA_EXECUTE_BYTES: usize = 8 * 1024 * 1024;
 /// Daytona accepts at most this many CIDR entries per sandbox allowlist.
 const DAYTONA_MAX_NETWORK_ALLOW_ENTRIES: usize = 10;
 /// Daytona accepts at most this many domain entries per sandbox allowlist.
@@ -660,37 +665,38 @@ impl DaytonaExecutionProvider {
         ) {
             return Err(RemoteSessionError::Missing);
         }
-        if response.status() == StatusCode::REQUEST_TIMEOUT {
-            return Ok(Capture::default().response(ExecProviderKind::Daytona, started, None, true));
-        }
+        let timed_out_status = response.status() == StatusCode::REQUEST_TIMEOUT;
         if !response.status().is_success() {
             let status = response.status();
-            let error = decode_bounded_json::<DaytonaErrorResponse>(
+            let error = decode_bounded_json::<DaytonaTimeoutBody>(
                 response,
                 "Daytona",
-                MAX_DAYTONA_RESPONSE_BYTES,
+                MAX_DAYTONA_EXECUTE_BYTES,
             )
             .await
             .ok();
-            if error
-                .and_then(|body| body.code)
-                .is_some_and(|code| code == "PROCESS_EXECUTION_TIMEOUT")
+            if timed_out_status
+                || error
+                    .as_ref()
+                    .and_then(|body| body.code.as_deref())
+                    .is_some_and(|code| code == "PROCESS_EXECUTION_TIMEOUT")
             {
-                return Ok(Capture::default().response(
-                    ExecProviderKind::Daytona,
+                return Ok(daytona_captured_response(
+                    error.unwrap_or_default().into_execute(),
                     started,
-                    None,
                     true,
+                    false,
                 ));
             }
             return Err(provider_status_error(status).into());
         }
-        let body =
-            decode_bounded_json::<ExecuteResponse>(response, "Daytona", MAX_DAYTONA_RESPONSE_BYTES)
-                .await?;
-        let mut capture = Capture::default();
-        capture.append(body.result.as_bytes(), StreamKind::Stdout);
-        Ok(capture.response(ExecProviderKind::Daytona, started, body.exit_code, false))
+        let (body, oversized) = decode_bounded_json_truncated::<ExecuteResponse>(
+            response,
+            "Daytona",
+            MAX_DAYTONA_EXECUTE_BYTES,
+        )
+        .await?;
+        Ok(daytona_captured_response(body, started, false, oversized))
     }
 
     fn toolbox_file_url(&self, session: &RemoteSession, suffix: &str) -> Result<Url, ExecError> {
@@ -1148,16 +1154,72 @@ struct ExecuteRequest<'a> {
     timeout: u32,
 }
 
-#[derive(Deserialize)]
+/// Toolbox `process/execute` payload.
+///
+/// Daytona's execute API returns one merged `result` string and no separate
+/// stderr stream. When `stdout` / `stderr` fields are present they are used;
+/// otherwise the merged `result` is filed as stdout and stderr stays empty.
+#[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct ExecuteResponse {
     exit_code: Option<i32>,
+    #[serde(default)]
     result: String,
+    stdout: Option<String>,
+    stderr: Option<String>,
 }
 
-#[derive(Deserialize)]
-struct DaytonaErrorResponse {
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct DaytonaTimeoutBody {
     code: Option<String>,
+    #[serde(default)]
+    result: String,
+    exit_code: Option<i32>,
+    stdout: Option<String>,
+    stderr: Option<String>,
+}
+
+impl DaytonaTimeoutBody {
+    fn into_execute(self) -> ExecuteResponse {
+        ExecuteResponse {
+            exit_code: self.exit_code,
+            result: self.result,
+            stdout: self.stdout,
+            stderr: self.stderr,
+        }
+    }
+}
+
+fn daytona_captured_response(
+    body: ExecuteResponse,
+    started: Instant,
+    timed_out: bool,
+    oversized: bool,
+) -> ExecResponse {
+    let mut capture = Capture::default();
+    match (body.stdout, body.stderr) {
+        (None, None) => capture.append(body.result.as_bytes(), StreamKind::Stdout),
+        (stdout, stderr) => {
+            if let Some(stdout) = stdout {
+                capture.append(stdout.as_bytes(), StreamKind::Stdout);
+            } else if !body.result.is_empty() {
+                capture.append(body.result.as_bytes(), StreamKind::Stdout);
+            }
+            if let Some(stderr) = stderr {
+                capture.append(stderr.as_bytes(), StreamKind::Stderr);
+            }
+        }
+    }
+    if oversized {
+        capture.mark_truncated();
+    }
+    capture.response(
+        ExecProviderKind::Daytona,
+        started,
+        if timed_out { None } else { body.exit_code },
+        timed_out,
+    )
 }
 
 /// Best-effort body on snapshot refusals so the degrade log names the real
@@ -1456,6 +1518,7 @@ mod tests {
                 Json(json!({
                     "code": "PROCESS_EXECUTION_TIMEOUT",
                     "message": "command exceeded its timeout",
+                    "result": "partial\n",
                 })),
             )
         } else {
@@ -1820,6 +1883,7 @@ mod tests {
         let response = provider.execute(timeout_request()).await.unwrap();
         assert!(response.timed_out);
         assert_eq!(response.exit_code, None);
+        assert_eq!(response.stdout, "partial\n");
         server.abort();
     }
 

--- a/crates/tidebreak-code-execution/src/daytona.rs
+++ b/crates/tidebreak-code-execution/src/daytona.rs
@@ -10,9 +10,7 @@ use tidebreak_core::{ExecDegradation, SecretProvider};
 use tidebreak_egress::{EgressEnforcement, EgressPolicy};
 
 use crate::credential::SecretCredential;
-use crate::http::{
-    decode_bounded_json, decode_bounded_json_truncated, download_bounded_file, multipart_file,
-};
+use crate::http::{decode_bounded_json, download_bounded_file, multipart_file};
 use crate::output::{Capture, StreamKind};
 use crate::remote::{
     connect_remote_workspace, create_remote_workspace, destroy_remote_workspace, execute_remote,
@@ -685,18 +683,14 @@ impl DaytonaExecutionProvider {
                     error.unwrap_or_default().into_execute(),
                     started,
                     true,
-                    false,
                 ));
             }
             return Err(provider_status_error(status).into());
         }
-        let (body, oversized) = decode_bounded_json_truncated::<ExecuteResponse>(
-            response,
-            "Daytona",
-            MAX_DAYTONA_EXECUTE_BYTES,
-        )
-        .await?;
-        Ok(daytona_captured_response(body, started, false, oversized))
+        let body =
+            decode_bounded_json::<ExecuteResponse>(response, "Daytona", MAX_DAYTONA_EXECUTE_BYTES)
+                .await?;
+        Ok(daytona_captured_response(body, started, false))
     }
 
     fn toolbox_file_url(&self, session: &RemoteSession, suffix: &str) -> Result<Url, ExecError> {
@@ -1195,7 +1189,6 @@ fn daytona_captured_response(
     body: ExecuteResponse,
     started: Instant,
     timed_out: bool,
-    oversized: bool,
 ) -> ExecResponse {
     let mut capture = Capture::default();
     match (body.stdout, body.stderr) {
@@ -1210,9 +1203,6 @@ fn daytona_captured_response(
                 capture.append(stderr.as_bytes(), StreamKind::Stderr);
             }
         }
-    }
-    if oversized {
-        capture.mark_truncated();
     }
     capture.response(
         ExecProviderKind::Daytona,

--- a/crates/tidebreak-code-execution/src/docker.rs
+++ b/crates/tidebreak-code-execution/src/docker.rs
@@ -701,24 +701,24 @@ impl DockerExecutionProvider {
         )
         .await
         else {
-            // The CLI itself was abandoned, so whether the command ran to
-            // completion inside the container is genuinely unknown.
+            // The CLI itself was abandoned with no bytes read, so whether the
+            // command ran to completion inside the container is unknown.
             return Err(ExecError::AmbiguousExecution.into());
         };
-        if output.status.is_none() {
-            return Err(ExecError::AmbiguousExecution.into());
-        }
         if is_missing_container(output.status, &output.stderr) {
             return Err(RemoteSessionError::Missing);
         }
         let mut capture = Capture::default();
         capture.append(&output.stdout, StreamKind::Stdout);
         capture.append(&output.stderr, StreamKind::Stderr);
+        if output.truncated {
+            capture.mark_truncated();
+        }
         // The in-container `timeout` is what stopped the command, and its own
         // exit status is how it says so. A command that exits 124 by itself is
         // indistinguishable from one that was stopped — the same conflation
         // every backend's timeout reporting carries.
-        let timed_out = output.status == Some(TIMEOUT_EXIT);
+        let timed_out = output.status == Some(TIMEOUT_EXIT) || output.status.is_none();
         Ok(capture.response(
             ExecProviderKind::Docker,
             started,
@@ -1123,15 +1123,22 @@ struct CapturedOutput {
     status: Option<i32>,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
+    truncated: bool,
 }
 
-/// Drain a child's streams up to `capture_bytes` each and wait for it,
-/// abandoning the whole thing after `deadline`.
+struct DrainedStream {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+/// Drain a child's streams up to `capture_bytes` each and wait for it.
 ///
 /// Reading concurrently rather than sequentially matters: a command that fills
 /// the stderr pipe while this waits on stdout would block forever. Bytes past
 /// the cap are read and dropped rather than left in the pipe, for the same
-/// reason.
+/// reason, and [`CapturedOutput::truncated`] is set so the caller can report
+/// it. A deadline that fires still returns whatever was already read rather
+/// than discarding the partial capture.
 async fn bounded_output(
     mut child: Child,
     deadline: Duration,
@@ -1139,37 +1146,65 @@ async fn bounded_output(
 ) -> Option<CapturedOutput> {
     let mut stdout = child.stdout.take();
     let mut stderr = child.stderr.take();
-    let drain = async {
-        let (out, err) = tokio::join!(
-            drain_stream(&mut stdout, capture_bytes),
-            drain_stream(&mut stderr, capture_bytes),
-        );
-        let status = child.wait().await.ok()?;
-        Some(CapturedOutput {
-            status: status.code(),
-            stdout: out,
-            stderr: err,
-        })
+    let stdout_task = tokio::spawn(async move { drain_stream(&mut stdout, capture_bytes).await });
+    let stderr_task = tokio::spawn(async move { drain_stream(&mut stderr, capture_bytes).await });
+    let wait = tokio::time::timeout(deadline, child.wait()).await;
+    let timed_out = wait.is_err();
+    if timed_out {
+        let _ = child.start_kill();
+    }
+    let status = match wait {
+        Ok(Ok(status)) => Some(status),
+        Ok(Err(_)) => return None,
+        Err(_) => tokio::time::timeout(Duration::from_secs(2), child.wait())
+            .await
+            .ok()
+            .and_then(Result::ok),
     };
-    tokio::time::timeout(deadline, drain).await.ok()?
+    let stdout = stdout_task.await.unwrap_or_else(|_| DrainedStream {
+        bytes: Vec::new(),
+        truncated: false,
+    });
+    let stderr = stderr_task.await.unwrap_or_else(|_| DrainedStream {
+        bytes: Vec::new(),
+        truncated: false,
+    });
+    Some(CapturedOutput {
+        status: status.and_then(|status| status.code()),
+        truncated: stdout.truncated || stderr.truncated || timed_out,
+        stdout: stdout.bytes,
+        stderr: stderr.bytes,
+    })
 }
 
-async fn drain_stream<S>(stream: &mut Option<S>, capture_bytes: usize) -> Vec<u8>
+async fn drain_stream<S>(stream: &mut Option<S>, capture_bytes: usize) -> DrainedStream
 where
     S: AsyncReadExt + Unpin,
 {
     let mut kept = Vec::new();
+    let mut truncated = false;
     let Some(stream) = stream.as_mut() else {
-        return kept;
+        return DrainedStream {
+            bytes: kept,
+            truncated,
+        };
     };
     let mut buffer = [0_u8; 16 * 1024];
     loop {
         match stream.read(&mut buffer).await {
-            Ok(0) | Err(_) => return kept,
+            Ok(0) | Err(_) => {
+                return DrainedStream {
+                    bytes: kept,
+                    truncated,
+                }
+            }
             Ok(read) => {
                 let available = capture_bytes.saturating_sub(kept.len());
                 if available > 0 {
                     kept.extend_from_slice(&buffer[..read.min(available)]);
+                }
+                if read > available {
+                    truncated = true;
                 }
             }
         }
@@ -1213,6 +1248,14 @@ fn inspect_args(reference: &str) -> Vec<String> {
 /// no shell parses the model's arguments and no quoting question arises. The
 /// in-container `timeout` is prepended because killing the CLI on this side
 /// would leave the command running inside the container.
+///
+/// The documents image ships GNU coreutils `timeout`. Unless `--foreground` is
+/// given, that `timeout` starts `COMMAND` in a new process group and delivers
+/// `TERM`/`KILL` to the group, so descendants that stay in the group are
+/// stopped with the command. `--` keeps a command whose first byte is `-`
+/// from being parsed as a `timeout` option. We do not wrap the command in
+/// `setsid`: a new session would move descendants *out* of the group `timeout`
+/// signals.
 fn exec_command_args(
     container: &str,
     request: &ExecRequest,
@@ -1226,6 +1269,7 @@ fn exec_command_args(
         "timeout".to_owned(),
         format!("--kill-after={TIMEOUT_KILL_AFTER_SECS}"),
         timeout_seconds(timeout).to_string(),
+        "--".to_owned(),
         request.command.clone(),
     ];
     args.extend(request.arguments.iter().cloned());
@@ -1370,15 +1414,25 @@ fn is_name_conflict(stderr: &str) -> bool {
 
 /// Whether a `docker exec` failure means the container is gone rather than
 /// that the command failed. The CLI reserves 125 for its own errors, so a
-/// "no such container" there is the runtime speaking, not the command.
+/// "no such container" there is the runtime speaking, not the command. Exit
+/// 126 with "is not running" is the same class: the container exists but is
+/// not a live session.
 fn is_missing_container(status: Option<i32>, stderr: &[u8]) -> bool {
-    status == Some(125) && is_no_such_container(&String::from_utf8_lossy(stderr))
+    let stderr = String::from_utf8_lossy(stderr);
+    let not_running = stderr.to_ascii_lowercase().contains("is not running");
+    match status {
+        Some(125) => is_no_such_container(&stderr) || not_running,
+        Some(126) => not_running,
+        _ => false,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::output::{Capture, StreamKind};
     use crate::ExecutionId;
+    use std::time::Instant;
     use tidebreak_egress::{DomainPattern, EgressAllowlist};
 
     fn provider() -> DockerExecutionProvider {
@@ -1600,6 +1654,7 @@ mod tests {
                 "timeout",
                 "--kill-after=5",
                 "30",
+                "--",
                 "python3",
                 "-c",
                 "print('a; rm -rf /')",
@@ -1608,6 +1663,45 @@ mod tests {
         // A cwd that tries to leave the workspace never reaches the runtime.
         assert!(container_cwd("../escape").is_err());
         assert_eq!(container_cwd(".").unwrap(), WORKSPACE_ROOT);
+    }
+
+    #[tokio::test]
+    async fn a_truncated_docker_capture_reports_truncated() {
+        let mut capture = Capture::default();
+        capture.append(
+            &vec![b'a'; crate::MAX_CAPTURE_BYTES + 8],
+            StreamKind::Stdout,
+        );
+        capture.append(b"err\n", StreamKind::Stderr);
+        let response = capture.response(ExecProviderKind::Docker, Instant::now(), Some(1), false);
+        assert!(response.output_truncated);
+        assert_eq!(response.stdout.len(), crate::MAX_CAPTURE_BYTES);
+        assert_eq!(response.stderr, "err\n");
+        assert_eq!(response.exit_code, Some(1));
+
+        let drained = drain_stream(
+            &mut Some(std::io::Cursor::new(vec![
+                b'x';
+                crate::MAX_CAPTURE_BYTES + 1
+            ])),
+            crate::MAX_CAPTURE_BYTES,
+        )
+        .await;
+        assert!(drained.truncated);
+        assert_eq!(drained.bytes.len(), crate::MAX_CAPTURE_BYTES);
+    }
+
+    #[test]
+    fn exit_126_is_not_running_is_a_missing_container() {
+        assert!(is_missing_container(
+            Some(126),
+            b"Error: container abc is not running\n"
+        ));
+        assert!(!is_missing_container(Some(126), b"permission denied\n"));
+        assert!(is_missing_container(
+            Some(125),
+            b"Error: No such container: abc\n"
+        ));
     }
 
     /// The listing feeds a pull that writes into host scratch, so the shape of

--- a/crates/tidebreak-code-execution/src/docker.rs
+++ b/crates/tidebreak-code-execution/src/docker.rs
@@ -471,6 +471,9 @@ impl DockerExecutionProvider {
         let output = bounded_output(child, CONTROL_TIMEOUT, CONTROL_CAPTURE_BYTES)
             .await
             .ok_or(ControlFailure::Unreachable)?;
+        if output.timed_out {
+            return Err(ControlFailure::Unreachable);
+        }
         if output.status == Some(0) {
             return Ok(output.stdout);
         }
@@ -718,7 +721,7 @@ impl DockerExecutionProvider {
         // exit status is how it says so. A command that exits 124 by itself is
         // indistinguishable from one that was stopped — the same conflation
         // every backend's timeout reporting carries.
-        let timed_out = output.status == Some(TIMEOUT_EXIT) || output.status.is_none();
+        let timed_out = output.status == Some(TIMEOUT_EXIT) || output.timed_out;
         Ok(capture.response(
             ExecProviderKind::Docker,
             started,
@@ -1124,6 +1127,9 @@ struct CapturedOutput {
     stdout: Vec<u8>,
     stderr: Vec<u8>,
     truncated: bool,
+    /// True when the wait deadline fired. Distinct from a signal kill, which
+    /// is not a timeout.
+    timed_out: bool,
 }
 
 struct DrainedStream {
@@ -1161,17 +1167,32 @@ async fn bounded_output(
             .ok()
             .and_then(Result::ok),
     };
-    let stdout = stdout_task.await.unwrap_or_else(|_| DrainedStream {
-        bytes: Vec::new(),
-        truncated: false,
-    });
-    let stderr = stderr_task.await.unwrap_or_else(|_| DrainedStream {
-        bytes: Vec::new(),
-        truncated: false,
-    });
+    let stdout = match tokio::time::timeout(CLI_GRACE, stdout_task).await {
+        Ok(Ok(stream)) => stream,
+        Ok(Err(_)) => DrainedStream {
+            bytes: Vec::new(),
+            truncated: false,
+        },
+        Err(_) => DrainedStream {
+            bytes: Vec::new(),
+            truncated: true,
+        },
+    };
+    let stderr = match tokio::time::timeout(CLI_GRACE, stderr_task).await {
+        Ok(Ok(stream)) => stream,
+        Ok(Err(_)) => DrainedStream {
+            bytes: Vec::new(),
+            truncated: false,
+        },
+        Err(_) => DrainedStream {
+            bytes: Vec::new(),
+            truncated: true,
+        },
+    };
     Some(CapturedOutput {
         status: status.and_then(|status| status.code()),
         truncated: stdout.truncated || stderr.truncated || timed_out,
+        timed_out,
         stdout: stdout.bytes,
         stderr: stderr.bytes,
     })
@@ -1252,10 +1273,10 @@ fn inspect_args(reference: &str) -> Vec<String> {
 /// The documents image ships GNU coreutils `timeout`. Unless `--foreground` is
 /// given, that `timeout` starts `COMMAND` in a new process group and delivers
 /// `TERM`/`KILL` to the group, so descendants that stay in the group are
-/// stopped with the command. `--` keeps a command whose first byte is `-`
-/// from being parsed as a `timeout` option. We do not wrap the command in
-/// `setsid`: a new session would move descendants *out* of the group `timeout`
-/// signals.
+/// stopped with the command. Option parsing already stops at DURATION, so
+/// GNU `timeout` does not accept `--` after the duration (`timeout 2 -- cmd`
+/// tries to run `--`). We do not wrap the command in `setsid`: a new session
+/// would move descendants *out* of the group `timeout` signals.
 fn exec_command_args(
     container: &str,
     request: &ExecRequest,
@@ -1269,7 +1290,6 @@ fn exec_command_args(
         "timeout".to_owned(),
         format!("--kill-after={TIMEOUT_KILL_AFTER_SECS}"),
         timeout_seconds(timeout).to_string(),
-        "--".to_owned(),
         request.command.clone(),
     ];
     args.extend(request.arguments.iter().cloned());
@@ -1654,7 +1674,6 @@ mod tests {
                 "timeout",
                 "--kill-after=5",
                 "30",
-                "--",
                 "python3",
                 "-c",
                 "print('a; rm -rf /')",

--- a/crates/tidebreak-code-execution/src/e2b.rs
+++ b/crates/tidebreak-code-execution/src/e2b.rs
@@ -62,6 +62,10 @@ const E2B_ENVD_PORT: &str = "49983";
 const E2B_SANDBOX_TTL_SECONDS: u64 = 300;
 const E2B_TRANSPORT_GRACE: Duration = Duration::from_secs(10);
 const MAX_MANAGEMENT_RESPONSE_BYTES: usize = 64 * 1024;
+/// Directory listings are truncated to [`MAX_WORKSPACE_LIST_ENTRIES`], so the
+/// JSON body is allowed to exceed the management cap instead of failing the
+/// whole listing.
+const MAX_LIST_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
 const MAX_CONNECT_FRAME_BYTES: usize = 256 * 1024;
 const CONNECT_END_STREAM_FLAG: u8 = 0b0000_0010;
 const CONNECT_COMPRESSED_FLAG: u8 = 0b0000_0001;
@@ -571,10 +575,9 @@ impl RemoteWorkspaceAdapter for E2BExecutionProvider {
         if !response.status().is_success() {
             return Err(provider_status_error(response.status()).into());
         }
-        let body =
-            decode_bounded_json::<ListDirResponse>(response, "E2B", MAX_MANAGEMENT_RESPONSE_BYTES)
-                .await
-                .map_err(RemoteSessionError::Provider)?;
+        let body = decode_bounded_json::<ListDirResponse>(response, "E2B", MAX_LIST_RESPONSE_BYTES)
+            .await
+            .map_err(RemoteSessionError::Provider)?;
         let mut entries = Vec::new();
         for entry in body.entries {
             if entry.name.is_empty() {

--- a/crates/tidebreak-code-execution/src/e2b.rs
+++ b/crates/tidebreak-code-execution/src/e2b.rs
@@ -575,9 +575,12 @@ impl RemoteWorkspaceAdapter for E2BExecutionProvider {
         if !response.status().is_success() {
             return Err(provider_status_error(response.status()).into());
         }
-        let body = decode_bounded_json::<ListDirResponse>(response, "E2B", MAX_LIST_RESPONSE_BYTES)
-            .await
-            .map_err(RemoteSessionError::Provider)?;
+        let mut body =
+            decode_bounded_json::<ListDirResponse>(response, "E2B", MAX_LIST_RESPONSE_BYTES)
+                .await
+                .map_err(RemoteSessionError::Provider)?;
+        let truncated = body.entries.len() > MAX_WORKSPACE_LIST_ENTRIES;
+        body.entries.truncate(MAX_WORKSPACE_LIST_ENTRIES);
         let mut entries = Vec::new();
         for entry in body.entries {
             if entry.name.is_empty() {
@@ -603,8 +606,6 @@ impl RemoteWorkspaceAdapter for E2BExecutionProvider {
             });
         }
         entries.sort_by(|left, right| left.path.cmp(&right.path));
-        let truncated = entries.len() > MAX_WORKSPACE_LIST_ENTRIES;
-        entries.truncate(MAX_WORKSPACE_LIST_ENTRIES);
         Ok(WorkspaceListing { entries, truncated })
     }
 }
@@ -1572,6 +1573,19 @@ mod tests {
         assert_eq!(listing.entries[0].path, "data/report.bin");
         assert!(!listing.entries[0].directory);
         assert_eq!(listing.entries[0].size_bytes, Some(content.len() as u64));
+
+        {
+            let mut files = state.files.lock().unwrap();
+            for index in 0..MAX_WORKSPACE_LIST_ENTRIES + 1 {
+                files.insert(format!("/home/user/many-{index:03}"), vec![b'x']);
+            }
+        }
+        let listing = provider
+            .list_workspace_files(&workspace, None)
+            .await
+            .unwrap();
+        assert!(listing.truncated);
+        assert_eq!(listing.entries.len(), MAX_WORKSPACE_LIST_ENTRIES);
 
         provider.destroy_workspace(&workspace).await.unwrap();
         assert_eq!(state.deletes.load(Ordering::SeqCst), 1);

--- a/crates/tidebreak-code-execution/src/http.rs
+++ b/crates/tidebreak-code-execution/src/http.rs
@@ -28,39 +28,6 @@ pub(crate) async fn decode_bounded_json<T: DeserializeOwned>(
         .map_err(|_| ExecError::Unavailable(format!("{provider} returned an invalid response")))
 }
 
-/// Decode JSON, keeping a truncation flag when the body exceeded `max_bytes`.
-///
-/// Extra bytes are drained so the connection can close cleanly. A body that
-/// was truncated may fail to parse; callers that need a partial command result
-/// should size `max_bytes` to hold a complete document.
-pub(crate) async fn decode_bounded_json_truncated<T: DeserializeOwned>(
-    response: Response,
-    provider: &str,
-    max_bytes: usize,
-) -> Result<(T, bool), ExecError> {
-    let mut bytes = Vec::new();
-    let mut truncated = false;
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|_| {
-            ExecError::Unavailable(format!("{provider} returned an incomplete response"))
-        })?;
-        if truncated {
-            continue;
-        }
-        if bytes.len().saturating_add(chunk.len()) > max_bytes {
-            let keep = max_bytes.saturating_sub(bytes.len());
-            bytes.extend_from_slice(&chunk[..keep]);
-            truncated = true;
-            continue;
-        }
-        bytes.extend_from_slice(&chunk);
-    }
-    let value = serde_json::from_slice(&bytes)
-        .map_err(|_| ExecError::Unavailable(format!("{provider} returned an invalid response")))?;
-    Ok((value, truncated))
-}
-
 /// Download one workspace file, refusing anything beyond the transfer bound.
 pub(crate) async fn download_bounded_file(
     response: Response,

--- a/crates/tidebreak-code-execution/src/http.rs
+++ b/crates/tidebreak-code-execution/src/http.rs
@@ -28,6 +28,39 @@ pub(crate) async fn decode_bounded_json<T: DeserializeOwned>(
         .map_err(|_| ExecError::Unavailable(format!("{provider} returned an invalid response")))
 }
 
+/// Decode JSON, keeping a truncation flag when the body exceeded `max_bytes`.
+///
+/// Extra bytes are drained so the connection can close cleanly. A body that
+/// was truncated may fail to parse; callers that need a partial command result
+/// should size `max_bytes` to hold a complete document.
+pub(crate) async fn decode_bounded_json_truncated<T: DeserializeOwned>(
+    response: Response,
+    provider: &str,
+    max_bytes: usize,
+) -> Result<(T, bool), ExecError> {
+    let mut bytes = Vec::new();
+    let mut truncated = false;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| {
+            ExecError::Unavailable(format!("{provider} returned an incomplete response"))
+        })?;
+        if truncated {
+            continue;
+        }
+        if bytes.len().saturating_add(chunk.len()) > max_bytes {
+            let keep = max_bytes.saturating_sub(bytes.len());
+            bytes.extend_from_slice(&chunk[..keep]);
+            truncated = true;
+            continue;
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    let value = serde_json::from_slice(&bytes)
+        .map_err(|_| ExecError::Unavailable(format!("{provider} returned an invalid response")))?;
+    Ok((value, truncated))
+}
+
 /// Download one workspace file, refusing anything beyond the transfer bound.
 pub(crate) async fn download_bounded_file(
     response: Response,

--- a/crates/tidebreak-code-execution/src/local.rs
+++ b/crates/tidebreak-code-execution/src/local.rs
@@ -536,10 +536,7 @@ impl ExecProvider for LocalExecutionProvider {
                 Ok(response)
             }
             Err(error) => {
-                let receipt = ExecutionReceipt::Failed {
-                    fingerprint,
-                    message: error.to_string(),
-                };
+                let receipt = ExecutionReceipt::from_outcome(fingerprint, &Err(error.clone()));
                 finish_execution(&receipt_path, &receipt)?;
                 Err(error)
             }
@@ -801,7 +798,7 @@ fn begin_execution_with_persistence(
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let receipt = read_receipt(path)?;
-            receipt.replay(fingerprint, ExecError::Sandbox)
+            receipt.replay(fingerprint)
         }
         Err(_) => Err(ExecError::Sandbox(
             "could not create execution receipt".into(),

--- a/crates/tidebreak-code-execution/src/output.rs
+++ b/crates/tidebreak-code-execution/src/output.rs
@@ -20,15 +20,19 @@ pub(crate) struct Capture {
 
 impl Capture {
     pub(crate) fn append(&mut self, bytes: &[u8], kind: StreamKind) {
-        let available = MAX_CAPTURE_BYTES.saturating_sub(self.total);
-        let kept = available.min(bytes.len());
         let target = match kind {
             StreamKind::Stdout => &mut self.stdout,
             StreamKind::Stderr => &mut self.stderr,
         };
+        let available = MAX_CAPTURE_BYTES.saturating_sub(target.len());
+        let kept = available.min(bytes.len());
         target.extend_from_slice(&bytes[..kept]);
-        self.total += kept;
+        self.total = self.stdout.len().saturating_add(self.stderr.len());
         self.truncated |= kept < bytes.len();
+    }
+
+    pub(crate) fn mark_truncated(&mut self) {
+        self.truncated = true;
     }
 
     pub(crate) fn append_base64(

--- a/crates/tidebreak-code-execution/src/output.rs
+++ b/crates/tidebreak-code-execution/src/output.rs
@@ -14,7 +14,6 @@ pub(crate) enum StreamKind {
 pub(crate) struct Capture {
     stdout: Vec<u8>,
     stderr: Vec<u8>,
-    total: usize,
     truncated: bool,
 }
 
@@ -27,7 +26,6 @@ impl Capture {
         let available = MAX_CAPTURE_BYTES.saturating_sub(target.len());
         let kept = available.min(bytes.len());
         target.extend_from_slice(&bytes[..kept]);
-        self.total = self.stdout.len().saturating_add(self.stderr.len());
         self.truncated |= kept < bytes.len();
     }
 

--- a/crates/tidebreak-code-execution/src/receipt.rs
+++ b/crates/tidebreak-code-execution/src/receipt.rs
@@ -152,23 +152,41 @@ impl ExecutionReceipt {
 
 /// Hash of the model-authored command identity.
 ///
-/// Host-injected fields such as per-turn overlay paths on folder grants are
-/// excluded: a replay across turns must not report [`ExecError::IdentityConflict`]
-/// merely because the overlay directory changed. The request has no model-set
-/// environment or stdin today; those belong here if they are ever added.
+/// Folder-grant overlay paths are per-turn host injection and are omitted so a
+/// replay across turns does not report [`ExecError::IdentityConflict`] merely
+/// because the overlay directory changed. The grant roots and access themselves
+/// stay in the hash. `workspace_id` is the chat workspace, not a per-turn
+/// field, so it is included. The request has no model-set environment or stdin
+/// today; those belong here if they are ever added.
 pub(crate) fn request_fingerprint(request: &ExecRequest) -> Result<String, ExecError> {
     #[derive(Serialize)]
+    struct FingerprintGrant<'a> {
+        path: &'a std::path::PathBuf,
+        access: crate::ExecFolderAccess,
+    }
+    #[derive(Serialize)]
     struct Fingerprint<'a> {
+        workspace_id: &'a crate::ExecutionWorkspaceId,
         command: &'a str,
         arguments: &'a [String],
         cwd: &'a str,
         files: &'a [crate::WorkspaceFilePath],
+        folder_grants: Vec<FingerprintGrant<'a>>,
     }
     let bytes = serde_json::to_vec(&Fingerprint {
+        workspace_id: &request.workspace_id,
         command: &request.command,
         arguments: &request.arguments,
         cwd: &request.cwd,
         files: &request.files,
+        folder_grants: request
+            .folder_grants
+            .iter()
+            .map(|grant| FingerprintGrant {
+                path: &grant.path,
+                access: grant.access,
+            })
+            .collect(),
     })
     .map_err(|_| ExecError::InvalidRequest("request is not serializable".into()))?;
     let digest = Sha256::digest(bytes);
@@ -188,9 +206,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::{
-        ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, WorkspaceFilePath,
-    };
+    use crate::{ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId};
 
     fn request() -> ExecRequest {
         ExecRequest::new(
@@ -238,6 +254,17 @@ mod tests {
             request_fingerprint(&left).unwrap(),
             request_fingerprint(&right).unwrap()
         );
+        let other_root = request()
+            .with_folder_grants(vec![ExecFolderGrant::new(
+                PathBuf::from("/granted/other"),
+                ExecFolderAccess::ReadWrite,
+            )
+            .unwrap()])
+            .unwrap();
+        assert_ne!(
+            request_fingerprint(&left).unwrap(),
+            request_fingerprint(&other_root).unwrap()
+        );
         let receipt = ExecutionReceipt::from_outcome(
             request_fingerprint(&left).unwrap(),
             &Err(ExecError::Unavailable("gone".into())),
@@ -270,6 +297,5 @@ mod tests {
             request_fingerprint(&request()).unwrap(),
             request_fingerprint(&staged).unwrap()
         );
-        let _ = WorkspaceFilePath::parse("output/a.txt").unwrap();
     }
 }

--- a/crates/tidebreak-code-execution/src/receipt.rs
+++ b/crates/tidebreak-code-execution/src/receipt.rs
@@ -15,10 +15,85 @@ pub(crate) enum ExecutionReceipt {
     },
     Failed {
         fingerprint: String,
-        message: String,
+        #[serde(default)]
+        error: ReceiptError,
+        /// Present on receipts written before the error kind was stored.
+        /// Ignored when [`Self::Failed::error`] is populated.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
     },
 }
 
+/// The [`ExecError`] kind a failed receipt must replay as.
+///
+/// Older receipts stored only a display string and flattened every failure to
+/// `Unavailable` / `Sandbox` at replay. The kind is the contract now.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum ReceiptError {
+    InvalidRequest { message: String },
+    NotConfigured,
+    Unavailable { message: String },
+    Sandbox { message: String },
+    Spawn,
+    IdentityConflict,
+    WorkspaceFileNotFound,
+    WorkspaceFileTooLarge,
+    AmbiguousExecution,
+}
+
+impl Default for ReceiptError {
+    fn default() -> Self {
+        Self::Unavailable {
+            message: String::new(),
+        }
+    }
+}
+
+impl ReceiptError {
+    fn from_exec(error: &ExecError) -> Self {
+        match error {
+            ExecError::InvalidRequest(message) => Self::InvalidRequest {
+                message: message.clone(),
+            },
+            ExecError::NotConfigured => Self::NotConfigured,
+            ExecError::Unavailable(message) => Self::Unavailable {
+                message: message.clone(),
+            },
+            ExecError::Sandbox(message) => Self::Sandbox {
+                message: message.clone(),
+            },
+            ExecError::Spawn => Self::Spawn,
+            ExecError::IdentityConflict => Self::IdentityConflict,
+            ExecError::WorkspaceFileNotFound => Self::WorkspaceFileNotFound,
+            ExecError::WorkspaceFileTooLarge => Self::WorkspaceFileTooLarge,
+            ExecError::AmbiguousExecution => Self::AmbiguousExecution,
+        }
+    }
+
+    fn into_exec(self, legacy_message: Option<String>) -> ExecError {
+        match self {
+            Self::InvalidRequest { message } => ExecError::InvalidRequest(message),
+            Self::NotConfigured => ExecError::NotConfigured,
+            Self::Unavailable { message } => {
+                let message = if message.is_empty() {
+                    legacy_message.unwrap_or_default()
+                } else {
+                    message
+                };
+                ExecError::Unavailable(message)
+            }
+            Self::Sandbox { message } => ExecError::Sandbox(message),
+            Self::Spawn => ExecError::Spawn,
+            Self::IdentityConflict => ExecError::IdentityConflict,
+            Self::WorkspaceFileNotFound => ExecError::WorkspaceFileNotFound,
+            Self::WorkspaceFileTooLarge => ExecError::WorkspaceFileTooLarge,
+            Self::AmbiguousExecution => ExecError::AmbiguousExecution,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub(crate) enum BeginExecution {
     Started,
     Cached(ExecResponse),
@@ -42,16 +117,13 @@ impl ExecutionReceipt {
             },
             Err(error) => Self::Failed {
                 fingerprint,
-                message: error.to_string(),
+                error: ReceiptError::from_exec(error),
+                message: None,
             },
         }
     }
 
-    pub(crate) fn replay(
-        &self,
-        fingerprint: &str,
-        failed_error: fn(String) -> ExecError,
-    ) -> Result<BeginExecution, ExecError> {
+    pub(crate) fn replay(&self, fingerprint: &str) -> Result<BeginExecution, ExecError> {
         match self {
             Self::Running {
                 fingerprint: existing,
@@ -68,18 +140,37 @@ impl ExecutionReceipt {
             }
             Self::Failed {
                 fingerprint: existing,
+                error,
                 message,
             } => {
                 ensure_same_fingerprint(existing, fingerprint)?;
-                Err(failed_error(message.clone()))
+                Err(error.clone().into_exec(message.clone()))
             }
         }
     }
 }
 
+/// Hash of the model-authored command identity.
+///
+/// Host-injected fields such as per-turn overlay paths on folder grants are
+/// excluded: a replay across turns must not report [`ExecError::IdentityConflict`]
+/// merely because the overlay directory changed. The request has no model-set
+/// environment or stdin today; those belong here if they are ever added.
 pub(crate) fn request_fingerprint(request: &ExecRequest) -> Result<String, ExecError> {
-    let bytes = serde_json::to_vec(request)
-        .map_err(|_| ExecError::InvalidRequest("request is not serializable".into()))?;
+    #[derive(Serialize)]
+    struct Fingerprint<'a> {
+        command: &'a str,
+        arguments: &'a [String],
+        cwd: &'a str,
+        files: &'a [crate::WorkspaceFilePath],
+    }
+    let bytes = serde_json::to_vec(&Fingerprint {
+        command: &request.command,
+        arguments: &request.arguments,
+        cwd: &request.cwd,
+        files: &request.files,
+    })
+    .map_err(|_| ExecError::InvalidRequest("request is not serializable".into()))?;
     let digest = Sha256::digest(bytes);
     Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
 }
@@ -89,5 +180,96 @@ fn ensure_same_fingerprint(existing: &str, expected: &str) -> Result<(), ExecErr
         Ok(())
     } else {
         Err(ExecError::IdentityConflict)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::{
+        ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, WorkspaceFilePath,
+    };
+
+    fn request() -> ExecRequest {
+        ExecRequest::new(
+            ExecutionId::parse("call-1").unwrap(),
+            ExecutionWorkspaceId::parse("chat-1").unwrap(),
+            "/bin/echo",
+            vec!["ok".into()],
+            ".",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn replay_preserves_the_original_error_kind() {
+        let fingerprint = "abc".to_owned();
+        let receipt = ExecutionReceipt::from_outcome(
+            fingerprint.clone(),
+            &Err(ExecError::WorkspaceFileTooLarge),
+        );
+        let replayed = receipt.replay(&fingerprint).unwrap_err();
+        assert!(matches!(replayed, ExecError::WorkspaceFileTooLarge));
+    }
+
+    #[test]
+    fn overlay_path_is_not_part_of_the_fingerprint() {
+        let left = request()
+            .with_folder_grants(vec![ExecFolderGrant::new(
+                PathBuf::from("/granted/folder"),
+                ExecFolderAccess::ReadWrite,
+            )
+            .unwrap()
+            .staged_at(PathBuf::from("/tmp/overlay-a"))
+            .unwrap()])
+            .unwrap();
+        let right = request()
+            .with_folder_grants(vec![ExecFolderGrant::new(
+                PathBuf::from("/granted/folder"),
+                ExecFolderAccess::ReadWrite,
+            )
+            .unwrap()
+            .staged_at(PathBuf::from("/tmp/overlay-b"))
+            .unwrap()])
+            .unwrap();
+        assert_eq!(
+            request_fingerprint(&left).unwrap(),
+            request_fingerprint(&right).unwrap()
+        );
+        let receipt = ExecutionReceipt::from_outcome(
+            request_fingerprint(&left).unwrap(),
+            &Err(ExecError::Unavailable("gone".into())),
+        );
+        let replayed = receipt.replay(&request_fingerprint(&right).unwrap());
+        assert!(matches!(
+            replayed,
+            Err(ExecError::Unavailable(message)) if message == "gone"
+        ));
+    }
+
+    #[test]
+    fn model_authored_fields_are_part_of_the_fingerprint() {
+        let changed = ExecRequest::new(
+            ExecutionId::parse("call-1").unwrap(),
+            ExecutionWorkspaceId::parse("chat-1").unwrap(),
+            "/bin/echo",
+            vec!["other".into()],
+            ".",
+        )
+        .unwrap();
+        assert_ne!(
+            request_fingerprint(&request()).unwrap(),
+            request_fingerprint(&changed).unwrap()
+        );
+        let staged = request()
+            .with_staged_files(vec!["output/a.txt".into()])
+            .unwrap();
+        assert_ne!(
+            request_fingerprint(&request()).unwrap(),
+            request_fingerprint(&staged).unwrap()
+        );
+        let _ = WorkspaceFilePath::parse("output/a.txt").unwrap();
     }
 }

--- a/crates/tidebreak-code-execution/src/receipt.rs
+++ b/crates/tidebreak-code-execution/src/receipt.rs
@@ -232,22 +232,27 @@ mod tests {
 
     #[test]
     fn overlay_path_is_not_part_of_the_fingerprint() {
+        let temp = std::env::temp_dir();
+        let grant_root = temp.join("tidebreak-exec-granted-folder");
+        let overlay_a = temp.join("tidebreak-exec-overlay-a");
+        let overlay_b = temp.join("tidebreak-exec-overlay-b");
+        let other_grant_root = temp.join("tidebreak-exec-granted-other");
         let left = request()
             .with_folder_grants(vec![ExecFolderGrant::new(
-                PathBuf::from("/granted/folder"),
+                grant_root.clone(),
                 ExecFolderAccess::ReadWrite,
             )
             .unwrap()
-            .staged_at(PathBuf::from("/tmp/overlay-a"))
+            .staged_at(overlay_a)
             .unwrap()])
             .unwrap();
         let right = request()
             .with_folder_grants(vec![ExecFolderGrant::new(
-                PathBuf::from("/granted/folder"),
+                grant_root,
                 ExecFolderAccess::ReadWrite,
             )
             .unwrap()
-            .staged_at(PathBuf::from("/tmp/overlay-b"))
+            .staged_at(overlay_b)
             .unwrap()])
             .unwrap();
         assert_eq!(
@@ -256,7 +261,7 @@ mod tests {
         );
         let other_root = request()
             .with_folder_grants(vec![ExecFolderGrant::new(
-                PathBuf::from("/granted/other"),
+                other_grant_root,
                 ExecFolderAccess::ReadWrite,
             )
             .unwrap()])

--- a/crates/tidebreak-code-execution/src/receipt.rs
+++ b/crates/tidebreak-code-execution/src/receipt.rs
@@ -203,8 +203,6 @@ fn ensure_same_fingerprint(existing: &str, expected: &str) -> Result<(), ExecErr
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use super::*;
     use crate::{ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId};
 

--- a/crates/tidebreak-code-execution/src/remote.rs
+++ b/crates/tidebreak-code-execution/src/remote.rs
@@ -289,7 +289,7 @@ impl RemoteSessionPool {
                 );
                 Ok(BeginExecution::Started)
             }
-            Some(entry) => entry.receipt.replay(&fingerprint, ExecError::Unavailable),
+            Some(entry) => entry.receipt.replay(&fingerprint),
         }
     }
 

--- a/crates/tidebreak-code-execution/src/types.rs
+++ b/crates/tidebreak-code-execution/src/types.rs
@@ -13,7 +13,11 @@ pub const MAX_ARGUMENTS: usize = 128;
 pub const MAX_ARGUMENT_BYTES: usize = 32 * 1_024;
 /// Maximum UTF-8 bytes in a private-workspace-relative current directory.
 pub const MAX_CWD_BYTES: usize = 1_024;
-/// Maximum bytes captured from stdout and stderr together.
+/// Maximum bytes captured from each of stdout and stderr.
+///
+/// The two streams have independent budgets so a stdout-heavy command cannot
+/// discard stderr (or the reverse). Bytes past either cap are dropped and
+/// [`ExecResponse::output_truncated`] is set.
 pub const MAX_CAPTURE_BYTES: usize = 40_000;
 /// Maximum bytes transferred for one workspace file in either direction.
 pub const MAX_WORKSPACE_FILE_BYTES: usize = tidebreak_core::MAX_EXEC_WORKSPACE_FILE_BYTES;
@@ -683,7 +687,7 @@ pub trait ExecProvider: Send + Sync {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum ExecError {
     #[error("invalid code execution request: {0}")]
     InvalidRequest(String),

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -443,7 +443,9 @@ The provider adapters own only their control-plane and command transports:
   execute API returns one merged output string (`result`) with no separate
   stderr stream. That merged text is filed as stdout; stderr on the normalized
   response stays empty unless a future toolbox payload includes distinct
-  `stdout` / `stderr` fields.
+  `stdout` / `stderr` fields. Daytona delivers exit code and output in one JSON
+  body; a response over the decode cap cannot be parsed, so oversized Daytona
+  output fails the command rather than returning a truncated capture.
 
 ### File staging
 

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -208,10 +208,14 @@ chat to private scratch and lets managed providers map the same chat identity to
 a reusable remote sandbox.
 
 Every provider returns the same bounded shape: provider kind, optional exit
-code, stdout, stderr, timeout and truncation flags, and duration. Provider-native
-responses, credentials, and unbounded logs do not cross the contract. Absolute
-folder paths are a host-only input to the local adapter: they are never tool
-arguments and are stripped from managed-provider requests.
+code, stdout, stderr, timeout and truncation flags, and duration. Each of
+stdout and stderr has its own capture budget, so a stdout-heavy command still
+returns stderr (and the reverse). Overflow is reported with `output_truncated`
+rather than failing the command or silently dropping the tail. A timeout keeps
+whatever was already captured. Provider-native responses, credentials, and
+unbounded logs do not cross the contract. Absolute folder paths are a host-only
+input to the local adapter: they are never tool arguments and are stripped from
+managed-provider requests.
 
 ## Container execution
 
@@ -229,11 +233,15 @@ and the image-publish workflow rewrites it there.
 One container serves one chat workspace, under a name derived from the
 workspace id so a restarted host adopts its containers rather than duplicating
 them. Commands cross as an argument vector through `docker exec` under an
-in-container `timeout`, so a command that exceeds its limit is stopped rather
-than left running behind an abandoned CLI. Workspace file transfers use the
-same channel. The container's only process is a bounded sleep and it is created
-with `--rm`, so an abandoned chat's container and its workspace volume remove
-themselves.
+in-container GNU coreutils `timeout --kill-after … -- command`. That `timeout`
+starts the command in a new process group and signals the group, so descendants
+that stay in the group stop with it; `--` keeps a command that starts with `-`
+from being parsed as a `timeout` option. `setsid` is not used, because a new
+session would move descendants out of the group `timeout` signals. A command
+that exceeds its limit is therefore stopped rather than left running behind an
+abandoned CLI. Workspace file transfers use the same channel. The container's
+only process is a bounded sleep and it is created with `--rm`, so an abandoned
+chat's container and its workspace volume remove themselves.
 
 Confinement is the container itself: the image's unprivileged uid forced from
 the host, every Linux capability dropped, privilege escalation refused, and
@@ -403,11 +411,14 @@ The executable receives its arguments directly. A model that truly needs a
 shell must invoke one explicitly, such as `/bin/sh` with `["-c", "..."]`.
 
 Before spawning, the adapter durably creates a private `running` receipt keyed
-by the stable execution ID and request fingerprint. It atomically replaces that
-marker with the bounded terminal response. An exact retry returns the cached
-response; a changed request is rejected; a surviving `running` marker is
-reported as ambiguous and is not replayed. Receipts live outside every
-model-visible chat scratch directory.
+by the stable execution ID and request fingerprint. The fingerprint covers only
+model-authored fields (command, arguments, workspace-relative cwd, staged
+files). Host-injected per-turn overlay paths are excluded, so a replay across
+turns is not an identity conflict. It atomically replaces that marker with the
+bounded terminal response. An exact retry returns the cached response, and a
+cached failure replays the original error kind. A changed request is rejected; a
+surviving `running` marker is reported as ambiguous and is not replayed.
+Receipts live outside every model-visible chat scratch directory.
 
 `exec` is still classified `Sensitive` and crosses the existing durable
 approval/standing-grant boundary. Native confinement limits what an approved
@@ -428,7 +439,11 @@ The provider adapters own only their control-plane and command transports:
 - Daytona's toolbox accepts shell text, so its adapter quotes every executable
   and argv element before dispatch and prefixes the result with `exec`. Shell
   metacharacters therefore remain argument data. A caller that deliberately
-  needs a shell must still name `/bin/sh` and `-c` explicitly.
+  needs a shell must still name `/bin/sh` and `-c` explicitly. The toolbox
+  execute API returns one merged output string (`result`) with no separate
+  stderr stream. That merged text is filed as stdout; stderr on the normalized
+  response stays empty unless a future toolbox payload includes distinct
+  `stdout` / `stderr` fields.
 
 ### File staging
 


### PR DESCRIPTION
## What was wrong

Container exec backends either failed or silently dropped oversized output, and receipt replay flattened errors and treated overlay path changes as identity conflicts.

- **Docker:** `bounded_output` capped each stream at `MAX_CAPTURE_BYTES` and discarded overflow without setting `truncated`. A shared capture budget let stdout consume the whole budget so a stdout-heavy failing command lost stderr. GNU `timeout` does not accept `--` after DURATION (`timeout --kill-after=5 2 -- cmd` runs `--`). Exit 126 / "is not running" was not classified as a missing container. CLI timeouts discarded whatever had already been read. Stream drain awaits after `child.wait()` were unbounded. A hung control-plane call that hit the deadline was reported as `Refused("")` instead of `Unreachable`. A CLI killed by a signal was reported as `timed_out`.
- **E2B:** A directory listing over 64 KB failed instead of truncating to 256 entries.
- **Daytona:** More than 1 MB of execute JSON failed the whole command with no exit code. Timeout responses discarded captured output. Merged toolbox `result` was filed as stdout with no note that stderr is not a separate stream. A truncated JSON body cannot be deserialized, so an `oversized`/`mark_truncated` path never fired.
- **Receipts:** Replaying a failed receipt always became `Unavailable`/`Sandbox`. The fingerprint hashed the full request, including per-turn overlay paths, so a replay across turns reported `IdentityConflict`. Dropping every grant made distinct grant roots collide.

## What changed

- Stdout and stderr each get an independent `MAX_CAPTURE_BYTES` budget; overflow sets `output_truncated` and keeps the real exit code.
- Docker keeps partial capture when the CLI deadline fires. GNU `timeout` argv is duration then command (no `--` after DURATION). Exit 126 with "is not running" maps to `Missing`. Stream drains are bounded by `CLI_GRACE` and expiry is truncated output. `CapturedOutput` carries `timed_out`; control-plane deadlines stay `Unreachable`; command `timed_out` uses that flag, not a missing exit status.
- E2B listings decode with a larger bound, truncate to 256 entries before mapping, and a test covers that cap.
- Daytona keeps timeout partials and distinct `stdout`/`stderr` when present. Exit code and output share one JSON body, so a response over the decode cap fails the command (documented in `docs/code-execution.md`). The dead truncated-JSON flag is gone.
- Receipts store the original error kind. Fingerprints include `workspace_id` (chat workspace, not per-turn) and folder grants with `overlay` omitted. Distinct grant roots do not collide.
- Dead `Capture::total` and the no-op path parse in the receipt test are gone.

## Windows native tests

Job `103108737500` failed `receipt::tests::overlay_path_is_not_part_of_the_fingerprint` at `receipt.rs:240` with `InvalidRequest("invalid execution folder path")` on every retry. That is this PR's Unix-only fixture: `PathBuf::from("/granted/folder")` and `/tmp/overlay-*` are not absolute on Windows, so `validate_folder_path` rejects them. The test now uses `std::env::temp_dir()` grant roots and overlays so overlay identity still does not change the fingerprint while distinct real grant roots still do. This is not an unrelated process-tree flake.

Closes #3338

## Checks

- `cargo test -p tidebreak-code-execution --lib receipt::` — 3 passed (replay error kind, overlay omitted from fingerprint, model-authored fields hashed)
- `cargo check -p tidebreak-code-execution` — ok
- `cargo fmt -p tidebreak-code-execution -- --check` — ok
