### PR TITLE
fix(code): price fast-mode turns and count workspace-less sessions in analytics

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeAnalyticsPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeAnalyticsPage.tsx
@@ -546,11 +546,11 @@ function RepositoryCard({ report }: { report: CodeAnalyticsSnapshot }) {
           <tbody>
             {report.repositories.map((repo) => (
               <tr
-                key={repo.repo_id}
+                key={repo.repo_id ?? "no-repository"}
                 className="border-b border-border-subtle last:border-0"
               >
                 <td className="max-w-64 truncate px-4 py-3 font-medium">
-                  {repo.name}
+                  {repo.repo_id ? repo.name : "no repository"}
                 </td>
                 <td className="px-3 py-3 text-right tabular-nums text-muted-foreground">
                   {formatNumber(repo.sessions)}

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -346,6 +346,25 @@ describe("parseCodeAnalytics", () => {
       }),
     ).toBeNull();
   });
+
+  it("accepts a no-repository row with a null repo_id", () => {
+    const noRepo = {
+      ...snapshot,
+      repositories: [
+        {
+          repo_id: null,
+          name: "no repository",
+          sessions: 1,
+          turns: 1,
+          total_tokens: 120,
+          estimated_cost_microusd: 0,
+          pull_requests_opened: 0,
+          pull_requests_merged: 0,
+        },
+      ],
+    };
+    expect(parseCodeAnalytics(noRepo)).toEqual(noRepo);
+  });
 });
 
 /**

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -1589,7 +1589,7 @@ function parseCodeAnalyticsRepository(
       "pull_requests_opened",
       "pull_requests_merged",
     ]) ||
-    !wireId(value.repo_id) ||
+    !nullableWireId(value.repo_id) ||
     !nonEmptyLine(value.name) ||
     !isNonNegativeInteger(value.sessions) ||
     !isNonNegativeInteger(value.turns) ||

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -977,9 +977,10 @@ export type CodeAnalyticsPricingCoverage = { priced_turns: number, unpriced_turn
 export type CodeAnalyticsRange = "7d" | "30d" | "90d" | "all";
 
 /**
- * Metrics attributed to one registered repository.
+ * Metrics attributed to one registered repository, or to the unattributed
+ * "no repository" group when `repo_id` is null.
  */
