### PR TITLE
fix(exec): never delete under a staged subtree the write-back walk could not observe, and bound the walks

### DIFF
--- a/crates/tidebreak-code-execution/src/host_paths.rs
+++ b/crates/tidebreak-code-execution/src/host_paths.rs
@@ -175,7 +175,7 @@ fn resolve_blocking(root: &Path, relative: &str, create: bool) -> Result<Dir, Sc
             // refusal to report, and it too is relative to the pinned parent.
             Err(_) => match directory.symlink_metadata(component) {
                 Ok(metadata) if metadata.is_symlink() => {
-                    return Err(ScratchRefusal::SymlinkedComponent)
+                    return Err(ScratchRefusal::SymlinkedComponent);
                 }
                 Ok(metadata) if !metadata.is_dir() => return Err(ScratchRefusal::NotADirectory),
                 Ok(_) => return Err(ScratchRefusal::Unavailable),
@@ -338,28 +338,11 @@ impl ScratchDir {
     /// The entries directly inside this directory, classified without following
     /// a symlink. Names that are not valid UTF-8 are dropped: every path this
     /// crate carries is UTF-8, and a name that cannot be represented is a name
-    /// no later operation could address.
+    /// no later operation could address. If an entry cannot be classified,
+    /// return an error so a partial listing cannot imply that files are absent.
     pub async fn entries(&self) -> io::Result<Vec<ScratchEntry>> {
-        self.blocking(|directory| {
-            let mut entries = Vec::new();
-            for entry in directory.entries()? {
-                let entry = entry?;
-                let Ok(name) = entry.file_name().into_string() else {
-                    continue;
-                };
-                let kind = match directory.symlink_metadata(&name) {
-                    Ok(metadata) if metadata.is_symlink() => ScratchEntryKind::Other,
-                    Ok(metadata) if metadata.is_dir() => ScratchEntryKind::Directory,
-                    Ok(metadata) if metadata.is_file() => ScratchEntryKind::File,
-                    Ok(_) => ScratchEntryKind::Other,
-                    Err(_) => continue,
-                };
-                entries.push(ScratchEntry { name, kind });
-            }
-            entries.sort_by(|left, right| left.name.cmp(&right.name));
-            Ok(entries)
-        })
-        .await
+        self.blocking(|directory| classify_entries(directory, directory.entries()?))
+            .await
     }
 
     /// The length and modification time of `name`, judged without following a
@@ -444,6 +427,32 @@ impl ScratchDir {
             .await
             .map_err(|_| io::Error::other("scratch operation did not complete"))?
     }
+}
+
+fn classify_entries(
+    directory: &Dir,
+    entries: impl IntoIterator<Item = io::Result<cap_std::fs::DirEntry>>,
+) -> io::Result<Vec<ScratchEntry>> {
+    let mut classified = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        let metadata = directory.symlink_metadata(&name)?;
+        let kind = if metadata.is_symlink() {
+            ScratchEntryKind::Other
+        } else if metadata.is_dir() {
+            ScratchEntryKind::Directory
+        } else if metadata.is_file() {
+            ScratchEntryKind::File
+        } else {
+            ScratchEntryKind::Other
+        };
+        classified.push(ScratchEntry { name, kind });
+    }
+    classified.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(classified)
 }
 
 fn write_blocking(
@@ -581,6 +590,37 @@ fn single_component(name: &str) -> io::Result<String> {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_entry_that_loses_search_permission_does_not_become_an_absent_file() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("keep.txt"), b"original").unwrap();
+        let directory = Dir::open_ambient_dir(root.path(), cap_std::ambient_authority()).unwrap();
+        let entries = directory.entries().unwrap();
+        let mut observed = 0;
+        // Change permissions after enumeration succeeds, at the boundary where
+        // another process can make an existing entry impossible to classify.
+        let raced = entries.inspect(|entry| {
+            assert!(entry.is_ok());
+            observed += 1;
+            std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o400)).unwrap();
+        });
+        let result = classify_entries(&directory, raced);
+        let search_denied = directory.symlink_metadata("keep.txt").is_err();
+        std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(observed, 1);
+        if !search_denied {
+            // Elevated privileges can bypass the directory search restriction.
+            return;
+        }
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            std::fs::read(root.path().join("keep.txt")).unwrap(),
+            b"original"
+        );
+    }
 
     #[tokio::test]
     async fn a_symlinked_component_refuses_instead_of_being_followed() {

--- a/crates/tidebreak-code-execution/src/overlay.rs
+++ b/crates/tidebreak-code-execution/src/overlay.rs
@@ -77,6 +77,45 @@ const MAX_OVERLAY_DEPTH: usize = 24;
 /// Ceiling on one staged file's size when it is written back.
 const MAX_STAGED_FILE_BYTES: u64 = 64 * 1_024 * 1_024;
 
+/// The bounds one overlay walk honors. Staging and write-back share the same
+/// ceilings, so a tree that staged also writes back in full, and a tree the
+/// agent grew past them at write-back stops where staging would have.
+#[derive(Clone, Copy)]
+struct WalkLimits {
+    entries: usize,
+    depth: usize,
+}
+
+const WALK_LIMITS: WalkLimits = WalkLimits {
+    entries: MAX_OVERLAY_ENTRIES,
+    depth: MAX_OVERLAY_DEPTH,
+};
+
+/// What the write-back walk saw, and where it could not look.
+///
+/// Deletion is judged against this rather than against the manifest alone:
+/// a manifest file the walk never observed is not evidence the agent removed
+/// it. Any prefix the walk could not list, open, or reach within its bounds
+/// is unobservable, and nothing under it is a deletion candidate. An empty
+/// prefix covers the whole slot.
+#[derive(Default)]
+struct Observed {
+    files: std::collections::HashSet<String>,
+    unobservable: Vec<String>,
+}
+
+impl Observed {
+    fn unobservable(&self, relative: &str) -> bool {
+        self.unobservable.iter().any(|prefix| {
+            prefix.is_empty()
+                || relative == prefix
+                || relative
+                    .strip_prefix(prefix.as_str())
+                    .is_some_and(|rest| rest.starts_with('/'))
+        })
+    }
+}
+
 /// Maximum paths included in one model-visible overlay note.
 const MAX_REPORTED_INERT_PATHS: usize = 8;
 
@@ -200,6 +239,9 @@ pub enum RejectedChangeReason {
     TrashUnavailable,
     /// A filesystem operation failed or found an unsupported entry.
     Unavailable,
+    /// The write-back walk stopped at its entry or depth ceiling before
+    /// reaching this path, so what the overlay holds there was never read.
+    WalkLimit,
 }
 
 /// What the destination must contain when one file is materialized.
@@ -473,21 +515,41 @@ impl WriteOverlay {
         snapshots: Option<&dyn WriteSnapshotSink>,
         trash: &dyn TrashSink,
     ) -> OverlayOutcome {
+        self.materialize_within(snapshots, trash, WALK_LIMITS).await
+    }
+
+    async fn materialize_within(
+        self,
+        snapshots: Option<&dyn WriteSnapshotSink>,
+        trash: &dyn TrashSink,
+        limits: WalkLimits,
+    ) -> OverlayOutcome {
         let mut outcome = OverlayOutcome::default();
         let trash_staging = self.home.join(".trash-staging");
         for slot in &self.slots {
-            let mut seen = Vec::new();
+            let mut observed = Observed::default();
+            let mut entry_count = 0;
             apply_directory(
                 slot,
                 "",
                 &slot.overlay_dir,
                 snapshots,
-                &mut seen,
+                &mut observed,
+                &mut entry_count,
                 0,
+                limits,
                 &mut outcome,
             )
             .await;
-            apply_deletions(slot, snapshots, trash, &trash_staging, &seen, &mut outcome).await;
+            apply_deletions(
+                slot,
+                snapshots,
+                trash,
+                &trash_staging,
+                &observed,
+                &mut outcome,
+            )
+            .await;
         }
         self.discard().await;
         outcome
@@ -782,27 +844,47 @@ fn quoted(value: &str) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "\"<unprintable>\"".to_owned())
 }
 
