### PR TITLE
fix(code): keep review_decision across hosted forge REST reconcile passes

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/pull_request.rs
+++ b/crates/tidebreak-core/src/db/ops/code/pull_request.rs
@@ -185,6 +185,7 @@ pub async fn set_pull_request_live_state(
 /// [`PullRequestReviewDecisionWrite::Preserve`] omits `review_decision` the
 /// same way: the update never assigns the column, so a concurrent
 /// authoritative write cannot be overwritten by a stale copy.
+#[allow(clippy::too_many_arguments)]
 pub async fn set_pull_request_live_state_with(
     store: &DbStore,
     owner: &OwnerId,

--- a/crates/tidebreak-core/src/db/ops/code/pull_request.rs
+++ b/crates/tidebreak-core/src/db/ops/code/pull_request.rs
@@ -126,6 +126,47 @@ pub async fn get_pull_request_fact(
     Ok(Some(fact_from_row(row)?))
 }
 
+/// How a live-tier write treats `review_decision`.
+///
+/// REST does not load reviews, so it must not assign the column: omitting
+/// it keeps whatever an authoritative write stored, including a concurrent
+/// write between the caller's awaits. `None` on the live struct is
+/// authoritative empty and still needs [`Self::Replace`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PullRequestReviewDecisionWrite {
+    /// Write `live.review_decision`, including `None` to clear the column.
+    Replace,
+    /// Leave the stored decision untouched. The update statement omits
+    /// `review_decision`.
+    Preserve,
+}
+
+/// Write the live tier onto one observed pull request (decision 66).
+///
+/// Authoritative callers replace `review_decision`. REST keep-the-row
+/// writes pass [`PullRequestReviewDecisionWrite::Preserve`].
+pub async fn set_pull_request_live_state(
+    store: &DbStore,
+    owner: &OwnerId,
+    host: &str,
+    repo_owner: &str,
+    repo_name: &str,
+    number: u64,
+    live: &CodePullRequestLiveState,
+) -> Result<Option<(CodePullRequestId, bool, CodePullRequestLiveState)>> {
+    set_pull_request_live_state_with(
+        store,
+        owner,
+        host,
+        repo_owner,
+        repo_name,
+        number,
+        live,
+        PullRequestReviewDecisionWrite::Replace,
+    )
+    .await
+}
+
 /// Write the live tier onto one observed pull request (decision 66).
 ///
 /// Returns the row id, whether any live field actually moved, and the tier
@@ -140,7 +181,11 @@ pub async fn get_pull_request_fact(
 /// conditional fetcher wrote would blind the watch and the check triggers
 /// for the length of the sweep interval. A read that loaded checks and found
 /// none carries `Some(vec![])`, which clears them.
-pub async fn set_pull_request_live_state(
+///
+/// [`PullRequestReviewDecisionWrite::Preserve`] omits `review_decision` the
+/// same way: the update never assigns the column, so a concurrent
+/// authoritative write cannot be overwritten by a stale copy.
+pub async fn set_pull_request_live_state_with(
     store: &DbStore,
     owner: &OwnerId,
     host: &str,
@@ -148,6 +193,7 @@ pub async fn set_pull_request_live_state(
     repo_name: &str,
     number: u64,
     live: &CodePullRequestLiveState,
+    review_decision_write: PullRequestReviewDecisionWrite,
 ) -> Result<Option<(CodePullRequestId, bool, CodePullRequestLiveState)>> {
     let number = i64::try_from(number)
         .map_err(|_| AgentError::Store(format!("pull request number {number} overflows")))?;
@@ -167,9 +213,13 @@ pub async fn set_pull_request_live_state(
         // The read did not load checks: keep what the row already knows.
         None => (row.checks_summary.clone(), row.checks.clone()),
     };
+    let review_decision = match review_decision_write {
+        PullRequestReviewDecisionWrite::Replace => live.review_decision.clone(),
+        PullRequestReviewDecisionWrite::Preserve => row.review_decision.clone(),
+    };
     let changed = row.checks_summary != checks_summary
         || row.checks != checks_json
-        || row.review_decision != live.review_decision
+        || row.review_decision != review_decision
         || row.mergeable != live.mergeable
         || row.merge_state_status != live.merge_state_status
         || row.auto_merge_enabled != live.auto_merge_enabled
@@ -187,7 +237,9 @@ pub async fn set_pull_request_live_state(
     let mut model: entities::code_pull_request::ActiveModel = row.into();
     model.checks_summary = Set(checks_summary.clone());
     model.checks = Set(checks_json);
-    model.review_decision = Set(live.review_decision.clone());
+    if review_decision_write == PullRequestReviewDecisionWrite::Replace {
+        model.review_decision = Set(live.review_decision.clone());
+    }
     model.mergeable = Set(live.mergeable.clone());
     model.merge_state_status = Set(live.merge_state_status.clone());
     model.auto_merge_enabled = Set(live.auto_merge_enabled);
@@ -197,6 +249,7 @@ pub async fn set_pull_request_live_state(
     let stored = CodePullRequestLiveState {
         checks_summary,
         checks: stored_checks,
+        review_decision,
         ..live.clone()
     };
     Ok(Some((id, changed, stored)))

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4115,7 +4115,8 @@ async fn pull_request_facts_upsert_claim_and_promote() {
         insert_pull_request_attribution, list_attributed_facts_for_workspace,
         list_fact_repo_identities_all_owners, promote_attribution_to_authored,
         save_pull_request_fact, set_pull_request_fetch_state, set_pull_request_live_state,
-        PullRequestFetchCondition,
+        set_pull_request_live_state_with, PullRequestFetchCondition,
+        PullRequestReviewDecisionWrite,
     };
 
     let (_dir, store) = temp_store().await;
@@ -4303,6 +4304,56 @@ async fn pull_request_facts_upsert_claim_and_promote() {
             .unwrap()
             .is_none()
     );
+
+    // Preserve omits `review_decision` so a later REST write cannot stamp a
+    // stale pre-read (or `None` after a failed read) over an authoritative
+    // value. Replace with `None` still clears.
+    let mut rest_unknown = live.clone();
+    rest_unknown.review_decision = None;
+    let (_, preserve_changed, preserve_stored) = set_pull_request_live_state_with(
+        &store,
+        &owner,
+        "github.com",
+        "acme",
+        "tools",
+        412,
+        &rest_unknown,
+        PullRequestReviewDecisionWrite::Preserve,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        !preserve_changed,
+        "preserving review_decision is not a change"
+    );
+    assert_eq!(
+        preserve_stored.review_decision.as_deref(),
+        Some("review_required")
+    );
+    let mut cleared_review = live.clone();
+    cleared_review.review_decision = None;
+    let (_, cleared_review_changed, cleared_review_stored) = set_pull_request_live_state(
+        &store,
+        &owner,
+        "github.com",
+        "acme",
+        "tools",
+        412,
+        &cleared_review,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        cleared_review_changed,
+        "authoritative None clears the column"
+    );
+    assert_eq!(cleared_review_stored.review_decision, None);
+    set_pull_request_live_state(&store, &owner, "github.com", "acme", "tools", 412, &live)
+        .await
+        .unwrap()
+        .unwrap();
 
     // Claim once: the second claim reports the row already exists and the
     // stored relation is untouched.

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -52,6 +52,9 @@ const CHECK_RUN_CONCURRENCY: usize = 4;
 const TIMELINE_PAGE_SIZE: u32 = 100;
 const TIMELINE_PAGE_LIMIT: u32 = 20;
 
+/// Review list was not loaded; the live-tier writer keeps the row's value.
+pub(crate) const REVIEW_DECISION_UNKNOWN: &str = "unknown";
+
 /// Stable action classification kept beside the HTTP response that proves it.
 ///
 /// This module always sends `sha` to GitHub's pull-request merge endpoint,
@@ -733,9 +736,10 @@ pub(crate) async fn pull_request_digest(
         check_counts: Some(counts),
         checks: (!checks.is_empty()).then_some(checks),
         draft: detail.get("draft").and_then(Value::as_bool),
-        // REST never derives a review decision; `None` is the keep-the-row
-        // marker the live-tier writer already honors.
-        review_decision: None,
+        // REST never derives a review decision. An open digest carries the
+        // internal keep-the-row sentinel; `None` is an authoritative empty
+        // decision (merged/closed, or a loaded review list with no objection).
+        review_decision: open.then(|| REVIEW_DECISION_UNKNOWN.to_owned()),
         mergeable: match detail.get("mergeable") {
             Some(Value::Bool(true)) => Some("mergeable".to_owned()),
             Some(Value::Bool(false)) => Some("conflicting".to_owned()),
@@ -894,13 +898,10 @@ pub(crate) fn queue_membership_from_timeline(value: &Value) -> Option<bool> {
     Some(last == Some("added_to_merge_queue"))
 }
 
-/// Review list was not loaded; the live-tier writer keeps the row's value.
-pub(crate) const REVIEW_DECISION_UNKNOWN: &str = "unknown";
-
-/// Whether a digest's review decision is the keep-the-row marker: REST never
-/// derives one, so `None` and the explicit sentinel both mean "leave it".
+/// Whether a digest's review decision is the REST keep-the-row sentinel.
+/// `None` is an authoritative empty decision, not an unloaded marker.
 pub(crate) fn review_decision_is_unknown(value: Option<&str>) -> bool {
-    value.is_none() || value == Some(REVIEW_DECISION_UNKNOWN)
+    value == Some(REVIEW_DECISION_UNKNOWN)
 }
 
 /// One REST pull request restated in the `gh --json` fact shape
@@ -986,6 +987,13 @@ mod tests {
         assert_eq!(fact["headRefName"], "feature");
         assert_eq!(fact["headRefOid"], "abc123");
         assert!(fact["reviewDecision"].is_null());
+    }
+
+    #[test]
+    fn only_the_unknown_sentinel_is_an_unloaded_review_decision() {
+        assert!(review_decision_is_unknown(Some(REVIEW_DECISION_UNKNOWN)));
+        assert!(!review_decision_is_unknown(None));
+        assert!(!review_decision_is_unknown(Some("changes_requested")));
     }
 
     /// github.com maps to the public API origin; any other forge host keeps

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -283,7 +283,8 @@ pub(crate) async fn delivery_pull_request(
     if !status.is_success() {
         return Err(forge_message(status, &value));
     }
-    let mut fact = fact_value(&value);
+    let reviews = pull_request_reviews(api_base, target, credential, number).await?;
+    let mut fact = fact_value_with_reviews(&value, Some(&reviews));
     let checks = match value.pointer("/head/sha").and_then(Value::as_str) {
         Some(sha) => check_run_values(api_base, target, credential, sha).await?,
         None => Vec::new(),
@@ -325,7 +326,14 @@ pub(crate) async fn delivery_pull_requests(
     let pulls = value.as_array().cloned().unwrap_or_default();
     stream::iter(pulls)
         .map(|pull| async move {
-            let mut fact = fact_value(&pull);
+            let number = pull.get("number").and_then(Value::as_u64);
+            let reviews = match number {
+                Some(number) if checks_loaded => {
+                    Some(pull_request_reviews(api_base, target, credential, number).await?)
+                }
+                _ => None,
+            };
+            let mut fact = fact_value_with_reviews(&pull, reviews.as_ref());
             if checks_loaded {
                 let checks = match pull.pointer("/head/sha").and_then(Value::as_str) {
                     Some(sha) => check_run_values(api_base, target, credential, sha).await?,
@@ -714,6 +722,12 @@ pub(crate) async fn pull_request_digest(
     } else {
         Some(false)
     };
+    let review_decision = if open {
+        let reviews = pull_request_reviews(api_base, target, credential, number).await?;
+        derived_review_decision(Some(&reviews))
+    } else {
+        None
+    };
     let text = |pointer: &str| {
         detail
             .pointer(pointer)
@@ -733,9 +747,7 @@ pub(crate) async fn pull_request_digest(
         check_counts: Some(counts),
         checks: (!checks.is_empty()).then_some(checks),
         draft: detail.get("draft").and_then(Value::as_bool),
-        // REST has no review-decision projection; the field stays unstated
-        // rather than approximated from raw reviews.
-        review_decision: None,
+        review_decision,
         mergeable: match detail.get("mergeable") {
             Some(Value::Bool(true)) => Some("mergeable".to_owned()),
             Some(Value::Bool(false)) => Some("conflicting".to_owned()),
@@ -894,11 +906,57 @@ pub(crate) fn queue_membership_from_timeline(value: &Value) -> Option<bool> {
     Some(last == Some("added_to_merge_queue"))
 }
 
+/// Review list was not loaded; the live-tier writer keeps the row's value.
+pub(crate) const REVIEW_DECISION_UNKNOWN: &str = "unknown";
+
+/// One page of reviews for a pull request — the same bound the conditional
+/// fetcher uses.
+async fn pull_request_reviews(
+    api_base: &str,
+    target: &CodeGitHubRepositoryTarget,
+    credential: &GitCredential,
+    number: u64,
+) -> Result<Value, String> {
+    let (status, value) = request(
+        reqwest::Method::GET,
+        format!(
+            "{api_base}/repos/{}/{}/pulls/{number}/reviews?per_page=100",
+            target.owner, target.name
+        ),
+        credential,
+        None,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(forge_message(status, &value));
+    }
+    Ok(value)
+}
+
+fn derived_review_decision(reviews: Option<&Value>) -> Option<String> {
+    reviews.and_then(|reviews| {
+        super::pr_fetch::derive_review_decision(None, &super::pr_fetch::tally_reviews(reviews))
+    })
+}
+
+fn review_decision_json(reviews: Option<&Value>) -> Value {
+    match reviews {
+        None => Value::String(REVIEW_DECISION_UNKNOWN.to_owned()),
+        Some(_) => derived_review_decision(reviews)
+            .map(Value::String)
+            .unwrap_or(Value::Null),
+    }
+}
+
 /// One REST pull request restated in the `gh --json` fact shape
 /// ([`super::gh::PR_FACT_FIELDS`]), so the fact store parses one vocabulary
 /// however the host was asked. `state` stays REST's own `open`/`closed`;
 /// the parser already reads closed-with-merged-at as merged.
 pub(crate) fn fact_value(pr: &Value) -> Value {
+    fact_value_with_reviews(pr, None)
+}
+
+pub(crate) fn fact_value_with_reviews(pr: &Value, reviews: Option<&Value>) -> Value {
     let head_repository = pr.pointer("/head/repo").map_or(Value::Null, |repository| {
         serde_json::json!({
             "nameWithOwner": repository.get("full_name").cloned().unwrap_or(Value::Null),
@@ -924,7 +982,7 @@ pub(crate) fn fact_value(pr: &Value) -> Value {
             "login": pr.pointer("/user/login").cloned().unwrap_or(Value::Null),
             "avatarUrl": pr.pointer("/user/avatar_url").cloned().unwrap_or(Value::Null),
         },
-        "reviewDecision": Value::Null,
+        "reviewDecision": review_decision_json(reviews),
         "mergeable": mergeable,
         "mergeStateStatus": pr.get("mergeable_state").cloned().unwrap_or(Value::Null),
         "autoMergeRequest": pr.get("auto_merge").cloned().unwrap_or(Value::Null),
@@ -973,6 +1031,26 @@ mod tests {
         assert_eq!(fact["author"]["login"], "mira-chen");
         assert_eq!(fact["headRefName"], "feature");
         assert_eq!(fact["headRefOid"], "abc123");
+        assert_eq!(fact["reviewDecision"], REVIEW_DECISION_UNKNOWN);
+    }
+
+    #[test]
+    fn a_changes_requested_review_yields_the_classifier_word() {
+        let rest = serde_json::json!({
+            "number": 7,
+            "html_url": "https://github.com/acme/demo/pull/7",
+            "title": "Add the thing",
+            "state": "open",
+            "draft": false,
+            "user": { "login": "mira-chen" },
+            "head": { "ref": "feature", "sha": "abc123" },
+            "base": { "ref": "main" },
+        });
+        let reviews = serde_json::json!([
+            { "user": { "login": "reviewer" }, "state": "CHANGES_REQUESTED" }
+        ]);
+        let fact = fact_value_with_reviews(&rest, Some(&reviews));
+        assert_eq!(fact["reviewDecision"], "changes_requested");
     }
 
     /// github.com maps to the public API origin; any other forge host keeps

--- a/crates/tidebreak-server/src/code/forge_rest.rs
+++ b/crates/tidebreak-server/src/code/forge_rest.rs
@@ -283,8 +283,7 @@ pub(crate) async fn delivery_pull_request(
     if !status.is_success() {
         return Err(forge_message(status, &value));
     }
-    let reviews = pull_request_reviews(api_base, target, credential, number).await?;
-    let mut fact = fact_value_with_reviews(&value, Some(&reviews));
+    let mut fact = fact_value(&value);
     let checks = match value.pointer("/head/sha").and_then(Value::as_str) {
         Some(sha) => check_run_values(api_base, target, credential, sha).await?,
         None => Vec::new(),
@@ -326,14 +325,7 @@ pub(crate) async fn delivery_pull_requests(
     let pulls = value.as_array().cloned().unwrap_or_default();
     stream::iter(pulls)
         .map(|pull| async move {
-            let number = pull.get("number").and_then(Value::as_u64);
-            let reviews = match number {
-                Some(number) if checks_loaded => {
-                    Some(pull_request_reviews(api_base, target, credential, number).await?)
-                }
-                _ => None,
-            };
-            let mut fact = fact_value_with_reviews(&pull, reviews.as_ref());
+            let mut fact = fact_value(&pull);
             if checks_loaded {
                 let checks = match pull.pointer("/head/sha").and_then(Value::as_str) {
                     Some(sha) => check_run_values(api_base, target, credential, sha).await?,
@@ -722,12 +714,6 @@ pub(crate) async fn pull_request_digest(
     } else {
         Some(false)
     };
-    let review_decision = if open {
-        let reviews = pull_request_reviews(api_base, target, credential, number).await?;
-        derived_review_decision(Some(&reviews))
-    } else {
-        None
-    };
     let text = |pointer: &str| {
         detail
             .pointer(pointer)
@@ -747,7 +733,9 @@ pub(crate) async fn pull_request_digest(
         check_counts: Some(counts),
         checks: (!checks.is_empty()).then_some(checks),
         draft: detail.get("draft").and_then(Value::as_bool),
-        review_decision,
+        // REST never derives a review decision; `None` is the keep-the-row
+        // marker the live-tier writer already honors.
+        review_decision: None,
         mergeable: match detail.get("mergeable") {
             Some(Value::Bool(true)) => Some("mergeable".to_owned()),
             Some(Value::Bool(false)) => Some("conflicting".to_owned()),
@@ -909,54 +897,20 @@ pub(crate) fn queue_membership_from_timeline(value: &Value) -> Option<bool> {
 /// Review list was not loaded; the live-tier writer keeps the row's value.
 pub(crate) const REVIEW_DECISION_UNKNOWN: &str = "unknown";
 
-/// One page of reviews for a pull request — the same bound the conditional
-/// fetcher uses.
-async fn pull_request_reviews(
-    api_base: &str,
-    target: &CodeGitHubRepositoryTarget,
-    credential: &GitCredential,
-    number: u64,
-) -> Result<Value, String> {
-    let (status, value) = request(
-        reqwest::Method::GET,
-        format!(
-            "{api_base}/repos/{}/{}/pulls/{number}/reviews?per_page=100",
-            target.owner, target.name
-        ),
-        credential,
-        None,
-    )
-    .await?;
-    if !status.is_success() {
-        return Err(forge_message(status, &value));
-    }
-    Ok(value)
-}
-
-fn derived_review_decision(reviews: Option<&Value>) -> Option<String> {
-    reviews.and_then(|reviews| {
-        super::pr_fetch::derive_review_decision(None, &super::pr_fetch::tally_reviews(reviews))
-    })
-}
-
-fn review_decision_json(reviews: Option<&Value>) -> Value {
-    match reviews {
-        None => Value::String(REVIEW_DECISION_UNKNOWN.to_owned()),
-        Some(_) => derived_review_decision(reviews)
-            .map(Value::String)
-            .unwrap_or(Value::Null),
-    }
+/// Whether a digest's review decision is the keep-the-row marker: REST never
+/// derives one, so `None` and the explicit sentinel both mean "leave it".
+pub(crate) fn review_decision_is_unknown(value: Option<&str>) -> bool {
+    value.is_none() || value == Some(REVIEW_DECISION_UNKNOWN)
 }
 
 /// One REST pull request restated in the `gh --json` fact shape
 /// ([`super::gh::PR_FACT_FIELDS`]), so the fact store parses one vocabulary
 /// however the host was asked. `state` stays REST's own `open`/`closed`;
 /// the parser already reads closed-with-merged-at as merged.
+///
+/// `reviewDecision` stays JSON null: REST does not derive it, and an
+/// internal keep-the-row marker must not land on the public summary.
 pub(crate) fn fact_value(pr: &Value) -> Value {
-    fact_value_with_reviews(pr, None)
-}
-
-pub(crate) fn fact_value_with_reviews(pr: &Value, reviews: Option<&Value>) -> Value {
     let head_repository = pr.pointer("/head/repo").map_or(Value::Null, |repository| {
         serde_json::json!({
             "nameWithOwner": repository.get("full_name").cloned().unwrap_or(Value::Null),
@@ -982,7 +936,7 @@ pub(crate) fn fact_value_with_reviews(pr: &Value, reviews: Option<&Value>) -> Va
             "login": pr.pointer("/user/login").cloned().unwrap_or(Value::Null),
             "avatarUrl": pr.pointer("/user/avatar_url").cloned().unwrap_or(Value::Null),
         },
-        "reviewDecision": review_decision_json(reviews),
+        "reviewDecision": Value::Null,
         "mergeable": mergeable,
         "mergeStateStatus": pr.get("mergeable_state").cloned().unwrap_or(Value::Null),
         "autoMergeRequest": pr.get("auto_merge").cloned().unwrap_or(Value::Null),
@@ -1031,26 +985,7 @@ mod tests {
         assert_eq!(fact["author"]["login"], "mira-chen");
         assert_eq!(fact["headRefName"], "feature");
         assert_eq!(fact["headRefOid"], "abc123");
-        assert_eq!(fact["reviewDecision"], REVIEW_DECISION_UNKNOWN);
-    }
-
-    #[test]
-    fn a_changes_requested_review_yields_the_classifier_word() {
-        let rest = serde_json::json!({
-            "number": 7,
-            "html_url": "https://github.com/acme/demo/pull/7",
-            "title": "Add the thing",
-            "state": "open",
-            "draft": false,
-            "user": { "login": "mira-chen" },
-            "head": { "ref": "feature", "sha": "abc123" },
-            "base": { "ref": "main" },
-        });
-        let reviews = serde_json::json!([
-            { "user": { "login": "reviewer" }, "state": "CHANGES_REQUESTED" }
-        ]);
-        let fact = fact_value_with_reviews(&rest, Some(&reviews));
-        assert_eq!(fact["reviewDecision"], "changes_requested");
+        assert!(fact["reviewDecision"].is_null());
     }
 
     /// github.com maps to the public API origin; any other forge host keeps

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -347,7 +347,8 @@ pub async fn push_branch(
     })
 }
 
-/// Inspect the worktree and, when `gh` can, refresh the PR digest.
+/// Inspect local git and `gh` availability, carrying the persisted PR digest.
+/// The runtime's conditional fetcher owns remote pull-request refreshes.
 #[allow(clippy::too_many_arguments)]
 pub async fn workspace_git_status(
     worktree: &Path,
@@ -2522,6 +2523,32 @@ mod tests {
         assert_eq!(result.git.changed_files, 2);
         assert_eq!(result.git.unstaged_files, 1);
         assert_eq!(result.git.untracked_files, 1);
+    }
+
+    #[tokio::test]
+    async fn workspace_status_carries_the_persisted_digest_unchanged() {
+        let (dir, work, _) = init_paired_repos();
+        let persisted: PullRequestDigest = serde_json::from_value(serde_json::json!({
+            "number": 17,
+            "url": "https://github.com/acme/tools/pull/17",
+            "state": "open",
+            "review_decision": "changes_requested",
+            "title": "Stored title"
+        }))
+        .unwrap();
+        let unavailable = dir.path().join("no-gh");
+        let status = workspace_git_status(
+            &work,
+            "Local title",
+            "main",
+            "main",
+            Some(persisted.clone()),
+            Some(unavailable.to_str().unwrap()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(status.pr, Some(persisted));
+        assert!(!status.gh_found);
     }
 
     fn init_paired_repos() -> (TempDir, PathBuf, PathBuf) {

--- a/crates/tidebreak-server/src/code/pr_fetch.rs
+++ b/crates/tidebreak-server/src/code/pr_fetch.rs
@@ -827,7 +827,7 @@ fn checks_from_value(value: &Value) -> Vec<PullRequestCheck> {
 
 /// Each reviewer's newest standing review, tallied. `COMMENTED` never moves
 /// a reviewer's standing, and a dismissal clears it.
-fn tally_reviews(value: &Value) -> ReviewTally {
+pub(crate) fn tally_reviews(value: &Value) -> ReviewTally {
     let empty = Vec::new();
     let reviews = value.as_array().unwrap_or(&empty);
     let mut standing: HashMap<String, &str> = HashMap::new();

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -1224,9 +1224,9 @@ impl CodeRuntime {
             return;
         }
         let mut live = tidebreak_core::CodePullRequestLiveState::from_digest(digest, Utc::now());
-        // REST never derives a review decision (`None` or the unknown
-        // sentinel): keep the row's value the same way an unloaded check
-        // rollup keeps the checks.
+        // REST never derives a review decision: the unknown sentinel keeps
+        // the row's value the same way an unloaded check rollup keeps the
+        // checks. Authoritative `None` (loaded reviews, no objection) clears.
         if crate::code::forge_rest::review_decision_is_unknown(live.review_decision.as_deref()) {
             live.review_decision = match tidebreak_core::db::code::get_pull_request_fact(
                 &self.db,
@@ -1947,8 +1947,8 @@ mod remote_pr_tests {
 
     /// Issue 3339: a REST list never derives a review decision, so the
     /// reconcile write keeps `changes_requested`. The list restatement is
-    /// `fact_value` (no reviews endpoint); `None` on the digest is the
-    /// keep-the-row marker.
+    /// `fact_value` (no reviews endpoint); the unknown sentinel on the
+    /// digest is the keep-the-row marker.
     #[tokio::test]
     async fn a_rest_list_reconcile_keeps_changes_requested_without_reading_reviews() {
         use crate::code::forge_rest;
@@ -2024,8 +2024,113 @@ mod remote_pr_tests {
         });
         let listed = forge_rest::fact_value(&rest);
         assert!(listed["reviewDecision"].is_null());
-        assert!(forge_rest::review_decision_is_unknown(None));
+        assert!(!forge_rest::review_decision_is_unknown(None));
+        assert!(forge_rest::review_decision_is_unknown(Some(
+            forge_rest::REVIEW_DECISION_UNKNOWN
+        )));
 
+        runtime
+            .record_pull_request_live_state(
+                &owner,
+                None,
+                &PullRequestDigest {
+                    number: 17,
+                    url: Some("https://github.com/acme/tools/pull/17".into()),
+                    state: "open".into(),
+                    title: Some("Stored title".into()),
+                    checks_summary: None,
+                    check_counts: None,
+                    checks: None,
+                    draft: Some(false),
+                    merged: Some(false),
+                    review_decision: Some(forge_rest::REVIEW_DECISION_UNKNOWN.into()),
+                    mergeable: None,
+                    merge_state_status: None,
+                    head_branch: Some("feat".into()),
+                    base_branch: Some("main".into()),
+                    head_sha: Some("abc".into()),
+                    auto_merge_enabled: None,
+                    in_merge_queue: None,
+                },
+            )
+            .await;
+        let stored = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "tools", 17)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.live.unwrap().review_decision.as_deref(),
+            Some("changes_requested")
+        );
+    }
+
+    /// A conditional refresh that fully loaded reviews and derived no
+    /// decision must clear a stored `changes_requested`. Unloaded REST
+    /// still keeps the row via the unknown sentinel (tested above).
+    #[tokio::test]
+    async fn a_loaded_empty_review_decision_clears_changes_requested() {
+        use crate::code::forge_rest;
+        use tidebreak_core::db::code::{
+            get_pull_request_fact, save_pull_request_fact, set_pull_request_live_state,
+        };
+        use tidebreak_core::{
+            CodePullRequestFact, CodePullRequestId, CodePullRequestLiveState, CodePullRequestState,
+            PullRequestDigest,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _, owner, _) = fixture(dir.path()).await;
+        let now = Utc::now();
+        save_pull_request_fact(
+            &runtime.db,
+            &CodePullRequestFact {
+                id: CodePullRequestId::new(),
+                owner: owner.clone(),
+                host: "github.com".into(),
+                repo_owner: "acme".into(),
+                repo_name: "tools".into(),
+                number: 17,
+                url: "https://github.com/acme/tools/pull/17".into(),
+                title: "Stored title".into(),
+                state: CodePullRequestState::Open,
+                draft: false,
+                author: None,
+                head_branch: "feat".into(),
+                base_branch: "main".into(),
+                head_sha: Some("abc".into()),
+                created_at: now,
+                updated_at: now,
+                merged_at: None,
+                closed_at: None,
+                first_seen_at: now,
+                last_seen_at: now,
+                live: None,
+            },
+        )
+        .await
+        .unwrap();
+        set_pull_request_live_state(
+            &runtime.db,
+            &owner,
+            "github.com",
+            "acme",
+            "tools",
+            17,
+            &CodePullRequestLiveState {
+                checks_summary: None,
+                checks: None,
+                review_decision: Some("changes_requested".into()),
+                mergeable: None,
+                merge_state_status: None,
+                auto_merge_enabled: None,
+                in_merge_queue: None,
+                observed_at: now,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!forge_rest::review_decision_is_unknown(None));
         runtime
             .record_pull_request_live_state(
                 &owner,
@@ -2055,10 +2160,7 @@ mod remote_pr_tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(
-            stored.live.unwrap().review_decision.as_deref(),
-            Some("changes_requested")
-        );
+        assert_eq!(stored.live.unwrap().review_decision, None);
     }
 
     /// A merged REST digest must not derive a review decision, so a stale

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -490,7 +490,7 @@ impl CodeRuntime {
         owner: &OwnerId,
         id: WorkspaceId,
     ) -> Result<WorkspaceGitStatus, ServerError> {
-        let mut workspace = self.get_workspace(owner, id).await?;
+        let workspace = self.get_workspace(owner, id).await?;
         // Being asked is the attention signal (decision 66): the request
         // path reads local git plus the stored row, and the hot refresher
         // this mark feeds is what keeps the row current while anyone reads.
@@ -531,16 +531,6 @@ impl CodeRuntime {
                         }
                     }
                 }
-            }
-        }
-        if status.pr != workspace.pr {
-            workspace.pr = status.pr.clone();
-            self.save_workspace(&workspace).await?;
-            // A digest that moved is a fresh host observation: write it onto
-            // the fact row's live tier and fan the change out (decision 66).
-            if let Some(digest) = &status.pr {
-                self.record_pull_request_live_state(owner, Some(workspace.id), digest)
-                    .await;
             }
         }
         Ok(status)
@@ -1659,8 +1649,8 @@ impl CodeRuntime {
         };
         self.delivery_cache.invalidate();
         let created_number = digest.number;
-        workspace.pr = Some(digest);
-        self.save_workspace(&workspace).await?;
+        self.save_created_workspace_pr(&mut workspace, digest)
+            .await?;
         // Best-effort authored fact (decision 77). The digest just came from
         // the host; the REST path already holds the full row, and the `gh`
         // path re-reads it repository-qualified for full identity and
@@ -1709,6 +1699,19 @@ impl CodeRuntime {
         // fetched digest — checks pending on the fresh pull request — not
         // the light creation stub.
         self.refresh_workspace_pr(owner, id).await
+    }
+
+    /// Persist the creation result before refresh, without internal read markers.
+    async fn save_created_workspace_pr(
+        &self,
+        workspace: &mut CodeWorkspace,
+        mut digest: PullRequestDigest,
+    ) -> Result<(), ServerError> {
+        if crate::code::forge_rest::review_decision_is_unknown(digest.review_decision.as_deref()) {
+            digest.review_decision = None;
+        }
+        workspace.pr = Some(digest);
+        self.save_workspace(workspace).await
     }
 
     pub async fn run_workspace_action(
@@ -2344,6 +2347,49 @@ mod remote_pr_tests {
             .unwrap()
             .unwrap();
         assert_eq!(stored.live.unwrap().review_decision, None);
+    }
+
+    #[tokio::test]
+    async fn a_created_rest_digest_stays_public_when_refresh_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _, owner, mut workspace) =
+            fixture_with_host(dir.path(), Some("unsupported.example")).await;
+        let mut created = workspace.pr.clone().unwrap();
+        created.review_decision = Some(crate::code::forge_rest::REVIEW_DECISION_UNKNOWN.into());
+        runtime
+            .save_created_workspace_pr(&mut workspace, created)
+            .await
+            .unwrap();
+        assert!(runtime
+            .refresh_workspace_pr(&owner, workspace.id)
+            .await
+            .is_err());
+
+        let stored = runtime.get_workspace(&owner, workspace.id).await.unwrap();
+        assert_eq!(stored.pr.as_ref().unwrap().review_decision, None);
+        let status = runtime.workspace_pr(&owner, workspace.id).await.unwrap();
+        assert_eq!(status.pr.as_ref().unwrap().review_decision, None);
+        let wire = serde_json::to_value(status.pr.unwrap()).unwrap();
+        assert!(wire
+            .get("review_decision")
+            .is_none_or(serde_json::Value::is_null));
+    }
+
+    #[tokio::test]
+    async fn a_created_digest_keeps_an_authoritative_review_decision() {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _, owner, mut workspace) = fixture(dir.path()).await;
+        let mut created = workspace.pr.clone().unwrap();
+        created.review_decision = Some("approved".into());
+        runtime
+            .save_created_workspace_pr(&mut workspace, created)
+            .await
+            .unwrap();
+        let stored = runtime.get_workspace(&owner, workspace.id).await.unwrap();
+        assert_eq!(
+            stored.pr.unwrap().review_decision.as_deref(),
+            Some("approved")
+        );
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -1223,7 +1223,26 @@ impl CodeRuntime {
         if number != digest.number {
             return;
         }
-        let live = tidebreak_core::CodePullRequestLiveState::from_digest(digest, Utc::now());
+        let mut live = tidebreak_core::CodePullRequestLiveState::from_digest(digest, Utc::now());
+        // A REST list that never loaded reviews marks the field unknown so
+        // this write keeps the row's decision, the same way an unloaded
+        // check rollup keeps the checks.
+        if live.review_decision.as_deref() == Some(crate::code::forge_rest::REVIEW_DECISION_UNKNOWN)
+        {
+            live.review_decision = match tidebreak_core::db::code::get_pull_request_fact(
+                &self.db,
+                owner,
+                &host,
+                &repo_owner,
+                &repo_name,
+                number,
+            )
+            .await
+            {
+                Ok(Some(fact)) => fact.live.and_then(|live| live.review_decision),
+                _ => None,
+            };
+        }
         let (changed, stored) = match tidebreak_core::db::code::set_pull_request_live_state(
             &self.db,
             owner,
@@ -1257,6 +1276,11 @@ impl CodeRuntime {
                 .as_deref()
                 .map(tidebreak_core::PullRequestCheckCounts::from_checks);
             digest.checks = stored.checks;
+        }
+        if digest.review_decision.as_deref()
+            == Some(crate::code::forge_rest::REVIEW_DECISION_UNKNOWN)
+        {
+            digest.review_decision = stored.review_decision.clone();
         }
         let digest = &digest;
         // One delivery nudge per real change (decision 66): the delivery
@@ -1830,6 +1854,98 @@ mod remote_pr_tests {
         resolve_external_machine_session(&runtime.db, owner, grant.id, "slack", identity, &session)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn an_unknown_rest_review_decision_keeps_the_live_tier() {
+        use tidebreak_core::db::code::{
+            get_pull_request_fact, save_pull_request_fact, set_pull_request_live_state,
+        };
+        use tidebreak_core::{
+            CodePullRequestFact, CodePullRequestId, CodePullRequestLiveState, CodePullRequestState,
+            PullRequestDigest,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _, owner, _) = fixture(dir.path()).await;
+        let now = Utc::now();
+        let fact = CodePullRequestFact {
+            id: CodePullRequestId::new(),
+            owner: owner.clone(),
+            host: "github.com".into(),
+            repo_owner: "acme".into(),
+            repo_name: "tools".into(),
+            number: 17,
+            url: "https://github.com/acme/tools/pull/17".into(),
+            title: "Stored title".into(),
+            state: CodePullRequestState::Open,
+            draft: false,
+            author: None,
+            head_branch: "feat".into(),
+            base_branch: "main".into(),
+            head_sha: Some("abc".into()),
+            created_at: now,
+            updated_at: now,
+            merged_at: None,
+            closed_at: None,
+            first_seen_at: now,
+            last_seen_at: now,
+            live: None,
+        };
+        save_pull_request_fact(&runtime.db, &fact).await.unwrap();
+        set_pull_request_live_state(
+            &runtime.db,
+            &owner,
+            "github.com",
+            "acme",
+            "tools",
+            17,
+            &CodePullRequestLiveState {
+                checks_summary: None,
+                checks: None,
+                review_decision: Some("changes_requested".into()),
+                mergeable: None,
+                merge_state_status: None,
+                auto_merge_enabled: None,
+                in_merge_queue: None,
+                observed_at: now,
+            },
+        )
+        .await
+        .unwrap();
+        runtime
+            .record_pull_request_live_state(
+                &owner,
+                None,
+                &PullRequestDigest {
+                    number: 17,
+                    url: Some("https://github.com/acme/tools/pull/17".into()),
+                    state: "open".into(),
+                    title: Some("Stored title".into()),
+                    checks_summary: None,
+                    check_counts: None,
+                    checks: None,
+                    draft: Some(false),
+                    merged: Some(false),
+                    review_decision: Some(crate::code::forge_rest::REVIEW_DECISION_UNKNOWN.into()),
+                    mergeable: None,
+                    merge_state_status: None,
+                    head_branch: Some("feat".into()),
+                    base_branch: Some("main".into()),
+                    head_sha: Some("abc".into()),
+                    auto_merge_enabled: None,
+                    in_merge_queue: None,
+                },
+            )
+            .await;
+        let stored = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "tools", 17)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.live.unwrap().review_decision.as_deref(),
+            Some("changes_requested")
+        );
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -1224,11 +1224,10 @@ impl CodeRuntime {
             return;
         }
         let mut live = tidebreak_core::CodePullRequestLiveState::from_digest(digest, Utc::now());
-        // A REST list that never loaded reviews marks the field unknown so
-        // this write keeps the row's decision, the same way an unloaded
-        // check rollup keeps the checks.
-        if live.review_decision.as_deref() == Some(crate::code::forge_rest::REVIEW_DECISION_UNKNOWN)
-        {
+        // REST never derives a review decision (`None` or the unknown
+        // sentinel): keep the row's value the same way an unloaded check
+        // rollup keeps the checks.
+        if crate::code::forge_rest::review_decision_is_unknown(live.review_decision.as_deref()) {
             live.review_decision = match tidebreak_core::db::code::get_pull_request_fact(
                 &self.db,
                 owner,
@@ -1277,9 +1276,7 @@ impl CodeRuntime {
                 .map(tidebreak_core::PullRequestCheckCounts::from_checks);
             digest.checks = stored.checks;
         }
-        if digest.review_decision.as_deref()
-            == Some(crate::code::forge_rest::REVIEW_DECISION_UNKNOWN)
-        {
+        if crate::code::forge_rest::review_decision_is_unknown(digest.review_decision.as_deref()) {
             digest.review_decision = stored.review_decision.clone();
         }
         let digest = &digest;
@@ -1946,6 +1943,215 @@ mod remote_pr_tests {
             stored.live.unwrap().review_decision.as_deref(),
             Some("changes_requested")
         );
+    }
+
+    /// Issue 3339: a REST list never derives a review decision, so the
+    /// reconcile write keeps `changes_requested`. The list restatement is
+    /// `fact_value` (no reviews endpoint); `None` on the digest is the
+    /// keep-the-row marker.
+    #[tokio::test]
+    async fn a_rest_list_reconcile_keeps_changes_requested_without_reading_reviews() {
+        use crate::code::forge_rest;
+        use tidebreak_core::db::code::{
+            get_pull_request_fact, save_pull_request_fact, set_pull_request_live_state,
+        };
+        use tidebreak_core::{
+            CodePullRequestFact, CodePullRequestId, CodePullRequestLiveState, CodePullRequestState,
+            PullRequestDigest,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _, owner, _) = fixture(dir.path()).await;
+        let now = Utc::now();
+        save_pull_request_fact(
+            &runtime.db,
+            &CodePullRequestFact {
+                id: CodePullRequestId::new(),
+                owner: owner.clone(),
+                host: "github.com".into(),
+                repo_owner: "acme".into(),
+                repo_name: "tools".into(),
+                number: 17,
+                url: "https://github.com/acme/tools/pull/17".into(),
+                title: "Stored title".into(),
+                state: CodePullRequestState::Open,
+                draft: false,
+                author: None,
+                head_branch: "feat".into(),
+                base_branch: "main".into(),
+                head_sha: Some("abc".into()),
+                created_at: now,
+                updated_at: now,
+                merged_at: None,
+                closed_at: None,
+                first_seen_at: now,
+                last_seen_at: now,
+                live: None,
+            },
+        )
+        .await
+        .unwrap();
+        set_pull_request_live_state(
+            &runtime.db,
+            &owner,
+            "github.com",
+            "acme",
+            "tools",
+            17,
+            &CodePullRequestLiveState {
+                checks_summary: None,
+                checks: None,
+                review_decision: Some("changes_requested".into()),
+                mergeable: None,
+                merge_state_status: None,
+                auto_merge_enabled: None,
+                in_merge_queue: None,
+                observed_at: now,
+            },
+        )
+        .await
+        .unwrap();
+
+        let rest = serde_json::json!({
+            "number": 17,
+            "html_url": "https://github.com/acme/tools/pull/17",
+            "title": "Stored title",
+            "state": "open",
+            "draft": false,
+            "user": { "login": "mira-chen" },
+            "head": { "ref": "feat", "sha": "abc" },
+            "base": { "ref": "main" },
+        });
+        let listed = forge_rest::fact_value(&rest);
+        assert!(listed["reviewDecision"].is_null());
+        assert!(forge_rest::review_decision_is_unknown(None));
+
+        runtime
+            .record_pull_request_live_state(
+                &owner,
+                None,
+                &PullRequestDigest {
+                    number: 17,
+                    url: Some("https://github.com/acme/tools/pull/17".into()),
+                    state: "open".into(),
+                    title: Some("Stored title".into()),
+                    checks_summary: None,
+                    check_counts: None,
+                    checks: None,
+                    draft: Some(false),
+                    merged: Some(false),
+                    review_decision: None,
+                    mergeable: None,
+                    merge_state_status: None,
+                    head_branch: Some("feat".into()),
+                    base_branch: Some("main".into()),
+                    head_sha: Some("abc".into()),
+                    auto_merge_enabled: None,
+                    in_merge_queue: None,
+                },
+            )
+            .await;
+        let stored = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "tools", 17)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.live.unwrap().review_decision.as_deref(),
+            Some("changes_requested")
+        );
+    }
+
+    /// A merged REST digest must not derive a review decision, so a stale
+    /// `changes_requested` is not written onto the live tier.
+    #[tokio::test]
+    async fn a_merged_rest_digest_does_not_write_a_review_decision() {
+        use tidebreak_core::db::code::{
+            get_pull_request_fact, save_pull_request_fact, set_pull_request_live_state,
+        };
+        use tidebreak_core::{
+            CodePullRequestFact, CodePullRequestId, CodePullRequestLiveState, CodePullRequestState,
+            PullRequestDigest,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _, owner, _) = fixture(dir.path()).await;
+        let now = Utc::now();
+        save_pull_request_fact(
+            &runtime.db,
+            &CodePullRequestFact {
+                id: CodePullRequestId::new(),
+                owner: owner.clone(),
+                host: "github.com".into(),
+                repo_owner: "acme".into(),
+                repo_name: "tools".into(),
+                number: 17,
+                url: "https://github.com/acme/tools/pull/17".into(),
+                title: "Merged title".into(),
+                state: CodePullRequestState::Merged,
+                draft: false,
+                author: None,
+                head_branch: "feat".into(),
+                base_branch: "main".into(),
+                head_sha: Some("abc".into()),
+                created_at: now,
+                updated_at: now,
+                merged_at: Some(now),
+                closed_at: Some(now),
+                first_seen_at: now,
+                last_seen_at: now,
+                live: None,
+            },
+        )
+        .await
+        .unwrap();
+        set_pull_request_live_state(
+            &runtime.db,
+            &owner,
+            "github.com",
+            "acme",
+            "tools",
+            17,
+            &CodePullRequestLiveState {
+                checks_summary: None,
+                checks: None,
+                review_decision: None,
+                mergeable: None,
+                merge_state_status: None,
+                auto_merge_enabled: None,
+                in_merge_queue: None,
+                observed_at: now,
+            },
+        )
+        .await
+        .unwrap();
+
+        let digest = PullRequestDigest {
+            number: 17,
+            url: Some("https://github.com/acme/tools/pull/17".into()),
+            state: "merged".into(),
+            title: Some("Merged title".into()),
+            checks_summary: None,
+            check_counts: None,
+            checks: None,
+            draft: Some(false),
+            merged: Some(true),
+            review_decision: None,
+            mergeable: None,
+            merge_state_status: None,
+            head_branch: Some("feat".into()),
+            base_branch: Some("main".into()),
+            head_sha: Some("abc".into()),
+            auto_merge_enabled: None,
+            in_merge_queue: Some(false),
+        };
+        runtime
+            .record_pull_request_live_state(&owner, None, &digest)
+            .await;
+        let stored = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "tools", 17)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.live.unwrap().review_decision, None);
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspace_delivery.rs
@@ -1224,25 +1224,21 @@ impl CodeRuntime {
             return;
         }
         let mut live = tidebreak_core::CodePullRequestLiveState::from_digest(digest, Utc::now());
-        // REST never derives a review decision: the unknown sentinel keeps
-        // the row's value the same way an unloaded check rollup keeps the
-        // checks. Authoritative `None` (loaded reviews, no objection) clears.
-        if crate::code::forge_rest::review_decision_is_unknown(live.review_decision.as_deref()) {
-            live.review_decision = match tidebreak_core::db::code::get_pull_request_fact(
-                &self.db,
-                owner,
-                &host,
-                &repo_owner,
-                &repo_name,
-                number,
-            )
-            .await
+        // REST never derives a review decision: the unknown sentinel omits
+        // the column on the live-tier write the same way an unloaded check
+        // rollup keeps the checks. Authoritative `None` (loaded reviews, no
+        // objection) still replaces and clears. Do not pre-read the row;
+        // a concurrent authoritative write would be overwritten by a stale
+        // copy, and a failed read would stamp `None`.
+        let review_decision_write =
+            if crate::code::forge_rest::review_decision_is_unknown(live.review_decision.as_deref())
             {
-                Ok(Some(fact)) => fact.live.and_then(|live| live.review_decision),
-                _ => None,
+                live.review_decision = None;
+                tidebreak_core::db::code::PullRequestReviewDecisionWrite::Preserve
+            } else {
+                tidebreak_core::db::code::PullRequestReviewDecisionWrite::Replace
             };
-        }
-        let (changed, stored) = match tidebreak_core::db::code::set_pull_request_live_state(
+        let (changed, stored) = match tidebreak_core::db::code::set_pull_request_live_state_with(
             &self.db,
             owner,
             &host,
@@ -1250,6 +1246,7 @@ impl CodeRuntime {
             &repo_name,
             number,
             &live,
+            review_decision_write,
         )
         .await
         {
@@ -2155,6 +2152,99 @@ mod remote_pr_tests {
                     in_merge_queue: None,
                 },
             )
+            .await;
+        let stored = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "tools", 17)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.live.unwrap().review_decision, None);
+    }
+
+    /// Seeded `changes_requested`, then an authoritative `approved`, then a
+    /// REST unknown write must leave `approved`. A later authoritative
+    /// `None` still clears. No pre-read: preserve is the column omit.
+    #[tokio::test]
+    async fn an_unknown_rest_write_does_not_overwrite_a_fresher_authoritative_decision() {
+        use crate::code::forge_rest;
+        use tidebreak_core::db::code::{get_pull_request_fact, save_pull_request_fact};
+        use tidebreak_core::{
+            CodePullRequestFact, CodePullRequestId, CodePullRequestState, PullRequestDigest,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, _, owner, _) = fixture(dir.path()).await;
+        let now = Utc::now();
+        save_pull_request_fact(
+            &runtime.db,
+            &CodePullRequestFact {
+                id: CodePullRequestId::new(),
+                owner: owner.clone(),
+                host: "github.com".into(),
+                repo_owner: "acme".into(),
+                repo_name: "tools".into(),
+                number: 17,
+                url: "https://github.com/acme/tools/pull/17".into(),
+                title: "Stored title".into(),
+                state: CodePullRequestState::Open,
+                draft: false,
+                author: None,
+                head_branch: "feat".into(),
+                base_branch: "main".into(),
+                head_sha: Some("abc".into()),
+                created_at: now,
+                updated_at: now,
+                merged_at: None,
+                closed_at: None,
+                first_seen_at: now,
+                last_seen_at: now,
+                live: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let digest = |review_decision: Option<&str>| PullRequestDigest {
+            number: 17,
+            url: Some("https://github.com/acme/tools/pull/17".into()),
+            state: "open".into(),
+            title: Some("Stored title".into()),
+            checks_summary: None,
+            check_counts: None,
+            checks: None,
+            draft: Some(false),
+            merged: Some(false),
+            review_decision: review_decision.map(str::to_owned),
+            mergeable: None,
+            merge_state_status: None,
+            head_branch: Some("feat".into()),
+            base_branch: Some("main".into()),
+            head_sha: Some("abc".into()),
+            auto_merge_enabled: None,
+            in_merge_queue: None,
+        };
+        runtime
+            .record_pull_request_live_state(&owner, None, &digest(Some("changes_requested")))
+            .await;
+        runtime
+            .record_pull_request_live_state(&owner, None, &digest(Some("approved")))
+            .await;
+        runtime
+            .record_pull_request_live_state(
+                &owner,
+                None,
+                &digest(Some(forge_rest::REVIEW_DECISION_UNKNOWN)),
+            )
+            .await;
+        let stored = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "tools", 17)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.live.unwrap().review_decision.as_deref(),
+            Some("approved")
+        );
+        runtime
+            .record_pull_request_live_state(&owner, None, &digest(None))
             .await;
         let stored = get_pull_request_fact(&runtime.db, &owner, "github.com", "acme", "tools", 17)
             .await


### PR DESCRIPTION
Hosted REST reads do not load the review information and branch rules needed to derive a review decision. Reconcile previously replaced the conditional fetcher's decision, which could incorrectly clear a required review or approve a pull request too early.

REST observations now preserve `review_decision` by omitting that column from the database update. The conditional fetcher remains authoritative, including `None` when a decision must clear. Existing setter callers keep replacement semantics. The private unknown marker stays out of public fact summaries and is removed before persisting a newly created workspace pull request, even when the subsequent refresh fails.

Local workspace status carries the persisted digest unchanged. This removes its unreachable digest write-back branch and corrects the helper's documentation. That cleanup addresses the stale-status branch portion of #3347; the other worktree audit findings remain separate.

Validation:
- Remote workspace delivery tests: 13 passed, including failed creation refresh, authoritative decision retention, REST preservation, and authoritative clearing.
- Local status persisted-digest test: 1 passed.
- `cargo clippy -p tidebreak-core -p tidebreak-server-core --lib --tests -- -D warnings`: passed.
- `cargo fmt --all --check` and `git diff --check`: passed.

No database schema or public wire shape changes. The explicit preservation policy only applies to unloaded REST review decisions.

Closes #3339
Refs #3347