-export type CodeAnalyticsRepository = { repo_id: RepoId, name: string, sessions: number, turns: number, total_tokens: number, estimated_cost_microusd: number, pull_requests_opened: number, pull_requests_merged: number, };
+export type CodeAnalyticsRepository = { repo_id: RepoId | null, name: string, sessions: number, turns: number, total_tokens: number, estimated_cost_microusd: number, pull_requests_opened: number, pull_requests_merged: number, };
 
 /**
  * Owner-scoped code activity and local cost estimates.

--- a/crates/tidebreak-server-api/src/routes/code/analytics.rs
+++ b/crates/tidebreak-server-api/src/routes/code/analytics.rs
@@ -47,13 +47,7 @@ pub(crate) async fn analytics(
         code.list_pull_request_attributions(),
     )?;
 
-    if let Some(repo_id) = query.repo_id {
-        if !repos.iter().any(|repo| repo.id == repo_id) {
-            return Err(ServerError::not_found(format!(
-                "code repository {repo_id} not found"
-            )));
-        }
-    }
+    require_known_repo(&repos, query.repo_id)?;
 
     Ok(Json(build_snapshot(
         range,
@@ -267,7 +261,7 @@ fn build_snapshot(
         .map(|repo| {
             let metrics = repo_metrics.remove(&Some(repo.id)).unwrap_or_default();
             CodeAnalyticsRepository {
-                repo_id: repo.id,
+                repo_id: Some(repo.id),
                 name: repo.display_name,
                 sessions: as_u64(metrics.sessions.len()),
                 turns: metrics.turns,
@@ -288,7 +282,7 @@ fn build_snapshot(
         if let Some(metrics) = repo_metrics.remove(&None) {
             if !metrics.sessions.is_empty() || metrics.turns > 0 {
                 repositories.push(CodeAnalyticsRepository {
-                    repo_id: RepoId::from(uuid::Uuid::nil()),
+                    repo_id: None,
                     name: NO_REPOSITORY_NAME.to_owned(),
                     sessions: as_u64(metrics.sessions.len()),
                     turns: metrics.turns,
@@ -757,6 +751,20 @@ fn as_u64(value: usize) -> u64 {
     u64::try_from(value).unwrap_or(u64::MAX)
 }
 
+fn require_known_repo(
+    repos: &[tidebreak_core::CodeRepo],
+    repo_id: Option<RepoId>,
+) -> Result<(), ServerError> {
+    if let Some(repo_id) = repo_id {
+        if !repos.iter().any(|repo| repo.id == repo_id) {
+            return Err(ServerError::not_found(format!(
+                "code repository {repo_id} not found"
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -968,9 +976,13 @@ mod tests {
             .iter()
             .find(|row| row.name == NO_REPOSITORY_NAME)
             .expect("no repository group");
+        assert_eq!(no_repo.repo_id, None);
         assert_eq!(no_repo.sessions, 1);
         assert_eq!(no_repo.turns, 1);
         assert_eq!(no_repo.total_tokens, 120);
+        let err = require_known_repo(&[], Some(RepoId::from(uuid::Uuid::nil())))
+            .expect_err("nil UUID is not a selectable repository");
+        assert_eq!(err.kind(), "not_found");
     }
 
     fn sample_session(

--- a/crates/tidebreak-server-api/src/routes/code/analytics.rs
+++ b/crates/tidebreak-server-api/src/routes/code/analytics.rs
@@ -21,6 +21,7 @@ use super::types::{
 };
 
 const PRICES_AS_OF: &str = "2026-09-03";
+const NO_REPOSITORY_NAME: &str = "no repository";
 
 #[derive(Debug, Default, Deserialize)]
 pub(crate) struct CodeAnalyticsQuery {
@@ -87,22 +88,17 @@ fn build_snapshot(
         .collect();
     let session_by_id: HashMap<SessionId, &Session> = sessions
         .iter()
-        .filter(|session| {
-            session
-                .workspace_id
-                .and_then(|workspace_id| workspace_repos.get(&workspace_id))
-                .is_some_and(|repo_id| repo_filter.is_none_or(|filter| filter == *repo_id))
-        })
+        .filter(|session| session_matches_repo_filter(session, &workspace_repos, repo_filter))
         .map(|session| (session.id, session))
         .collect();
 
     let mut totals = CodeAnalyticsTotals::default();
     let mut pricing = PricingAccumulator::default();
     let mut daily: BTreeMap<NaiveDate, DailyAccumulator> = BTreeMap::new();
-    let mut repo_metrics: HashMap<RepoId, MetricsAccumulator> = repos
+    let mut repo_metrics: HashMap<Option<RepoId>, MetricsAccumulator> = repos
         .iter()
         .filter(|repo| repo_filter.is_none_or(|filter| filter == repo.id))
-        .map(|repo| (repo.id, MetricsAccumulator::default()))
+        .map(|repo| (Some(repo.id), MetricsAccumulator::default()))
         .collect();
     let mut model_metrics: HashMap<ModelKey, ModelAccumulator> = HashMap::new();
     let mut harness_metrics: HashMap<HarnessKind, MetricsAccumulator> = HashMap::new();
@@ -123,11 +119,10 @@ fn build_snapshot(
         if !in_range(turn.started_at, from, through) {
             continue;
         }
-        let Some(repo_id) = session
-            .workspace_id
-            .and_then(|workspace_id| workspace_repos.get(&workspace_id).copied())
-        else {
-            continue;
+        let repo_id = match session_repo_id(session, &workspace_repos) {
+            SessionRepo::MissingWorkspace => continue,
+            SessionRepo::None => None,
+            SessionRepo::Some(repo_id) => Some(repo_id),
         };
         active_sessions.insert(session.id);
         let date = turn.started_at.date_naive();
@@ -167,9 +162,7 @@ fn build_snapshot(
         day.total_tokens = day.total_tokens.saturating_add(tokens.total);
 
         let canonical_model = turn.model.as_deref().and_then(canonical_model_id);
-        let rate = (!turn.fast_mode)
-            .then(|| canonical_model.and_then(price_for_canonical))
-            .flatten();
+        let rate = canonical_model.and_then(price_for_canonical);
         let cost_millimicrousd = rate
             .map(|rate| rate.cost_millimicrousd(tokens))
             .unwrap_or(0);
@@ -212,11 +205,10 @@ fn build_snapshot(
         let Some(session) = session_by_id.get(&session_id).copied() else {
             continue;
         };
-        let Some(repo_id) = session
-            .workspace_id
-            .and_then(|workspace_id| workspace_repos.get(&workspace_id).copied())
-        else {
-            continue;
+        let repo_id = match session_repo_id(session, &workspace_repos) {
+            SessionRepo::MissingWorkspace => continue,
+            SessionRepo::None => None,
+            SessionRepo::Some(repo_id) => Some(repo_id),
         };
         repo_metrics
             .entry(repo_id)
@@ -250,7 +242,7 @@ fn build_snapshot(
                 .or_default();
             day.pull_requests_opened = day.pull_requests_opened.saturating_add(1);
             for repo_id in &matching_repos {
-                let metrics = repo_metrics.entry(*repo_id).or_default();
+                let metrics = repo_metrics.entry(Some(*repo_id)).or_default();
                 metrics.pull_requests_opened = metrics.pull_requests_opened.saturating_add(1);
             }
         }
@@ -260,7 +252,7 @@ fn build_snapshot(
                 let day = daily.entry(merged_at.date_naive()).or_default();
                 day.pull_requests_merged = day.pull_requests_merged.saturating_add(1);
                 for repo_id in &matching_repos {
-                    let metrics = repo_metrics.entry(*repo_id).or_default();
+                    let metrics = repo_metrics.entry(Some(*repo_id)).or_default();
                     metrics.pull_requests_merged = metrics.pull_requests_merged.saturating_add(1);
                 }
             }
@@ -273,7 +265,7 @@ fn build_snapshot(
         .into_iter()
         .filter(|repo| repo_filter.is_none_or(|filter| filter == repo.id))
         .map(|repo| {
-            let metrics = repo_metrics.remove(&repo.id).unwrap_or_default();
+            let metrics = repo_metrics.remove(&Some(repo.id)).unwrap_or_default();
             CodeAnalyticsRepository {
                 repo_id: repo.id,
                 name: repo.display_name,
@@ -292,6 +284,22 @@ fn build_snapshot(
             .cmp(&left.total_tokens)
             .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
     });
+    if repo_filter.is_none() {
+        if let Some(metrics) = repo_metrics.remove(&None) {
+            if !metrics.sessions.is_empty() || metrics.turns > 0 {
+                repositories.push(CodeAnalyticsRepository {
+                    repo_id: RepoId::from(uuid::Uuid::nil()),
+                    name: NO_REPOSITORY_NAME.to_owned(),
+                    sessions: as_u64(metrics.sessions.len()),
+                    turns: metrics.turns,
+                    total_tokens: metrics.tokens,
+                    estimated_cost_microusd: microusd(metrics.cost_millimicrousd),
+                    pull_requests_opened: metrics.pull_requests_opened,
+                    pull_requests_merged: metrics.pull_requests_merged,
+                });
+            }
+        }
+    }
 
     let mut models = model_metrics
         .into_iter()
@@ -344,6 +352,37 @@ fn build_snapshot(
             priced_tokens: pricing.priced_tokens,
             unpriced_tokens: pricing.unpriced_tokens,
             prices_as_of: PRICES_AS_OF.to_owned(),
+        },
+    }
+}
+
+enum SessionRepo {
+    Some(RepoId),
+    None,
+    MissingWorkspace,
+}
+
+fn session_matches_repo_filter(
+    session: &Session,
+    workspace_repos: &HashMap<WorkspaceId, RepoId>,
+    repo_filter: Option<RepoId>,
+) -> bool {
+    match session_repo_id(session, workspace_repos) {
+        SessionRepo::MissingWorkspace => false,
+        SessionRepo::None => repo_filter.is_none(),
+        SessionRepo::Some(repo_id) => repo_filter.is_none_or(|filter| filter == repo_id),
+    }
+}
+
+fn session_repo_id(
+    session: &Session,
+    workspace_repos: &HashMap<WorkspaceId, RepoId>,
+) -> SessionRepo {
+    match session.workspace_id {
+        None => SessionRepo::None,
+        Some(workspace_id) => match workspace_repos.get(&workspace_id).copied() {
+            Some(repo_id) => SessionRepo::Some(repo_id),
+            None => SessionRepo::MissingWorkspace,
         },
     }
 }
@@ -839,5 +878,132 @@ mod tests {
             total: 4_000_000,
         });
         assert_eq!(microusd(cost), 73_500_000);
+    }
+
+    #[test]
+    fn fast_mode_turn_uses_the_canonical_rate_and_is_priced() {
+        let now = Utc::now();
+        let session = sample_session(None, now);
+        let usage = tidebreak_core::TurnUsage {
+            input_tokens: 1_000,
+            output_tokens: 500,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            context_tokens: 0,
+            first_call_context_tokens: None,
+        };
+        let turn = tidebreak_core::db::code::TurnMetric {
+            session_id: session.id,
+            status: TurnStatus::Completed,
+            model: Some("claude-sonnet-5".into()),
+            fast_mode: true,
+            usage: Some(usage.clone()),
+            started_at: now,
+        };
+        let snapshot = build_snapshot(
+            CodeAnalyticsRange::All,
+            None,
+            now,
+            None,
+            Vec::new(),
+            Vec::new(),
+            vec![session],
+            vec![turn],
+            Vec::new(),
+            Vec::new(),
+        );
+        let tokens = UsageTotals::from_usage(&usage);
+        let expected = microusd(
+            price_for_canonical("claude-sonnet-5")
+                .unwrap()
+                .cost_millimicrousd(tokens),
+        );
+        assert!(expected > 0);
+        assert_eq!(snapshot.totals.estimated_cost_microusd, expected);
+        assert_eq!(snapshot.pricing.priced_turns, 1);
+        assert_eq!(snapshot.pricing.unpriced_turns, 0);
+        assert!(snapshot.models[0].fast_mode);
+        assert!(snapshot.models[0].priced);
+        assert_eq!(snapshot.models[0].estimated_cost_microusd, expected);
+    }
+
+    #[test]
+    fn workspace_less_session_turns_count_in_totals_and_no_repository_group() {
+        let now = Utc::now();
+        let session = sample_session(None, now);
+        let usage = tidebreak_core::TurnUsage {
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            context_tokens: 0,
+            first_call_context_tokens: None,
+        };
+        let turn = tidebreak_core::db::code::TurnMetric {
+            session_id: session.id,
+            status: TurnStatus::Completed,
+            model: Some("claude-sonnet-5".into()),
+            fast_mode: false,
+            usage: Some(usage),
+            started_at: now,
+        };
+        let snapshot = build_snapshot(
+            CodeAnalyticsRange::All,
+            None,
+            now,
+            None,
+            Vec::new(),
+            Vec::new(),
+            vec![session],
+            vec![turn],
+            Vec::new(),
+            Vec::new(),
+        );
+        assert_eq!(snapshot.totals.sessions, 1);
+        assert_eq!(snapshot.totals.turns, 1);
+        assert_eq!(snapshot.totals.completed_turns, 1);
+        assert_eq!(snapshot.totals.total_tokens, 120);
+        let no_repo = snapshot
+            .repositories
+            .iter()
+            .find(|row| row.name == NO_REPOSITORY_NAME)
+            .expect("no repository group");
+        assert_eq!(no_repo.sessions, 1);
+        assert_eq!(no_repo.turns, 1);
+        assert_eq!(no_repo.total_tokens, 120);
+    }
+
+    fn sample_session(
+        workspace_id: Option<tidebreak_core::WorkspaceId>,
+        created_at: DateTime<Utc>,
+    ) -> Session {
+        Session {
+            id: SessionId::new(),
+            owner: tidebreak_core::OwnerId::local(),
+            owner_kind: None,
+            workspace_id,
+            kind: tidebreak_core::SessionKind::Interactive,
+            harness_kind: HarnessKind::Internal,
+            harness_version: None,
+            harness_resume_ref: None,
+            permission_mode: tidebreak_core::PermissionMode::Ask,
+            model: Some("claude-sonnet-5".into()),
+            reasoning_effort: None,
+            fast_mode: false,
+            lifecycle: tidebreak_core::SessionLifecycle::Idle,
+            fence_reason: None,
+            child_pid: None,
+            child_process_identity: None,
+            spawn_epoch: 0,
+            attention: tidebreak_core::Attention::working(
+                tidebreak_core::AttentionSource::Lifecycle,
+            ),
+            unrecognized_event_count: 0,
+            subagents: Vec::new(),
+            visibility: tidebreak_core::SessionVisibility::Private,
+            created_at,
+            execution_location: tidebreak_core::ExecutionLocation::Machine,
+            acts_as: None,
+        }
     }
 }

--- a/crates/tidebreak-server/src/code/types.rs
+++ b/crates/tidebreak-server/src/code/types.rs
@@ -523,10 +523,11 @@ pub struct CodeAnalyticsDay {
     pub pull_requests_merged: u64,
 }
 
-/// Metrics attributed to one registered repository.
+/// Metrics attributed to one registered repository, or to the unattributed
+/// "no repository" group when `repo_id` is null.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub struct CodeAnalyticsRepository {
-    pub repo_id: RepoId,
+    pub repo_id: Option<RepoId>,
     pub name: String,
     pub sessions: u64,
     pub turns: u64,

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -977,9 +977,10 @@ export type CodeAnalyticsPricingCoverage = { priced_turns: number, unpriced_turn
 export type CodeAnalyticsRange = "7d" | "30d" | "90d" | "all";
 
 /**
- * Metrics attributed to one registered repository.
+ * Metrics attributed to one registered repository, or to the unattributed
+ * "no repository" group when `repo_id` is null.
  */