+/// Walk one overlay directory, writing back what changed. Returns `false`
+/// when the walk hit its entry ceiling, which stops every caller up the
+/// stack: past that point nothing is observed, and the slot is marked so
+/// that [`apply_deletions`] removes nothing.
+#[allow(clippy::too_many_arguments)]
 async fn apply_directory(
     slot: &OverlaySlot,
     prefix: &str,
     directory: &ScratchDir,
     snapshots: Option<&dyn WriteSnapshotSink>,
-    seen: &mut Vec<String>,
+    observed: &mut Observed,
+    entry_count: &mut usize,
     depth: usize,
+    limits: WalkLimits,
     outcome: &mut OverlayOutcome,
-) {
-    if depth > MAX_OVERLAY_DEPTH {
-        return;
+) -> bool {
+    if depth > limits.depth {
+        // A directory the agent nested past the ceiling: staging would not
+        // have recorded it either, so nothing under it is deletable, but the
+        // agent's changes there are lost and the outcome says so.
+        outcome.rejected(slot, prefix, RejectedChangeReason::WalkLimit);
+        observed.unobservable.push(prefix.to_owned());
+        return true;
     }
     let Ok(entries) = directory.entries().await else {
         outcome.rejected(slot, prefix, RejectedChangeReason::Unavailable);
-        return;
+        observed.unobservable.push(prefix.to_owned());
+        return true;
     };
     for ScratchEntry { name, kind } in entries {
+        if *entry_count >= limits.entries {
+            let relative = join_relative(prefix, &name);
+            outcome.rejected(slot, &relative, RejectedChangeReason::WalkLimit);
+            observed.unobservable.push(String::new());
+            return false;
+        }
+        *entry_count += 1;
         let relative = join_relative(prefix, &name);
         match kind {
             ScratchEntryKind::File => {
-                seen.push(relative.clone());
+                observed.files.insert(relative.clone());
                 let Some(stamp) = directory.file_stamp(&name).await else {
                     outcome.rejected(slot, &relative, RejectedChangeReason::Unavailable);
                     continue;
@@ -839,22 +921,31 @@ async fn apply_directory(
             }
             ScratchEntryKind::Directory => match directory.open_dir(&name).await {
                 Ok(child) => {
-                    Box::pin(apply_directory(
+                    if !Box::pin(apply_directory(
                         slot,
                         &relative,
                         &child,
                         snapshots,
-                        seen,
+                        observed,
+                        entry_count,
                         depth + 1,
+                        limits,
                         outcome,
                     ))
-                    .await;
+                    .await
+                    {
+                        return false;
+                    }
                 }
-                Err(_) => outcome.rejected(slot, &relative, RejectedChangeReason::Unavailable),
+                Err(_) => {
+                    outcome.rejected(slot, &relative, RejectedChangeReason::Unavailable);
+                    observed.unobservable.push(relative);
+                }
             },
             ScratchEntryKind::Other => {}
         }
     }
+    true
 }
 
 async fn changed_staged_content(
@@ -1066,18 +1157,19 @@ async fn observe_prior(
 /// Remove from the real folder every file the overlay started with and no
 /// longer has. This is the only place anything is deleted, and it consults the
 /// manifest rather than the folder, so a file that was never staged is never a
-/// candidate.
+/// candidate. A manifest file under a prefix the walk could not observe is
+/// not a candidate either: absent from the walk is not the same as absent
+/// from the overlay.
 async fn apply_deletions(
     slot: &OverlaySlot,
     snapshots: Option<&dyn WriteSnapshotSink>,
     trash: &dyn TrashSink,
     trash_staging: &Path,
-    seen: &[String],
+    observed: &Observed,
     outcome: &mut OverlayOutcome,
 ) {
-    let seen = seen.iter().collect::<std::collections::HashSet<_>>();
     for (relative, manifest) in &slot.manifest {
-        if seen.contains(relative) {
+        if observed.files.contains(relative) || observed.unobservable(relative) {
             continue;
         }
         let (prefix, name) = split_relative(relative);
@@ -1820,5 +1912,141 @@ mod tests {
         );
         assert_eq!(std::fs::read_to_string(target).unwrap(), "user edit");
         assert!(!applied.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    /// The invariant deletion rests on: nothing is removed unless it was
+    /// observed to be gone from the overlay. A staged subdirectory that
+    /// cannot be listed is unobserved, not empty, so the files under it stay.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_unlistable_staged_subdirectory_never_deletes_its_files() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let granted = tempfile::tempdir().unwrap();
+        std::fs::write(granted.path().join("top.txt"), "top").unwrap();
+        std::fs::create_dir(granted.path().join("sub")).unwrap();
+        std::fs::write(granted.path().join("sub/a.txt"), "a").unwrap();
+        std::fs::write(granted.path().join("sub/b.txt"), "b").unwrap();
+
+        let (_scratch, overlay) = overlay_for(granted.path()).await;
+        let staged = overlay.slots()[0].overlay().to_path_buf();
+        std::fs::write(staged.join("top.txt"), "revised").unwrap();
+        let locked = staged.join("sub");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read_dir(&locked).is_ok() {
+            // Running as root: the mode does not bite, so the case cannot
+            // be exercised here.
+            let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755));
+            return;
+        }
+
+        let trash = RecordingTrash::default();
+        let outcome = overlay.materialize_with_trash(None, &trash).await;
+        let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755));
+
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("sub/a.txt")).unwrap(),
+            "a"
+        );
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("sub/b.txt")).unwrap(),
+            "b"
+        );
+        assert!(
+            trash.files.lock().unwrap().is_empty(),
+            "nothing was trashed"
+        );
+        assert!(
+            outcome
+                .written
+                .iter()
+                .all(|change| change.change != MaterializedChangeKind::Deleted),
+            "{:?}",
+            outcome.written
+        );
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("top.txt")).unwrap(),
+            "revised",
+            "the rest of the overlay still applies"
+        );
+        assert_eq!(
+            outcome
+                .rejected
+                .iter()
+                .map(|file| (file.relative.as_str(), file.reason))
+                .collect::<Vec<_>>(),
+            vec![("sub", RejectedChangeReason::Unavailable)]
+        );
+    }
+
+    /// Write-back honors the same entry ceiling staging does, and a walk that
+    /// stops early has observed nothing about the rest: the files it never
+    /// reached are neither written nor deleted, and the stop is reported.
+    #[tokio::test]
+    async fn a_write_back_walk_past_the_entry_ceiling_stops_and_deletes_nothing_unseen() {
+        let granted = tempfile::tempdir().unwrap();
+        for name in ["a.txt", "b.txt", "c.txt", "d.txt"] {
+            std::fs::write(granted.path().join(name), name).unwrap();
+        }
+        let (_scratch, overlay) = overlay_for(granted.path()).await;
+        let staged = overlay.slots()[0].overlay().to_path_buf();
+        // The agent deleted one file and left three; a walk capped at two
+        // entries reaches two of the three and stops.
+        std::fs::remove_file(staged.join("d.txt")).unwrap();
+
+        let trash = RecordingTrash::default();
+        let outcome = overlay
+            .materialize_within(
+                None,
+                &trash,
+                WalkLimits {
+                    entries: 2,
+                    depth: MAX_OVERLAY_DEPTH,
+                },
+            )
+            .await;
+
+        assert!(
+            granted.path().join("d.txt").exists(),
+            "an unwalked slot deletes nothing"
+        );
+        assert!(trash.files.lock().unwrap().is_empty());
+        assert_eq!(outcome.written, Vec::new(), "nothing changed content");
+        assert_eq!(outcome.rejected.len(), 1, "{:?}", outcome.rejected);
+        assert_eq!(outcome.rejected[0].reason, RejectedChangeReason::WalkLimit);
+    }
+
+    /// A directory the agent nested past the depth ceiling is reported, not
+    /// silently dropped.
+    #[tokio::test]
+    async fn a_write_back_walk_reports_the_depth_cutoff() {
+        let granted = tempfile::tempdir().unwrap();
+        std::fs::write(granted.path().join("top.txt"), "top").unwrap();
+        let (_scratch, overlay) = overlay_for(granted.path()).await;
+        let staged = overlay.slots()[0].overlay().to_path_buf();
+        std::fs::create_dir_all(staged.join("one/two")).unwrap();
+        std::fs::write(staged.join("one/two/deep.txt"), "deep").unwrap();
+
+        let trash = RecordingTrash::default();
+        let outcome = overlay
+            .materialize_within(
+                None,
+                &trash,
+                WalkLimits {
+                    entries: MAX_OVERLAY_ENTRIES,
+                    depth: 1,
+                },
+            )
+            .await;
+
+        assert!(!granted.path().join("one/two/deep.txt").exists());
+        assert_eq!(
+            outcome
+                .rejected
+                .iter()
+                .map(|file| (file.relative.as_str(), file.reason))
+                .collect::<Vec<_>>(),
+            vec![("one/two", RejectedChangeReason::WalkLimit)]
+        );
     }
 }

