### PR TITLE
fix(code): bound git and log output, let external clones retry, and stop clones re-pointing the shared parent dir

### DIFF
--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -1035,7 +1035,15 @@ async fn collect_changes(
     to: &str,
     bounds: DiffBounds,
 ) -> Result<BoundedFiles, CheckpointError> {
-    collect_changes_inner(worktree, from, to, bounds, None).await
+    collect_changes_inner(
+        worktree,
+        from,
+        to,
+        bounds,
+        None,
+        OutputBudget::head(GIT_OUTPUT_BYTES, GIT_OUTPUT_LINES),
+    )
+    .await
 }
 
 async fn collect_changes_for_paths(
@@ -1053,6 +1061,7 @@ async fn collect_changes_for_paths(
             max_files: usize::MAX,
         },
         Some(paths),
+        OutputBudget::head(GIT_OUTPUT_BYTES, GIT_OUTPUT_LINES),
     )
     .await
 }
@@ -1063,6 +1072,7 @@ async fn collect_changes_inner(
     to: &str,
     bounds: DiffBounds,
     paths: Option<&[GitPath]>,
+    output_budget: OutputBudget,
 ) -> Result<BoundedFiles, CheckpointError> {
     let name_status_args = [
         "diff",
@@ -1074,29 +1084,45 @@ async fn collect_changes_inner(
         "--",
     ];
     let numstat_args = ["diff", "--numstat", "-z", "--find-renames", from, to, "--"];
-    let name_status = match paths {
+    let (name_status, name_truncated) = match paths {
         Some(paths) => {
-            git_bytes_with_literal_paths(worktree, &name_status_args, paths, GIT_TIMEOUT).await
+            git_bytes_with_literal_paths_bounded(
+                worktree,
+                &name_status_args,
+                paths,
+                GIT_TIMEOUT,
+                output_budget,
+            )
+            .await
         }
         None => {
-            git_bytes(
+            git_bytes_bounded(
                 worktree,
                 &name_status_args[..name_status_args.len() - 1],
                 GIT_TIMEOUT,
+                output_budget,
             )
             .await
         }
     }
     .map_err(CheckpointError::internal)?;
-    let numstat = match paths {
+    let (numstat, numstat_truncated) = match paths {
         Some(paths) => {
-            git_bytes_with_literal_paths(worktree, &numstat_args, paths, GIT_TIMEOUT).await
+            git_bytes_with_literal_paths_bounded(
+                worktree,
+                &numstat_args,
+                paths,
+                GIT_TIMEOUT,
+                output_budget,
+            )
+            .await
         }
         None => {
-            git_bytes(
+            git_bytes_bounded(
                 worktree,
                 &numstat_args[..numstat_args.len() - 1],
                 GIT_TIMEOUT,
+                output_budget,
             )
             .await
         }
@@ -1122,8 +1148,8 @@ async fn collect_changes_inner(
         .iter()
         .map(|file| file.deletions)
         .fold(0u32, u32::saturating_add);
-    let truncated = total_files > bounds.max_files;
-    if truncated {
+    let truncated = total_files > bounds.max_files || name_truncated || numstat_truncated;
+    if total_files > bounds.max_files {
         files.truncate(bounds.max_files);
     }
     Ok(BoundedFiles {
@@ -1289,8 +1315,15 @@ async fn git_text_env_before(
     Ok(String::from_utf8_lossy(&bytes).trim().to_owned())
 }
 
-async fn git_bytes(cwd: &Path, args: &[&str], limit: Duration) -> Result<Vec<u8>, String> {
-    git_bytes_env(cwd, args, &[], limit).await
+async fn git_bytes_bounded(
+    cwd: &Path,
+    args: &[&str],
+    limit: Duration,
+    stdout_budget: OutputBudget,
+) -> Result<(Vec<u8>, bool), String> {
+    let mut command = git_command(cwd);
+    command.args(args);
+    run_git_command_bounded(command, args.join(" "), limit, stdout_budget, true).await
 }
 
 async fn git_bytes_env(
@@ -1338,29 +1371,6 @@ async fn git_bytes_env_before(
     } else {
         Ok(stdout)
     }
-}
-
-async fn git_bytes_with_literal_paths(
-    cwd: &Path,
-    args: &[&str],
-    paths: &[GitPath],
-    limit: Duration,
-) -> Result<Vec<u8>, String> {
-    let mut command = git_command(cwd);
-    command.arg("--literal-pathspecs").args(args);
-    for path in paths {
-        command.arg(path.to_os_string()?);
-    }
-    run_git_command(
-        command,
-        format!(
-            "--literal-pathspecs {} <{} paths>",
-            args.join(" "),
-            paths.len()
-        ),
-        limit,
-    )
-    .await
 }
 
 async fn git_bytes_with_literal_paths_bounded(
@@ -2022,6 +2032,33 @@ mod tests {
             (1, 2, 0)
         );
         assert!(!diff.stat.truncated);
+    }
+
+    #[tokio::test]
+    async fn an_oversized_name_status_truncates_instead_of_failing_the_checkpoint() {
+        let (_dir, repo) = init_repo();
+        let tree = add_worktree(&repo, "huge-name-status");
+        for index in 0..80 {
+            std::fs::write(tree.join(format!("file-{index:02}.txt")), "changed\n").unwrap();
+        }
+        let recorded =
+            record_checkpoint(&tree, ws(), sess(), 1, TurnStatus::Completed, None, "main")
+                .await
+                .unwrap();
+        let from = merge_base(&tree, "main").await.unwrap();
+        let listed = collect_changes_inner(
+            &tree,
+            &from,
+            &recorded.checkpoint_ref,
+            DiffBounds::default(),
+            None,
+            OutputBudget::head(64, 4),
+        )
+        .await
+        .expect("truncated name-status must still record");
+        assert!(listed.truncated);
+        assert!(listed.stat.truncated);
+        assert!(!listed.files.is_empty());
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/ci_logs.rs
+++ b/crates/tidebreak-server/src/code/ci_logs.rs
@@ -4,8 +4,8 @@
 //! The fix-errors action used to hand an agent check names and URLs and let it
 //! find the logs itself: two or three `gh` calls before it saw an error line,
 //! and then a whole multi-megabyte job log in one read. This module does that
-//! fetch on the agent's behalf. The fetch itself is unbounded; only the
-//! rendered output is capped.
+//! fetch on the agent's behalf. The fetch is byte-capped; rendered output is
+//! capped again so the file keeps the failure tail.
 //!
 //! Files land under the workspace's private root, beside fork transcripts, so
 //! Git cannot index them and the session's `allowed_read_roots` already covers
@@ -19,6 +19,7 @@ use futures::{stream, StreamExt};
 use tidebreak_core::{PullRequestCheck, PullRequestCheckBucket};
 
 use super::gh;
+use tidebreak_harness::OutputBudget;
 
 /// Directory holding downloaded job logs below the workspace's private root.
 const CI_LOGS_DIR: &str = "ci-logs";
@@ -212,7 +213,8 @@ pub(crate) async fn write_failing_check_logs(
                 continue;
             }
         };
-        let rendered = render_job_log(&check, &url, head_sha, &raw);
+        let rendered = render_job_log(&check, &url, head_sha, &raw.text);
+        let truncated = rendered.truncated || raw.truncated;
         let name = log_file_name(&check, job.job_id);
         dir.publish(std::ffi::OsStr::new(&name), rendered.text.as_bytes())
             .await?;
@@ -225,7 +227,7 @@ pub(crate) async fn write_failing_check_logs(
                 .display()
                 .to_string(),
             byte_len: rendered.text.len() as u64,
-            truncated: rendered.truncated,
+            truncated,
             url,
         });
         written_names.push(name);
@@ -247,7 +249,12 @@ pub(crate) async fn write_failing_check_logs(
     Ok(WrittenCheckLogs { logs, failures })
 }
 
-async fn fetch_job_log(binary: &Path, job: &JobRef) -> Result<String, String> {
+struct FetchedLog {
+    text: String,
+    truncated: bool,
+}
+
+async fn fetch_job_log(binary: &Path, job: &JobRef) -> Result<FetchedLog, String> {
     let endpoint = job.endpoint();
     let mut args = vec!["api".to_owned(), endpoint];
     if job.host != "github.com" {
@@ -255,8 +262,31 @@ async fn fetch_job_log(binary: &Path, job: &JobRef) -> Result<String, String> {
     }
     let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
     // `cwd` is unused by an absolute REST read, and this runs for a workspace
-    // whose worktree may be mid-rebase.
-    gh::run_gh(Path::new("."), binary, &borrowed, GH_LOG_TIMEOUT).await
+    // whose worktree may be mid-rebase. The fetch itself is capped: a job log
+    // can be many megabytes, and only the tail is worth keeping.
+    let output = gh::run_gh_capped(
+        Path::new("."),
+        binary,
+        &borrowed,
+        GH_LOG_TIMEOUT,
+        OutputBudget::tail(MAX_JOB_LOG_BYTES, usize::MAX),
+        OutputBudget::tail(64 * 1024, 2_048),
+    )
+    .await?;
+    let truncated = output.stdout.truncated;
+    let text =
+        if output.status.success() || (output.terminated_for_output && output.stdout.truncated) {
+            output.stdout.into_marked_text()
+        } else {
+            let stderr = output.stderr.into_marked_text();
+            let stdout = output.stdout.into_marked_text();
+            return Err(if stderr.trim().is_empty() {
+                stdout
+            } else {
+                stderr
+            });
+        };
+    Ok(FetchedLog { text, truncated })
 }
 
 struct RenderedLog {
@@ -557,5 +587,33 @@ mod tests {
         assert!(written.logs.is_empty());
         assert!(written.failures.is_empty());
         assert!(!root.path().join(CI_LOGS_DIR).join(old_name).exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn job_log_fetch_truncates_unbounded_output() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().expect("temp root");
+        let gh = directory.path().join("gh");
+        std::fs::write(&gh, "#!/bin/sh\nhead -c 800000 /dev/zero | tr '\\0' 'x'\n").unwrap();
+        let mut permissions = std::fs::metadata(&gh).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&gh, permissions).unwrap();
+
+        let fetched = fetch_job_log(
+            &gh,
+            &JobRef {
+                host: "github.com".into(),
+                owner: "acme".into(),
+                repo: "tools".into(),
+                job_id: 1,
+            },
+        )
+        .await
+        .expect("capped fetch");
+        assert!(fetched.truncated);
+        assert!(fetched.text.contains("[output truncated]"));
+        assert!(fetched.text.len() <= MAX_JOB_LOG_BYTES + 32);
     }
 }

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -395,7 +395,12 @@ impl CodeRuntime {
         attribution: crate::obo_gateway::GitForgeAttributionRequest,
         lender: Option<std::sync::Arc<dyn crate::obo_gateway::GitCredentialLender>>,
     ) -> Result<CodeCloneJobSnapshot, ServerError> {
-        let parent = self.clone_parent(request.parent_dir.as_deref()).await?;
+        let requested_parent = request
+            .parent_dir
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let parent = self.clone_parent(requested_parent).await?;
         validate_parent_dir(&parent).await?;
         let source = resolve_clone_source(
             &request,
@@ -438,7 +443,12 @@ impl CodeRuntime {
                 format!("destination {} already exists", legacy_target.display()),
             ));
         }
-        write_clone_parent_dir(&*self.db, &parent).await?;
+        // The parent-dir setting is process-wide. Persist it only when this
+        // caller named a destination; a default-parent clone must not re-point
+        // everyone else's remembered path.
+        if requested_parent.is_some() {
+            write_clone_parent_dir(&*self.db, &parent).await?;
+        }
         tokio::fs::create_dir_all(target.parent().expect("clone target has a parent"))
             .await
             .map_err(|error| {
@@ -1326,6 +1336,86 @@ mod tests {
             external_origin: None,
             finished_at,
         }
+    }
+
+    async fn test_runtime(dir: &tempfile::TempDir) -> std::sync::Arc<CodeRuntime> {
+        let db = std::sync::Arc::new(
+            tidebreak_core::DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("code.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        std::sync::Arc::new(
+            CodeRuntime::new(db, dir.path().into(), None, None, None, None, None, None)
+                .with_clone_parent_default(dir.path().join("default-parent")),
+        )
+    }
+
+    #[tokio::test]
+    async fn a_default_parent_clone_does_not_repoint_another_users_parent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = test_runtime(&dir).await;
+        let alice = OwnerId::local();
+        let bob = OwnerId::new("user:bob").unwrap();
+        let alice_parent = dir.path().join("alice-repos");
+        std::fs::create_dir_all(&alice_parent).unwrap();
+        std::fs::create_dir_all(dir.path().join("default-parent")).unwrap();
+
+        assert_eq!(runtime.clone_defaults().await.unwrap().parent_dir, None);
+        runtime
+            .start_clone(
+                &bob,
+                CloneRequest {
+                    url: Some("https://github.com/acme/demo.git".into()),
+                    github: None,
+                    parent_dir: None,
+                    name: Some("bob-default".into()),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            runtime.clone_defaults().await.unwrap().parent_dir,
+            None,
+            "a clone that used the machine default must not persist it as everyone's parent"
+        );
+
+        runtime
+            .start_clone(
+                &alice,
+                CloneRequest {
+                    url: Some("https://github.com/acme/demo.git".into()),
+                    github: None,
+                    parent_dir: Some(alice_parent.display().to_string()),
+                    name: Some("alice-copy".into()),
+                },
+            )
+            .await
+            .unwrap();
+        let alice_default = runtime.clone_defaults().await.unwrap().parent_dir;
+        assert_eq!(
+            alice_default.as_deref(),
+            Some(alice_parent.display().to_string().as_str())
+        );
+
+        runtime
+            .start_clone(
+                &bob,
+                CloneRequest {
+                    url: Some("https://github.com/acme/demo.git".into()),
+                    github: None,
+                    parent_dir: None,
+                    name: Some("bob-copy".into()),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            runtime.clone_defaults().await.unwrap().parent_dir,
+            alice_default
+        );
     }
 
     #[test]

--- a/crates/tidebreak-server/src/code/clone/external.rs
+++ b/crates/tidebreak-server/src/code/clone/external.rs
@@ -99,14 +99,20 @@ impl CodeRuntime {
         let previous = {
             let mut jobs = self.clone_jobs.jobs.lock().expect("clone jobs");
             prune_completed_jobs(&mut jobs, Instant::now());
-            jobs.values()
-                .find(|job| &job.owner == owner && job.external_origin.as_deref() == Some(&origin))
+            let matching = jobs
+                .values()
+                .filter(|job| {
+                    &job.owner == owner && job.external_origin.as_deref() == Some(&origin)
+                })
                 .cloned()
+                .collect::<Vec<_>>();
+            matching
+                .iter()
+                .find(|job| !job.done)
+                .cloned()
+                .or_else(|| matching.into_iter().find(|job| job.error.is_none()))
         };
         if let Some(job) = previous {
-            if let Some(error) = job.error {
-                return Err(ServerError::conflict_kind("repository_clone_failed", error));
-            }
             if job.done {
                 return Err(ServerError::conflict_kind("repo_removed", "This repository registration was removed. Register it again before starting a session."));
             }
@@ -181,18 +187,18 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(first.kind(), "repository_preparing");
+        let job_id = {
+            let jobs = runtime.clone_jobs.jobs.lock().expect("clone jobs");
+            jobs.values()
+                .find(|job| job.owner == owner)
+                .map(|job| job.id)
+                .expect("clone job")
+        };
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            let error = runtime
-                .prepare_external_repository(
-                    &owner,
-                    grant,
-                    "ACME/Tools",
-                    GitForgeAttributionRequest::Installation,
-                )
-                .await
-                .unwrap_err();
-            if error.kind() == "repository_clone_failed" {
+            let snapshot = runtime.get_clone_job(&owner, job_id).unwrap();
+            if snapshot.done {
+                assert!(snapshot.error.is_some());
                 break;
             }
             assert!(Instant::now() < deadline, "clone did not finish");
@@ -220,5 +226,67 @@ mod tests {
             "one owner's failed job must not be reused by another owner"
         );
         assert_eq!(runtime.clone_jobs.jobs.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_failed_external_clone_can_be_retried() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Arc::new(
+            tidebreak_core::DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("code.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let lender = Arc::new(FakeLender::refusing(GitForgeError::RepositoryNotInstalled));
+        let runtime = Arc::new(
+            CodeRuntime::new(db, dir.path().into(), None, None, None, None, None, None)
+                .with_git_credentials(lender)
+                .with_clone_parent_default(dir.path().into()),
+        );
+        let owner = OwnerId::new("user:slack-service").unwrap();
+        let grant = tidebreak_core::CodeGrantId::new();
+        let first = runtime
+            .prepare_external_repository(
+                &owner,
+                grant,
+                "acme/tools",
+                GitForgeAttributionRequest::Installation,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(first.kind(), "repository_preparing");
+        let job_id = {
+            let jobs = runtime.clone_jobs.jobs.lock().expect("clone jobs");
+            jobs.values()
+                .find(|job| job.owner == owner)
+                .map(|job| job.id)
+                .expect("clone job")
+        };
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let snapshot = runtime.get_clone_job(&owner, job_id).unwrap();
+            if snapshot.done {
+                assert!(snapshot.error.is_some());
+                break;
+            }
+            assert!(Instant::now() < deadline, "clone did not finish");
+            tokio::task::yield_now().await;
+        }
+        let after_failure = runtime
+            .prepare_external_repository(
+                &owner,
+                grant,
+                "acme/tools",
+                GitForgeAttributionRequest::Installation,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            after_failure.kind(),
+            "repository_preparing",
+            "a failed job must not block a later clone of the same origin"
+        );
     }
 }

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -16,7 +16,9 @@ use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 
 use tidebreak_core::{Diffstat, PullRequestDigest, QuickAction};
-use tidebreak_harness::{filter_child_env, probe_shell, HostEnv, OutputBudget};
+use tidebreak_harness::{
+    filter_child_env, probe_shell, spawn_process_tree, BoundedProcessOutput, HostEnv, OutputBudget,
+};
 
 use super::setup_script::{missing_image_toolchain_notice, spawn_workspace_script};
 use crate::code::types::CodeGitHubRepositoryTarget;
@@ -30,6 +32,10 @@ const MAX_OUTPUT_CHARS: usize = 4_096;
 const MAX_UNTRACKED_DIFFSTAT_BYTES: u64 = 1024 * 1024;
 const MAX_ACTION_OUTPUT_BYTES: usize = 4_096;
 const MAX_ACTION_OUTPUT_LINES: usize = 256;
+const GIT_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+const GIT_OUTPUT_LINES: usize = 200_000;
+const GIT_ERROR_BYTES: usize = 64 * 1024;
+const GIT_ERROR_LINES: usize = 2_048;
 const GH_OBSERVATION_TTL: Duration = Duration::from_secs(30);
 pub const GH_UNAVAILABLE_PREFIX: &str = "gh_unavailable: ";
 pub const PR_HEAD_CHANGED_PREFIX: &str = "pr_head_changed: ";
@@ -1735,6 +1741,41 @@ fn classify_gh(
     GhError::user(format!("gh failed: {err}"))
 }
 
+pub(crate) async fn wait_command_bounded(
+    command: &mut Command,
+    limit: Duration,
+    stdout_budget: OutputBudget,
+    stderr_budget: OutputBudget,
+    description: &str,
+) -> Result<BoundedProcessOutput, String> {
+    let child = spawn_process_tree(command)
+        .map_err(|err| format!("failed to spawn {description}: {err}"))?;
+    timeout(
+        limit,
+        child.wait_with_bounded_output(stdout_budget, stderr_budget, true),
+    )
+    .await
+    .map_err(|_| format!("{description} timed out"))?
+    .map_err(|err| format!("{description} failed: {err}"))
+}
+
+fn finish_bounded_command(
+    output: BoundedProcessOutput,
+    accept_truncated_stdout: bool,
+) -> Result<String, String> {
+    let stdout_truncated = output.stdout.truncated;
+    let stderr_empty = output.stderr.bytes.is_empty();
+    let stdout = output.stdout.into_marked_text().trim().to_owned();
+    let stderr = output.stderr.into_marked_text().trim().to_owned();
+    if output.status.success() && !output.terminated_for_output {
+        return Ok(stdout);
+    }
+    if output.terminated_for_output && accept_truncated_stdout && stdout_truncated && stderr_empty {
+        return Ok(stdout);
+    }
+    Err(if stderr.is_empty() { stdout } else { stderr })
+}
+
 async fn git(cwd: &Path, args: &[&str], limit: Duration) -> Result<String, String> {
     git_with_credential(cwd, args, limit, None).await
 }
@@ -1762,20 +1803,15 @@ async fn git_with_credential(
             .env(GIT_CREDENTIAL_SECRET_ENV, &credential.secret)
             .env(GIT_CREDENTIAL_HOST_ENV, GIT_CREDENTIAL_FORGE_HOST);
     }
-    let child = command
-        .spawn()
-        .map_err(|err| format!("failed to spawn git: {err}"))?;
-    let output = timeout(limit, child.wait_with_output())
-        .await
-        .map_err(|_| format!("git {} timed out", args.join(" ")))?
-        .map_err(|err| format!("git {} failed: {err}", args.join(" ")))?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if output.status.success() {
-        Ok(stdout)
-    } else {
-        Err(if stderr.is_empty() { stdout } else { stderr })
-    }
+    let output = wait_command_bounded(
+        &mut command,
+        limit,
+        OutputBudget::head(GIT_OUTPUT_BYTES, GIT_OUTPUT_LINES),
+        OutputBudget::tail(GIT_ERROR_BYTES, GIT_ERROR_LINES),
+        &format!("git {}", args.join(" ")),
+    )
+    .await?;
+    finish_bounded_command(output, true)
 }
 
 /// General `gh` runner for creation, status, and comment reads — every
@@ -2290,6 +2326,50 @@ async fn spawn_gh_output(
         .map_err(|err| format!("gh {} failed: {err}", args.join(" ")))
 }
 
+/// `gh` with bounded stdout/stderr. Job-log fetches use this so a huge log
+/// cannot grow without a cap.
+pub(crate) async fn run_gh_capped(
+    cwd: &Path,
+    binary: &Path,
+    args: &[&str],
+    limit: Duration,
+    stdout_budget: OutputBudget,
+    stderr_budget: OutputBudget,
+) -> Result<BoundedProcessOutput, String> {
+    if refuse_gh_args(args) {
+        return Err("refusing to run a merge or GraphQL gh command".into());
+    }
+    let login_env = GH_LAUNCH
+        .get()
+        .filter(|launch| launch.binary == binary)
+        .and_then(|launch| launch.login_env.as_deref().map(Vec::as_slice));
+    let mut command = Command::new(binary);
+    if let Some(login_env) = login_env {
+        command.env_clear();
+        for (key, value) in filter_child_env(login_env.iter().cloned()) {
+            command.env(key, value);
+        }
+    }
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .env("GH_PROMPT_DISABLED", "1")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GH_NO_UPDATE_NOTIFIER", "1");
+    wait_command_bounded(
+        &mut command,
+        limit,
+        stdout_budget,
+        stderr_budget,
+        &format!("gh {}", args.join(" ")),
+    )
+    .await
+}
+
 /// One `gh api --include` answer: the status line, the caching and pacing
 /// headers the fetcher acts on, and the body.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2592,6 +2672,31 @@ mod tests {
             generate_commit_message("first change", &stat),
             generate_commit_message("first change", &stat)
         );
+    }
+
+    #[tokio::test]
+    async fn git_output_beyond_the_cap_is_truncated() {
+        let mut command = Command::new("head");
+        command
+            .args(["-c", "4096", "/dev/zero"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let output = wait_command_bounded(
+            &mut command,
+            Duration::from_secs(5),
+            OutputBudget::head(64, 8),
+            OutputBudget::tail(64, 8),
+            "python3",
+        )
+        .await
+        .unwrap();
+        assert!(output.stdout.truncated);
+        assert!(output.stdout.bytes.len() <= 64);
+        let marked = output.stdout.clone().into_marked_text();
+        assert!(marked.contains("[output truncated]"));
+        let finished = finish_bounded_command(output, true).unwrap();
+        assert!(finished.contains("[output truncated]"));
     }
 
     #[test]


### PR DESCRIPTION
## What was wrong

1. `start_clone_as` always persisted `CLONE_PARENT_DIR_SETTING` from the resolved parent directory. On a multi-user host, a clone that used the machine default rewrote the shared setting for everyone.
2. `prepare_external_repository` returned `repository_clone_failed` for as long as the failed job row survived (30 minutes), so a transient failure wedged adapter-initiated sessions with no retry.
3. `gh.rs` git and `ci_logs.rs` job-log fetch used unbounded `wait_with_output()`.
4. `collect_changes_inner` treated a git name-status/numstat over the 8 MB cap as a hard error, so `record_checkpoint` failed instead of recording a truncated stat.

## What changed

- Write the clone parent setting only when the caller explicitly named a parent directory. Settings are process-wide, not per-user.
- Ignore failed clone jobs when matching an origin so a later request starts a fresh clone. In-flight jobs still return `repository_preparing`.
- Run git (and job-log `gh`) through `wait_with_bounded_output`, mark truncation, and keep a truncated success rather than growing without a cap.
- Accept truncated git list output in `collect_changes_inner` and set `truncated` on the checkpoint diffstat.

Part of #3347

## Checks

- `cargo fmt --all` — formatted
- `cargo check -p tidebreak-server` — ok
- `cargo test -p tidebreak-server-core clone` — 16 passed
- `cargo test -p tidebreak-server-core gh` — `git_output_beyond_the_cap_is_truncated` passed; filter also ran unrelated `obo_gateway` test that failed on a local token-exchange URL (not this change)
- `cargo test -p tidebreak-server-core ci_logs` — 12 passed
- `cargo test -p tidebreak-server-core checkpoint` — 34 passed
- `cargo clippy -p tidebreak-server-core --all-targets -- -D warnings -A clippy::too_many_arguments` — ok
- `cargo clippy -p tidebreak-server --all-targets -- -D warnings -A clippy::too_many_arguments` — ok

Unit tests live in `tidebreak-server-core`. `cargo test -p tidebreak-server clone` also matches API integration tests that wait on live clone jobs; those were not used as the focused check.