### PR TITLE
fix(code): keep fork generations until workspace removal and order private-root cleanup

### DIFF
--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -337,6 +337,23 @@ pub(crate) fn generations_named_by_children(
     named
 }
 
+/// Named generations to keep after reading live children.
+///
+/// `None` for the child list, or `Err` for any live child's turns, means skip
+/// pruning so a failed read cannot delete a handoff still in use. Successful
+/// reads still produce a keep-set, including an empty one when nothing is named.
+pub(crate) fn keep_fork_generations_from_reads(
+    parent: tidebreak_core::SessionId,
+    live_child_reads: Option<Vec<Result<Vec<String>, ()>>>,
+) -> Option<HashSet<uuid::Uuid>> {
+    let reads = live_child_reads?;
+    let mut texts = Vec::new();
+    for read in reads {
+        texts.extend(read.ok()?);
+    }
+    Some(generations_named_by_children(parent, texts))
+}
+
 /// Delete this session's fork generations that no live child still names.
 ///
 /// Unknown names stay. An empty keep-set removes every UUID generation.
@@ -2132,6 +2149,30 @@ mod tests {
             .join(FORKS_DIR)
             .join(session.id.to_string())
             .exists());
+    }
+
+    #[test]
+    fn a_failed_live_child_read_skips_prune_instead_of_dropping_named_generations() {
+        let parent = tidebreak_core::SessionId::new();
+        let named = uuid::Uuid::new_v4();
+        let unnamed = uuid::Uuid::new_v4();
+        let text = format!("Read `/{FORKS_DIR}/{parent}/{named}/transcript.md`");
+
+        let failed_list = keep_fork_generations_from_reads(parent, None);
+        assert!(failed_list.is_none());
+
+        let failed_turns =
+            keep_fork_generations_from_reads(parent, Some(vec![Ok(vec![text.clone()]), Err(())]));
+        assert!(failed_turns.is_none());
+
+        let keep = keep_fork_generations_from_reads(parent, Some(vec![Ok(vec![text])]))
+            .expect("successful reads still prune");
+        assert!(keep.contains(&named));
+        assert!(!keep.contains(&unnamed));
+
+        let empty = keep_fork_generations_from_reads(parent, Some(vec![Ok(vec![])]))
+            .expect("empty successful reads still prune");
+        assert!(empty.is_empty());
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -230,10 +230,10 @@ pub struct WrittenTranscript {
 ///
 /// Every fork writes a fresh generation directory named by a UUID, so a
 /// child keeps reading a whole, immutable handoff no matter how many later
-/// forks the same session produces. Ending the parent session prunes
-/// generations that no live child still names. A failure before the
-/// transcript publishes removes the whole directory rather than leaving a
-/// partial handoff for the child to trip over.
+/// forks the same session produces. Generations stay until the owning
+/// workspace's private root is removed. A failure before the transcript
+/// publishes removes the whole directory rather than leaving a partial
+/// handoff for the child to trip over.
 pub(crate) async fn write_transcript(
     private_root: &super::scratch::ScratchRoot,
     blobs: &dyn BlobStore,
@@ -307,118 +307,6 @@ pub(crate) async fn write_transcript(
             .flatten(),
         truncated: rendered.truncated,
     })
-}
-
-/// Generation ids a live child still names in user input.
-///
-/// The composer puts the generation directory path in the child's first
-/// message. A UUID that is not that path's generation name is ignored.
-pub(crate) fn generations_named_by_children(
-    parent: tidebreak_core::SessionId,
-    texts: impl IntoIterator<Item = impl AsRef<str>>,
-) -> HashSet<uuid::Uuid> {
-    let marker = format!("/{FORKS_DIR}/{parent}/");
-    let mut named = HashSet::new();
-    for text in texts {
-        let text = text.as_ref();
-        let mut rest = text;
-        while let Some(at) = rest.find(&marker) {
-            let after = &rest[at + marker.len()..];
-            let token = after
-                .split(|ch: char| !(ch.is_ascii_hexdigit() || ch == '-'))
-                .next()
-                .unwrap_or("");
-            if let Ok(generation) = token.parse::<uuid::Uuid>() {
-                named.insert(generation);
-            }
-            rest = after;
-        }
-    }
-    named
-}
-
-/// Named generations to keep after reading live children.
-///
-/// `None` for the child list, or `Err` for any live child's turns, means skip
-/// pruning so a failed read cannot delete a handoff still in use. Successful
-/// reads still produce a keep-set, including an empty one when nothing is named.
-pub(crate) fn keep_fork_generations_from_reads(
-    parent: tidebreak_core::SessionId,
-    live_child_reads: Option<Vec<Result<Vec<String>, ()>>>,
-) -> Option<HashSet<uuid::Uuid>> {
-    let reads = live_child_reads?;
-    let mut texts = Vec::new();
-    for read in reads {
-        texts.extend(read.ok()?);
-    }
-    Some(generations_named_by_children(parent, texts))
-}
-
-/// Delete this session's fork generations that no live child still names.
-///
-/// Unknown names stay. An empty keep-set removes every UUID generation.
-pub(crate) fn prune_session_fork_generations(
-    private_root: &super::scratch::ScratchRoot,
-    session_id: tidebreak_core::SessionId,
-    keep: &HashSet<uuid::Uuid>,
-) -> std::io::Result<()> {
-    let Some(session_dir) =
-        super::scratch::scratch_dir_if_exists(private_root, &format!("{FORKS_DIR}/{session_id}"))?
-    else {
-        return Ok(());
-    };
-    let mut failures = Vec::new();
-    let mut remaining = 0usize;
-    for entry in session_dir.read_dir()? {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(error) => {
-                failures.push(error.to_string());
-                remaining += 1;
-                continue;
-            }
-        };
-        let name = entry.file_name();
-        let Some(generation) = name
-            .to_str()
-            .and_then(|name| name.parse::<uuid::Uuid>().ok())
-        else {
-            remaining += 1;
-            continue;
-        };
-        if keep.contains(&generation) {
-            remaining += 1;
-            continue;
-        }
-        let result = match session_dir.symlink_metadata(&name) {
-            Ok(metadata) if metadata.file_type().is_symlink() || metadata.is_file() => {
-                session_dir.remove_file(&name)
-            }
-            Ok(metadata) if metadata.is_dir() => session_dir.remove_dir_all(&name),
-            Ok(_) => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "fork generation is not a regular directory",
-            )),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(error),
-        };
-        if let Err(error) = result {
-            remaining += 1;
-            failures.push(format!("{}: {error}", name.to_string_lossy()));
-        }
-    }
-    if remaining == 0 {
-        let _ = super::scratch::scratch_dir(private_root, FORKS_DIR)
-            .and_then(|forks| forks.remove_dir_all(std::ffi::OsStr::new(&session_id.to_string())));
-    }
-    if failures.is_empty() {
-        Ok(())
-    } else {
-        Err(std::io::Error::other(format!(
-            "could not prune every fork generation: {}",
-            failures.join("; ")
-        )))
-    }
 }
 
 /// A turn's full-record file name, `turn-0007.md` for turn 7.