--- a/crates/tidebreak-code-execution/src/sync.rs
+++ b/crates/tidebreak-code-execution/src/sync.rs
@@ -42,6 +42,11 @@ pub const PULLED_DIRS: &[&str] = &["output", "preview"];
 /// anything past the limit with an already-shown reason becomes a count.
 pub const MAX_SYNC_NOTES: usize = 32;
 
+/// Ceiling on the directories one pull walks. A backend's listing is data,
+/// not a tree: it may name a directory twice, name its own parent, or keep
+/// inventing children, and none of that may keep the walk alive.
+pub const MAX_PULLED_DIRS: usize = 4_096;
+
 /// Directory names never staged or pulled: version control and dependency
 /// trees that are large, regenerable, and meaningless to copy between the host
 /// and a sandbox.
@@ -354,7 +359,20 @@ pub async fn pull_result_dirs(
         .filter_map(|root| WorkspaceFilePath::parse(*root).ok())
         .collect();
     let mut files: Vec<WorkspaceFilePath> = Vec::new();
+    let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
     while let Some(dir) = stack.pop() {
+        if !visited.insert(dir.as_str().to_owned()) {
+            continue;
+        }
+        if visited.len() > MAX_PULLED_DIRS {
+            report.skip(
+                "beyond the directory sync limit",
+                format!(
+                    "not fully pulled: more than {MAX_PULLED_DIRS} directories under output/ and preview/"
+                ),
+            );
+            break;
+        }
         let listing = match lifecycle.list_workspace_files(workspace, Some(&dir)).await {
             Ok(listing) => listing,
             // A workspace with no output/ or preview/ yet has nothing to pull;
@@ -404,7 +422,7 @@ pub async fn pull_result_dirs(
                         "dependency or VCS tree",
                         format!("not pulled: {}/ (dependency or VCS tree)", path.as_str()),
                     );
-                } else {
+                } else if !visited.contains(path.as_str()) {
                     stack.push(path);
                 }
                 continue;
@@ -594,6 +612,9 @@ mod tests {
         /// Extra rows returned verbatim from the `output/` listing, for
         /// hostile-backend cases.
         planted: Mutex<Vec<WorkspaceFileEntry>>,
+        /// When set, every listing also names the listed directory itself
+        /// as a child, the shape of a backend that echoes its argument.
+        lists_itself: bool,
     }
 
     impl FakeWorkspace {
@@ -684,6 +705,19 @@ mod tests {
             }
             if path.map(WorkspaceFilePath::as_str) == Some("output") {
                 entries.extend(self.planted.lock().unwrap().drain(..));
+            }
+            // A root named without a trailing component fails the scope
+            // check before it can loop; a nested directory naming itself is
+            // the shape that walked forever.
+            if let (true, Some(dir)) = (
+                self.lists_itself,
+                path.filter(|dir| dir.as_str().contains('/')),
+            ) {
+                entries.push(WorkspaceFileEntry {
+                    path: dir.as_str().to_owned(),
+                    directory: true,
+                    size_bytes: None,
+                });
             }
             Ok(WorkspaceListing {
                 entries,
@@ -1083,5 +1117,36 @@ mod tests {
             pulled.notes.last().unwrap(),
             &format!("not pulled: 9 more note(s) beyond the {MAX_SYNC_NOTES}-note sync limit")
         );
+    }
+
+    /// A listing that names its own directory must not walk forever: the
+    /// pull visits each directory once and still pulls the files it found.
+    #[tokio::test]
+    async fn pull_terminates_when_a_listing_names_its_own_directory() {
+        let fake = FakeWorkspace {
+            lists_itself: true,
+            ..FakeWorkspace::default()
+        };
+        fake.insert("output/report.txt", b"done");
+        fake.insert("output/nested/more.txt", b"more");
+        let host = tempfile::tempdir().unwrap();
+
+        let pulled = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            pull_result_dirs(&fake, &workspace_id(), host.path()),
+        )
+        .await
+        .expect("the walk terminates")
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(host.path().join("output/report.txt")).unwrap(),
+            "done"
+        );
+        assert_eq!(
+            std::fs::read_to_string(host.path().join("output/nested/more.txt")).unwrap(),
+            "more"
+        );
+        assert_eq!(pulled.notes, Vec::<String>::new());
     }
 }

--- a/crates/tidebreak-desktop/src/client_execution/output_writeback.rs
+++ b/crates/tidebreak-desktop/src/client_execution/output_writeback.rs
@@ -555,7 +555,9 @@ fn materialization_resolution(
         (_, RejectedChangeReason::SnapshotUnavailable) => "output_writeback_snapshot_unavailable",
         (_, RejectedChangeReason::StagedFileTooLarge) => "output_writeback_source_unavailable",
         (_, RejectedChangeReason::TrashUnavailable) => "output_writeback_unavailable",
-        (_, RejectedChangeReason::Unavailable) => "output_writeback_unavailable",
+        (_, RejectedChangeReason::Unavailable | RejectedChangeReason::WalkLimit) => {
+            "output_writeback_unavailable"
+        }
     };
     unavailable(code)
 }