-export type CodeAnalyticsRepository = { repo_id: RepoId, name: string, sessions: number, turns: number, total_tokens: number, estimated_cost_microusd: number, pull_requests_opened: number, pull_requests_merged: number, };
+export type CodeAnalyticsRepository = { repo_id: RepoId | null, name: string, sessions: number, turns: number, total_tokens: number, estimated_cost_microusd: number, pull_requests_opened: number, pull_requests_merged: number, };
 
 /**
  * Owner-scoped code activity and local cost estimates.


### PR DESCRIPTION
## What was wrong

Code analytics priced every fast-mode turn at $0 by skipping `price_for_canonical` when `fast_mode` was true, and counted those turns as unpriced coverage. `session_by_id` also required a mapped workspace, so internal-engine conversations created through `POST /sessions` (decision 0094) never appeared in install totals. The unattributed group also reused the nil UUID as `repo_id`, which is still a valid `RepoId` and would 404 if used as a filter.

## What changed

- Fast-mode turns use the same canonical per-token table as standard turns (there is no separate fast-mode table in this repo) and count as priced when that rate exists.
- Sessions with no workspace are included in totals and grouped under a `no repository` row wherever the report groups by repository.
- That row now serializes `repo_id` as null rather than the nil UUID; the desktop table labels it "no repository" and does not offer it as a repository filter.
- Tests cover a fast-mode turn contributing a non-zero cost equal to the canonical rate, a workspace-less session appearing in totals and the no-repository group with a null `repo_id`, and a nil-UUID filter remaining not found.

Closes #3340

## Checks

- `cargo fmt --all` — formatted
- `cargo test -p tidebreak-server analytics` — 7 passed
- `cargo clippy -p tidebreak-server --all-targets -- -D warnings -A clippy::too_many_arguments` — success
- `UPDATE_WIRE_TYPES=1 cargo test -p tidebreak-server --lib wire_types` then regenerated `wire.ts`
- desktop UI lint, test, and build