@@ -2082,22 +1970,27 @@ mod tests {
         );
     }
 
-    /// Ending the parent session deletes fork generations that no live child
-    /// still names in its first message.
+    /// Desktop `forkConversation` writes the transcript before any child
+    /// session exists, and `createCodeSession` does not bind `parent_session`.
+    /// Those generations must survive parent-session private-root removal and
+    /// only leave with the workspace private root.
     #[tokio::test]
-    async fn ending_a_session_removes_its_fork_generations() {
-        let private = tempfile::tempdir().expect("tempdir");
+    async fn fork_generations_stay_until_the_workspace_private_root_is_removed() {
+        let data_dir = tempfile::tempdir().expect("data dir");
         let blob_root = tempfile::tempdir().expect("blob tempdir");
         let blobs = FsBlobStore::new(blob_root.path());
-        let session = session();
-        let turns = vec![turn(session.id, 1, "hello")];
+        let workspace_id = WorkspaceId::new();
+        let private_root =
+            crate::code::scratch::workspace_root(data_dir.path(), workspace_id).expect("workspace");
+        let parent = session();
+        let turns = vec![turn(parent.id, 1, "hello")];
         let complete = all_turn_ids(&turns);
-        let private_root = test_root(&private);
 
-        let first = write_transcript(
+        // Draft: transcript on disk, no child session row yet.
+        let draft = write_transcript(
             &private_root,
             &blobs,
-            &session,
+            &parent,
             ForkCut {
                 turns: &turns,
                 excluded: 0,
@@ -2106,11 +1999,13 @@ mod tests {
             &complete,
         )
         .await
-        .expect("first write");
-        let second = write_transcript(
+        .expect("draft write");
+        // Unparented sibling: another generation the composer would attach
+        // without `parent_session_id`.
+        let unparented = write_transcript(
             &private_root,
             &blobs,
-            &session,
+            &parent,
             ForkCut {
                 turns: &turns,
                 excluded: 0,
@@ -2119,60 +2014,25 @@ mod tests {
             &complete,
         )
         .await
-        .expect("second write");
-        let first_generation = Path::new(&first.dir)
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .parse()
-            .unwrap();
-        let keep = generations_named_by_children(
-            session.id,
-            [format!(
-                "Read the attached transcript first\n`{}/transcript.md`",
-                first.dir
-            )],
+        .expect("unparented write");
+
+        crate::code::scratch::remove_session_root(data_dir.path(), parent.id).expect("parent end");
+
+        assert!(
+            Path::new(&draft.dir).is_dir(),
+            "an open fork draft must survive parent session end"
         );
-        assert!(keep.contains(&first_generation));
+        assert!(
+            Path::new(&unparented.dir).is_dir(),
+            "an unparented fork session's generation must survive parent session end"
+        );
 
-        prune_session_fork_generations(&private_root, session.id, &keep).expect("prune");
+        crate::code::scratch::remove_workspace_root(data_dir.path(), workspace_id)
+            .expect("workspace gone");
 
-        assert!(Path::new(&first.dir).is_dir());
-        assert!(!Path::new(&second.dir).exists());
-
-        prune_session_fork_generations(&private_root, session.id, &HashSet::new()).expect("end");
-
-        assert!(!Path::new(&first.dir).exists());
-        assert!(!private
-            .path()
-            .join(FORKS_DIR)
-            .join(session.id.to_string())
-            .exists());
-    }
-
-    #[test]
-    fn a_failed_live_child_read_skips_prune_instead_of_dropping_named_generations() {
-        let parent = tidebreak_core::SessionId::new();
-        let named = uuid::Uuid::new_v4();
-        let unnamed = uuid::Uuid::new_v4();
-        let text = format!("Read `/{FORKS_DIR}/{parent}/{named}/transcript.md`");
-
-        let failed_list = keep_fork_generations_from_reads(parent, None);
-        assert!(failed_list.is_none());
-
-        let failed_turns =
-            keep_fork_generations_from_reads(parent, Some(vec![Ok(vec![text.clone()]), Err(())]));
-        assert!(failed_turns.is_none());
-
-        let keep = keep_fork_generations_from_reads(parent, Some(vec![Ok(vec![text])]))
-            .expect("successful reads still prune");
-        assert!(keep.contains(&named));
-        assert!(!keep.contains(&unnamed));
-
-        let empty = keep_fork_generations_from_reads(parent, Some(vec![Ok(vec![])]))
-            .expect("empty successful reads still prune");
-        assert!(empty.is_empty());
+        assert!(!Path::new(&draft.dir).exists());
+        assert!(!Path::new(&unparented.dir).exists());
+        assert!(!private_root.path().exists());
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/fork.rs
+++ b/crates/tidebreak-server/src/code/fork.rs
@@ -230,10 +230,10 @@ pub struct WrittenTranscript {
 ///
 /// Every fork writes a fresh generation directory named by a UUID, so a
 /// child keeps reading a whole, immutable handoff no matter how many later
-/// forks the same session produces. The generation is kept; nothing removes
-/// it today. A failure before the transcript publishes removes the whole
-/// directory rather than leaving a partial handoff for the child to trip
-/// over.
+/// forks the same session produces. Ending the parent session prunes
+/// generations that no live child still names. A failure before the
+/// transcript publishes removes the whole directory rather than leaving a
+/// partial handoff for the child to trip over.
 pub(crate) async fn write_transcript(
     private_root: &super::scratch::ScratchRoot,
     blobs: &dyn BlobStore,
@@ -307,6 +307,101 @@ pub(crate) async fn write_transcript(
             .flatten(),
         truncated: rendered.truncated,
     })
+}
+
+/// Generation ids a live child still names in user input.
+///
+/// The composer puts the generation directory path in the child's first
+/// message. A UUID that is not that path's generation name is ignored.
+pub(crate) fn generations_named_by_children(
+    parent: tidebreak_core::SessionId,
+    texts: impl IntoIterator<Item = impl AsRef<str>>,
+) -> HashSet<uuid::Uuid> {
+    let marker = format!("/{FORKS_DIR}/{parent}/");
+    let mut named = HashSet::new();
+    for text in texts {
+        let text = text.as_ref();
+        let mut rest = text;
+        while let Some(at) = rest.find(&marker) {
+            let after = &rest[at + marker.len()..];
+            let token = after
+                .split(|ch: char| !(ch.is_ascii_hexdigit() || ch == '-'))
+                .next()
+                .unwrap_or("");
+            if let Ok(generation) = token.parse::<uuid::Uuid>() {
+                named.insert(generation);
+            }
+            rest = after;
+        }
+    }
+    named
+}
+
+/// Delete this session's fork generations that no live child still names.
+///
+/// Unknown names stay. An empty keep-set removes every UUID generation.
+pub(crate) fn prune_session_fork_generations(
+    private_root: &super::scratch::ScratchRoot,
+    session_id: tidebreak_core::SessionId,
+    keep: &HashSet<uuid::Uuid>,
+) -> std::io::Result<()> {
+    let Some(session_dir) =
+        super::scratch::scratch_dir_if_exists(private_root, &format!("{FORKS_DIR}/{session_id}"))?
+    else {
+        return Ok(());
+    };
+    let mut failures = Vec::new();
+    let mut remaining = 0usize;
+    for entry in session_dir.read_dir()? {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                failures.push(error.to_string());
+                remaining += 1;
+                continue;
+            }
+        };
+        let name = entry.file_name();
+        let Some(generation) = name
+            .to_str()
+            .and_then(|name| name.parse::<uuid::Uuid>().ok())
+        else {
+            remaining += 1;
+            continue;
+        };
+        if keep.contains(&generation) {
+            remaining += 1;
+            continue;
+        }
+        let result = match session_dir.symlink_metadata(&name) {
+            Ok(metadata) if metadata.file_type().is_symlink() || metadata.is_file() => {
+                session_dir.remove_file(&name)
+            }
+            Ok(metadata) if metadata.is_dir() => session_dir.remove_dir_all(&name),
+            Ok(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "fork generation is not a regular directory",
+            )),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        };
+        if let Err(error) = result {
+            remaining += 1;
+            failures.push(format!("{}: {error}", name.to_string_lossy()));
+        }
+    }
+    if remaining == 0 {
+        let _ = super::scratch::scratch_dir(private_root, FORKS_DIR)
+            .and_then(|forks| forks.remove_dir_all(std::ffi::OsStr::new(&session_id.to_string())));
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "could not prune every fork generation: {}",
+            failures.join("; ")
+        )))
+    }
 }
 
 /// A turn's full-record file name, `turn-0007.md` for turn 7.
@@ -1968,6 +2063,75 @@ mod tests {
             std::fs::read_dir(session_dir).expect("session dir").count(),
             2
         );
+    }
+
+    /// Ending the parent session deletes fork generations that no live child
+    /// still names in its first message.
+    #[tokio::test]
+    async fn ending_a_session_removes_its_fork_generations() {
+        let private = tempfile::tempdir().expect("tempdir");
+        let blob_root = tempfile::tempdir().expect("blob tempdir");
+        let blobs = FsBlobStore::new(blob_root.path());
+        let session = session();
+        let turns = vec![turn(session.id, 1, "hello")];
+        let complete = all_turn_ids(&turns);
+        let private_root = test_root(&private);
+
+        let first = write_transcript(
+            &private_root,
+            &blobs,
+            &session,
+            ForkCut {
+                turns: &turns,
+                excluded: 0,
+            },
+            &[],
+            &complete,
+        )
+        .await
+        .expect("first write");
+        let second = write_transcript(
+            &private_root,
+            &blobs,
+            &session,
+            ForkCut {
+                turns: &turns,
+                excluded: 0,
+            },
+            &[],
+            &complete,
+        )
+        .await
+        .expect("second write");
+        let first_generation = Path::new(&first.dir)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        let keep = generations_named_by_children(
+            session.id,
+            [format!(
+                "Read the attached transcript first\n`{}/transcript.md`",
+                first.dir
+            )],
+        );
+        assert!(keep.contains(&first_generation));
+
+        prune_session_fork_generations(&private_root, session.id, &keep).expect("prune");
+
+        assert!(Path::new(&first.dir).is_dir());
+        assert!(!Path::new(&second.dir).exists());
+
+        prune_session_fork_generations(&private_root, session.id, &HashSet::new()).expect("end");
+
+        assert!(!Path::new(&first.dir).exists());
+        assert!(!private
+            .path()
+            .join(FORKS_DIR)
+            .join(session.id.to_string())
+            .exists());
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -289,6 +289,9 @@ impl CodeRuntime {
             })
         }))
         .await;