--- a/crates/tidebreak-server/src/code_execution/provider.rs
+++ b/crates/tidebreak-server/src/code_execution/provider.rs
@@ -1092,7 +1092,12 @@ impl ConfiguredExecProvider {
                     RejectedChangeReason::TrashUnavailable => {
                         ExecFileRejectionReason::TrashUnavailable
                     }
-                    RejectedChangeReason::Unavailable => ExecFileRejectionReason::Unavailable,
+                    // The record's vocabulary is a stable wire shape; a walk
+                    // that stopped short is, to the user, a path that could
+                    // not be used safely.
+                    RejectedChangeReason::Unavailable | RejectedChangeReason::WalkLimit => {
+                        ExecFileRejectionReason::Unavailable
+                    }
                 },
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
## What was wrong

In `crates/tidebreak-code-execution/src/overlay.rs`, `apply_directory` recorded a subdirectory it could not list as `Unavailable` and returned without adding that subtree's files to `seen`. `apply_deletions` then treated every unseen manifest entry as an agent deletion, and because the real folder still matched the manifest digest, each file passed its precondition and was unlinked. `chmod 000 <overlay>/subdir` reproduced it. That contradicted the module's invariant that nothing is removed unless it was observed to be gone from the overlay.

Related bounds in the same crate: `MAX_OVERLAY_ENTRIES` was enforced at staging but not at write-back, the depth cutoff dropped changes silently, and `sync.rs`'s pull walk had no visited set and looped forever on a listing that named its own directory.