+        let Some(listed) = crate::code::scratch::list_private_roots(&self.data_dir) else {
+            return Ok(actions);
+        };
         match (
             list_workspaces_all_owners(&self.db).await,
             list_sessions_all_owners(&self.db).await,
@@ -296,6 +299,7 @@ impl CodeRuntime {
             (Ok(workspaces), Ok(sessions)) => {
                 crate::code::scratch::sweep_orphan_private_roots(
                     &self.data_dir,
+                    &listed,
                     &workspaces
                         .into_iter()
                         .map(|workspace| workspace.id)

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -592,87 +592,20 @@ impl CodeRuntime {
         Ok(())
     }
 
-    /// Drop the session private root and fork generations no live child names.
+    /// Drop this session's private root. Fork generations stay under the
+    /// workspace private root until that workspace is archived or released.
+    ///
+    /// Desktop forks do not set `parent_session_id`, and `forkConversation`
+    /// writes the transcript before any child session exists, so pruning from
+    /// `child_sessions` at parent end would delete an open draft or a live
+    /// unparented sibling's handoff.
     async fn prune_session_private_scratch(&self, session: &Session) {
-        if let Some(workspace_id) = session.workspace_id {
-            match crate::code::scratch::workspace_root(&self.data_dir, workspace_id) {
-                Ok(private_root) => match self.live_child_fork_generations(session).await {
-                    Some(keep) => {
-                        if let Err(error) = crate::code::fork::prune_session_fork_generations(
-                            &private_root,
-                            session.id,
-                            &keep,
-                        ) {
-                            tracing::warn!(
-                                session = %session.id,
-                                "code-mode: could not prune fork generations: {error}"
-                            );
-                        }
-                    }
-                    None => {
-                        tracing::warn!(
-                            session = %session.id,
-                            "code-mode: skipping fork generation prune after a child read failed"
-                        );
-                    }
-                },
-                Err(error) => {
-                    tracing::warn!(
-                        session = %session.id,
-                        "code-mode: could not open private storage to prune fork generations: {error}"
-                    );
-                }
-            }
-        }
         if let Err(error) = crate::code::scratch::remove_session_root(&self.data_dir, session.id) {
             tracing::warn!(
                 session = %session.id,
                 "code-mode: could not delete the session private root: {error}"
             );
         }
-    }
-
-    /// Named generations to keep, or `None` to skip pruning so a failed read
-    /// cannot delete a handoff a live child still names.
-    async fn live_child_fork_generations(&self, parent: &Session) -> Option<HashSet<uuid::Uuid>> {
-        let children = match tidebreak_core::db::code::child_sessions(
-            &self.db,
-            &parent.owner,
-            parent.id,
-        )
-        .await
-        {
-            Ok(children) => children,
-            Err(error) => {
-                tracing::warn!(
-                    session = %parent.id,
-                    error = %error,
-                    "code-mode: could not list child sessions before pruning fork generations"
-                );
-                return None;
-            }
-        };
-        let mut reads = Vec::new();
-        for child in children {
-            if child.lifecycle == SessionLifecycle::Ended {
-                continue;
-            }
-            match list_turns(&self.db, &parent.owner, child.id).await {
-                Ok(turns) => {
-                    reads.push(Ok(turns.into_iter().map(|turn| turn.user_input).collect()));
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        session = %parent.id,
-                        child = %child.id,
-                        error = %error,
-                        "code-mode: could not read a child session before pruning fork generations"
-                    );
-                    reads.push(Err(()));
-                }
-            }
-        }
-        crate::code::fork::keep_fork_generations_from_reads(parent.id, Some(reads))
     }
 
     pub async fn list_sessions(&self, owner: &OwnerId) -> Result<Vec<Session>, ServerError> {

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -516,14 +516,7 @@ impl CodeRuntime {
         };
         if session.lifecycle == SessionLifecycle::Ended {
             self.bus.forget(session.id);
-            if let Err(error) =
-                crate::code::scratch::remove_session_root(&self.data_dir, session.id)
-            {
-                tracing::warn!(
-                    session = %session.id,
-                    "code-mode: could not delete the session private root: {error}"
-                );
-            }
+            self.prune_session_private_scratch(&session).await;
             return Ok(());
         }
         if let Ok(Some(workspace)) = self.session_workspace(&session).await {
@@ -595,13 +588,81 @@ impl CodeRuntime {
             );
         }
         self.bus.forget(current.id);
-        if let Err(error) = crate::code::scratch::remove_session_root(&self.data_dir, current.id) {
+        self.prune_session_private_scratch(&current).await;
+        Ok(())
+    }
+
+    /// Drop the session private root and fork generations no live child names.
+    async fn prune_session_private_scratch(&self, session: &Session) {
+        if let Some(workspace_id) = session.workspace_id {
+            match crate::code::scratch::workspace_root(&self.data_dir, workspace_id) {
+                Ok(private_root) => {
+                    let keep = self.live_child_fork_generations(session).await;
+                    if let Err(error) = crate::code::fork::prune_session_fork_generations(
+                        &private_root,
+                        session.id,
+                        &keep,
+                    ) {
+                        tracing::warn!(
+                            session = %session.id,
+                            "code-mode: could not prune fork generations: {error}"
+                        );
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        session = %session.id,
+                        "code-mode: could not open private storage to prune fork generations: {error}"
+                    );
+                }
+            }
+        }
+        if let Err(error) = crate::code::scratch::remove_session_root(&self.data_dir, session.id) {
             tracing::warn!(
-                session = %current.id,
+                session = %session.id,
                 "code-mode: could not delete the session private root: {error}"
             );
         }
-        Ok(())
+    }
+
+    async fn live_child_fork_generations(&self, parent: &Session) -> HashSet<uuid::Uuid> {
+        let children = match tidebreak_core::db::code::child_sessions(
+            &self.db,
+            &parent.owner,
+            parent.id,
+        )
+        .await
+        {
+            Ok(children) => children,
+            Err(error) => {
+                tracing::warn!(
+                    session = %parent.id,
+                    error = %error,
+                    "code-mode: could not list child sessions before pruning fork generations"
+                );
+                return HashSet::new();
+            }
+        };
+        let mut texts = Vec::new();
+        for child in children {
+            if child.lifecycle == SessionLifecycle::Ended {
+                continue;
+            }
+            match list_turns(&self.db, &parent.owner, child.id).await {
+                Ok(turns) => {
+                    texts.extend(turns.into_iter().map(|turn| turn.user_input));
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        session = %parent.id,
+                        child = %child.id,
+                        error = %error,
+                        "code-mode: could not read a child session before pruning fork generations"
+                    );
+                }
+            }
+        }
+        crate::code::fork::generations_named_by_children(parent.id, &texts)
     }
 
     pub async fn list_sessions(&self, owner: &OwnerId) -> Result<Vec<Session>, ServerError> {

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -596,19 +596,26 @@ impl CodeRuntime {
     async fn prune_session_private_scratch(&self, session: &Session) {
         if let Some(workspace_id) = session.workspace_id {
             match crate::code::scratch::workspace_root(&self.data_dir, workspace_id) {
-                Ok(private_root) => {
-                    let keep = self.live_child_fork_generations(session).await;
-                    if let Err(error) = crate::code::fork::prune_session_fork_generations(
-                        &private_root,
-                        session.id,
-                        &keep,
-                    ) {
+                Ok(private_root) => match self.live_child_fork_generations(session).await {
+                    Some(keep) => {
+                        if let Err(error) = crate::code::fork::prune_session_fork_generations(
+                            &private_root,
+                            session.id,
+                            &keep,
+                        ) {
+                            tracing::warn!(
+                                session = %session.id,
+                                "code-mode: could not prune fork generations: {error}"
+                            );
+                        }
+                    }
+                    None => {
                         tracing::warn!(
                             session = %session.id,
-                            "code-mode: could not prune fork generations: {error}"
+                            "code-mode: skipping fork generation prune after a child read failed"
                         );
                     }
-                }
+                },
                 Err(error) => {
                     tracing::warn!(
                         session = %session.id,
@@ -625,7 +632,9 @@ impl CodeRuntime {
         }
     }
 
-    async fn live_child_fork_generations(&self, parent: &Session) -> HashSet<uuid::Uuid> {
+    /// Named generations to keep, or `None` to skip pruning so a failed read
+    /// cannot delete a handoff a live child still names.
+    async fn live_child_fork_generations(&self, parent: &Session) -> Option<HashSet<uuid::Uuid>> {
         let children = match tidebreak_core::db::code::child_sessions(
             &self.db,
             &parent.owner,
@@ -640,17 +649,17 @@ impl CodeRuntime {
                     error = %error,
                     "code-mode: could not list child sessions before pruning fork generations"
                 );
-                return HashSet::new();
+                return None;
             }
         };
-        let mut texts = Vec::new();
+        let mut reads = Vec::new();
         for child in children {
             if child.lifecycle == SessionLifecycle::Ended {
                 continue;
             }
             match list_turns(&self.db, &parent.owner, child.id).await {
                 Ok(turns) => {
-                    texts.extend(turns.into_iter().map(|turn| turn.user_input));
+                    reads.push(Ok(turns.into_iter().map(|turn| turn.user_input).collect()));
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -659,10 +668,11 @@ impl CodeRuntime {
                         error = %error,
                         "code-mode: could not read a child session before pruning fork generations"
                     );
+                    reads.push(Err(()));
                 }
             }
         }
-        crate::code::fork::generations_named_by_children(parent.id, &texts)
+        crate::code::fork::keep_fork_generations_from_reads(parent.id, Some(reads))
     }
 
     pub async fn list_sessions(&self, owner: &OwnerId) -> Result<Vec<Session>, ServerError> {

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -521,14 +521,6 @@ impl CodeRuntime {
     ) -> Result<CodeWorkspace, ServerError> {
         let _ = prune_worktrees(std::path::Path::new(&repo.root_path)).await;
         if let Err(error) =
-            crate::code::scratch::remove_workspace_root(&self.data_dir, workspace.id)
-        {
-            tracing::warn!(
-                workspace = %workspace.id,
-                "code-mode: could not delete the workspace private root: {error}"
-            );
-        }
-        if let Err(error) =
             delete_workspace_refs(std::path::Path::new(&repo.root_path), workspace.id).await
         {
             tracing::warn!(
@@ -552,6 +544,7 @@ impl CodeRuntime {
                     "the workspace row changed before archive completed",
                 ));
             }
+            self.remove_workspace_private_root(workspace.id);
             crate::code::attention::emit_workspace_digests(
                 &self.db,
                 &self.bus,
@@ -586,6 +579,7 @@ impl CodeRuntime {
                 "the workspace row changed before release completed",
             ));
         }
+        self.remove_workspace_private_root(workspace.id);
         let repo_root = std::path::Path::new(&repo.root_path);
         if worktree::branch_exists(repo_root, &workspace.branch_name)
             .await
@@ -603,6 +597,17 @@ impl CodeRuntime {
         )
         .await;
         Ok(workspace)
+    }
+
+    fn remove_workspace_private_root(&self, workspace_id: WorkspaceId) {
+        if let Err(error) =
+            crate::code::scratch::remove_workspace_root(&self.data_dir, workspace_id)
+        {
+            tracing::warn!(
+                workspace = %workspace_id,
+                "code-mode: could not delete the workspace private root: {error}"
+            );
+        }
     }
 
     /// Bundle a local branch after archive removes its checkout.

--- a/crates/tidebreak-server/src/code/scratch.rs
+++ b/crates/tidebreak-server/src/code/scratch.rs
@@ -218,15 +218,21 @@ pub(crate) fn remove_session_root(
     )
 }
 
-/// Delete private roots whose workspace or session row is gone.
+/// Parseable private-root directory names observed on disk.
 ///
-/// Unknown names stay untouched. Per-entry failures are logged; this never
-/// fails the caller, so boot cannot get stuck on one undeletable leftover.
-pub(crate) fn sweep_orphan_private_roots(
-    data_dir: &Path,
-    live_workspaces: &HashSet<WorkspaceId>,
-    live_sessions: &HashSet<tidebreak_core::SessionId>,
-) {
+/// Recovery lists these first, then snapshots workspace and session rows,
+/// then deletes only names that were already present before that snapshot.
+#[derive(Debug, Default)]
+pub(crate) struct PrivateRootListing {
+    pub workspaces: Vec<WorkspaceId>,
+    pub sessions: Vec<tidebreak_core::SessionId>,
+}
+
+/// List workspace and session private-root ids without deleting anything.
+///
+/// Returns `None` when the tree cannot be opened; the caller must not sweep.
+/// Unparseable names and the `sessions` directory itself are omitted.
+pub(crate) fn list_private_roots(data_dir: &Path) -> Option<PrivateRootListing> {
     let data_dir = match absolute_path(data_dir) {
         Ok(path) => path,
         Err(error) => {
@@ -234,19 +240,19 @@ pub(crate) fn sweep_orphan_private_roots(
                 %error,
                 "code-mode: could not resolve the data directory for a private-root sweep"
             );
-            return;
+            return None;
         }
     };
     let root = match open_root_if_exists(&data_dir) {
         Ok(Some(root)) => root,
-        Ok(None) => return,
+        Ok(None) => return Some(PrivateRootListing::default()),
         Err(error) => {
             tracing::warn!(
                 path = %data_dir.display(),
                 %error,
                 "code-mode: could not open the data directory for a private-root sweep"
             );
-            return;
+            return None;
         }
     };
     let private = match open_existing_child(&root, OsStr::new(CODE_DIR)).and_then(|code| match code
@@ -255,68 +261,97 @@ pub(crate) fn sweep_orphan_private_roots(
         None => Ok(None),
     }) {
         Ok(Some(private)) => private,
-        Ok(None) => return,
+        Ok(None) => return Some(PrivateRootListing::default()),
         Err(error) => {
             tracing::warn!(
                 %error,
                 "code-mode: could not open code/private for a private-root sweep"
             );
-            return;
+            return None;
         }
     };
-    if let Err(error) = sweep_named_orphans(&private, |name| {
+    let mut listing = PrivateRootListing::default();
+    match list_named_ids(&private, |name| {
         if name == SESSIONS_DIR {
-            return SweepDecision::Skip;
+            return None;
         }
-        match name
-            .to_str()
+        name.to_str()
             .and_then(|name| name.parse::<WorkspaceId>().ok())
-        {
-            Some(id) if live_workspaces.contains(&id) => SweepDecision::Keep,
-            Some(_) => SweepDecision::Remove,
-            None => SweepDecision::Skip,
-        }
     }) {
-        tracing::warn!(
-            %error,
-            "code-mode: could not list workspace private roots"
-        );
+        Ok(ids) => listing.workspaces = ids,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "code-mode: could not list workspace private roots"
+            );
+            return None;
+        }
     }
-    let sessions = match open_existing_child(&private, OsStr::new(SESSIONS_DIR)) {
-        Ok(Some(sessions)) => sessions,
-        Ok(None) => return,
+    match open_existing_child(&private, OsStr::new(SESSIONS_DIR)) {
+        Ok(Some(sessions)) => match list_named_ids(&sessions, |name| {
+            name.to_str()
+                .and_then(|name| name.parse::<tidebreak_core::SessionId>().ok())
+        }) {
+            Ok(ids) => listing.sessions = ids,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "code-mode: could not list session private roots"
+                );
+                return None;
+            }
+        },
+        Ok(None) => {}
         Err(error) => {
             tracing::warn!(
                 %error,
                 "code-mode: could not open code/private/sessions for a private-root sweep"
             );
-            return;
+            return None;
         }
-    };
-    if let Err(error) = sweep_named_orphans(&sessions, |name| {
-        match name
-            .to_str()
-            .and_then(|name| name.parse::<tidebreak_core::SessionId>().ok())
-        {
-            Some(id) if live_sessions.contains(&id) => SweepDecision::Keep,
-            Some(_) => SweepDecision::Remove,
-            None => SweepDecision::Skip,
+    }
+    Some(listing)
+}
+
+/// Delete private roots whose workspace or session row is gone.
+///
+/// `listed` must come from [`list_private_roots`] taken **before** the live
+/// row snapshot. Unknown names stay untouched. Per-entry failures are logged;
+/// this never fails the caller, so boot cannot get stuck on one leftover.
+pub(crate) fn sweep_orphan_private_roots(
+    data_dir: &Path,
+    listed: &PrivateRootListing,
+    live_workspaces: &HashSet<WorkspaceId>,
+    live_sessions: &HashSet<tidebreak_core::SessionId>,
+) {
+    for id in &listed.workspaces {
+        if live_workspaces.contains(id) {
+            continue;
         }
-    }) {
-        tracing::warn!(
-            %error,
-            "code-mode: could not list session private roots"
-        );
+        if let Err(error) = remove_workspace_root(data_dir, *id) {
+            tracing::warn!(
+                workspace = %id,
+                %error,
+                "code-mode: could not delete an orphaned private root"
+            );
+        }
+    }
+    for id in &listed.sessions {
+        if live_sessions.contains(id) {
+            continue;
+        }
+        if let Err(error) = remove_session_root(data_dir, *id) {
+            tracing::warn!(
+                session = %id,
+                %error,
+                "code-mode: could not delete an orphaned private root"
+            );
+        }
     }
 }
 
-enum SweepDecision {
-    Keep,
-    Remove,
-    Skip,
-}
-
-fn sweep_named_orphans(parent: &Dir, decide: impl Fn(&OsStr) -> SweepDecision) -> io::Result<()> {
+fn list_named_ids<T>(parent: &Dir, parse: impl Fn(&OsStr) -> Option<T>) -> io::Result<Vec<T>> {
+    let mut ids = Vec::new();
     for entry in parent.read_dir(".")? {
         let entry = match entry {
             Ok(entry) => entry,
@@ -328,20 +363,11 @@ fn sweep_named_orphans(parent: &Dir, decide: impl Fn(&OsStr) -> SweepDecision) -
                 continue;
             }
         };
-        let name = entry.file_name();
-        match decide(&name) {
-            SweepDecision::Keep | SweepDecision::Skip => continue,
-            SweepDecision::Remove => {}
-        }
-        if let Err(error) = remove_named_entry(parent, &name) {
-            tracing::warn!(
-                name = %name.to_string_lossy(),
-                %error,
-                "code-mode: could not delete an orphaned private root"
-            );
+        if let Some(id) = parse(&entry.file_name()) {
+            ids.push(id);
         }
     }
-    Ok(())
+    Ok(ids)
 }
 
 fn remove_private_named_child(data_dir: &Path, parents: &[&str], name: &str) -> io::Result<()> {
@@ -1086,6 +1112,39 @@ mod tests {
 
         assert!(!private_root.path().exists());
         assert!(data_dir.path().join(CODE_DIR).join(PRIVATE_DIR).is_dir());
+    }
+
+    #[test]
+    fn sweep_keeps_live_ids_removes_dead_ids_and_leaves_unknown_names() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let live_workspace = WorkspaceId::new();
+        let dead_workspace = WorkspaceId::new();
+        let live_session = tidebreak_core::SessionId::new();
+        let dead_session = tidebreak_core::SessionId::new();
+        let live_workspace_root = workspace_root(data_dir.path(), live_workspace).unwrap();
+        let dead_workspace_root = workspace_root(data_dir.path(), dead_workspace).unwrap();
+        let live_session_root = session_root(data_dir.path(), live_session).unwrap();
+        let dead_session_root = session_root(data_dir.path(), dead_session).unwrap();
+        std::fs::write(live_workspace_root.path().join("keep.txt"), b"live").unwrap();
+        std::fs::write(dead_workspace_root.path().join("gone.txt"), b"dead").unwrap();
+        std::fs::write(live_session_root.path().join("keep.txt"), b"live").unwrap();
+        std::fs::write(dead_session_root.path().join("gone.txt"), b"dead").unwrap();
+        let private = data_dir.path().join(CODE_DIR).join(PRIVATE_DIR);
+        let odd = private.join("not-a-uuid");
+        std::fs::create_dir(&odd).unwrap();
+        std::fs::write(odd.join("stay.txt"), b"odd").unwrap();
+
+        let listed = list_private_roots(data_dir.path()).expect("list");
+        let live_workspaces = HashSet::from([live_workspace]);
+        let live_sessions = HashSet::from([live_session]);
+        sweep_orphan_private_roots(data_dir.path(), &listed, &live_workspaces, &live_sessions);
+
+        assert!(live_workspace_root.path().join("keep.txt").is_file());
+        assert!(!dead_workspace_root.path().exists());
+        assert!(live_session_root.path().join("keep.txt").is_file());
+        assert!(!dead_session_root.path().exists());
+        assert!(private.join(SESSIONS_DIR).is_dir());
+        assert_eq!(std::fs::read(odd.join("stay.txt")).unwrap(), b"odd");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## What was wrong

#3363 deleted workspace and session private roots, but left fork generation directories under `forks/{session_id}/{generation}`. Boot recovery listed workspace and session rows first, then walked the filesystem, so a root created after that snapshot could be deleted while the server was already serving. `finalize_removed_workspace` removed the private root before `complete_workspace_release` / `complete_workspace_archive`; if those returned `workspace_lifecycle_changed`, the row stayed Active or Archiving with its private data gone.

A first follow-up pruned those fork generations when the parent session ended, keeping names found in live `child_sessions` user input. That is unsafe for the actual desktop path: `useWorkspaceSessions.ts` `createCodeSession` does not bind `parent_session`, so sibling fork sessions never appear in `child_sessions`. `forkConversation` also writes the transcript before any child session exists, so ending the parent would delete an open draft. Fail-closed child-list/turn-read handling does not cover those cases.

## What changed

- Ending a session still deletes that session's private root. It does **not** prune fork generations.
- Fork generations stay under the workspace private root until archive or release commits and then `remove_workspace_root` runs. That is the same explicit workspace destruction that already clears the rest of private scratch.
- Recovery lists private-root directory names first, then snapshots workspace and session rows, then deletes only names that were already on disk and absent from that later snapshot.
- Workspace private-root removal runs after the archive or release row transition commits.
- Tests: a draft generation (transcript written, no child session) and an unparented sibling generation survive parent-session private-root removal and are deleted when the workspace private root is removed; the orphan sweep keeps a live id, removes a dead id, and leaves `sessions` plus an unparseable name alone.

## Limitations

- Fork generations accumulate for the life of the workspace. There is no session-end or TTL prune. Safer per-generation cleanup would need a durable owner (for example binding desktop forks to `parent_session`, or recording the generation on the child/draft) and is out of this change.
- Per-turn attachment `sweep_scopes` is unchanged.

Refs #3328
Follows up #3363

## Checks

- `cargo fmt --all -- --check`
- `cargo check -p tidebreak-server-core`
- `cargo test -p tidebreak-server-core fork_generations_stay_until_the_workspace_private_root_is_removed`
- `cargo test -p tidebreak-server-core removing_a_workspace_deletes_its_private_root`
- `cargo test -p tidebreak-server-core sweep_keeps_live_ids`