## What changed

- The write-back walk records what it observed and every prefix it could not observe: an unlistable or unopenable directory, a directory past the depth ceiling, and everything after the entry ceiling (the whole slot). `apply_deletions` skips any manifest entry under an unobservable prefix.
- Write-back honors the same entry cap staging does, stops the whole walk when it trips, and reports the stop as a new `RejectedChangeReason::WalkLimit`. The depth cutoff is reported the same way instead of returning silently. The server maps `WalkLimit` onto the existing `Unavailable` record reason, so no wire or database shape changes.
- `pull_result_dirs` keeps a visited set and a `MAX_PULLED_DIRS` cap, and skips a child it has already visited.

## Tests

- `an_unlistable_staged_subdirectory_never_deletes_its_files` (unix): a `chmod 000` overlay subdirectory leaves its real files and trash untouched, the rest of the overlay still applies, and the subdirectory is reported `Unavailable`. Skips itself when running as root.
- `a_write_back_walk_past_the_entry_ceiling_stops_and_deletes_nothing_unseen`: a walk capped below the tree size writes and deletes nothing and reports one `WalkLimit`.
- `a_write_back_walk_reports_the_depth_cutoff`: a directory nested past the ceiling is reported, not dropped.
- `pull_terminates_when_a_listing_names_its_own_directory`: a backend whose nested listings echo themselves no longer walks forever, and the files still pull. Guarded by a timeout so a regression fails instead of hanging.

## Checks

```
cargo fmt --all
cargo test -p tidebreak-code-execution --lib -- overlay sync        25 passed
cargo clippy -p tidebreak-code-execution -p tidebreak-server-core --all-targets -- -D warnings -A clippy::too_many_arguments   no issues
cargo check -p tidebreak-server-core                                 ok
```

Closes #3336
