### PR TITLE
fix(code): keep truncated git output parseable and surface a failed external clone once

### DIFF
--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -423,6 +423,7 @@ pub async fn record_checkpoint(
 }
 
 #[cfg(test)]
+#[allow(clippy::too_many_arguments)] // mirrors record_checkpoint plus a test-only output budget
 async fn record_checkpoint_with_output_budget(
     worktree: &Path,
     workspace_id: WorkspaceId,

--- a/crates/tidebreak-server/src/code/checkpoint.rs
+++ b/crates/tidebreak-server/src/code/checkpoint.rs
@@ -422,6 +422,40 @@ pub async fn record_checkpoint(
     })
 }
 
+#[cfg(test)]
+async fn record_checkpoint_with_output_budget(
+    worktree: &Path,
+    workspace_id: WorkspaceId,
+    session_id: SessionId,
+    ordinal: i64,
+    status: TurnStatus,
+    previous_oid: Option<&str>,
+    base_ref: &str,
+    output_budget: OutputBudget,
+) -> Result<RecordedCheckpoint, CheckpointError> {
+    let r#ref = checkpoint_ref(workspace_id, session_id, ordinal);
+    let message = format!("checkpoint turn {ordinal} ({})", status.as_str());
+    let commit = write_snapshot_ref(worktree, &r#ref, previous_oid, &message).await?;
+
+    let from = match previous_oid {
+        Some(oid) => oid.to_owned(),
+        None => merge_base(worktree, base_ref).await?,
+    };
+    let files = collect_changes_inner(
+        worktree,
+        &from,
+        &commit,
+        DiffBounds::default(),
+        None,
+        output_budget,
+    )
+    .await?;
+    Ok(RecordedCheckpoint {
+        checkpoint_ref: r#ref,
+        diffstat: files.stat,
+    })
+}
+
 /// Snapshot the worktree, commit it, and move `r#ref` onto the commit.
 ///
 /// The commit's parent is `parent_oid`, or `HEAD` when there is none, so a
@@ -1128,8 +1162,10 @@ async fn collect_changes_inner(
         }
     }
     .map_err(CheckpointError::internal)?;
-    let stats = parse_numstat(&numstat);
-    let mut files = parse_name_status(&name_status);
+    let name_status = complete_nul_terminated_records(&name_status, name_truncated);
+    let numstat = complete_nul_terminated_records(&numstat, numstat_truncated);
+    let stats = parse_numstat(numstat);
+    let mut files = parse_name_status(name_status);
     for file in &mut files {
         if let Some((insertions, deletions)) = stats
             .get(&file.path)
@@ -1162,6 +1198,18 @@ async fn collect_changes_inner(
             truncated,
         },
     })
+}
+
+/// A head-budget cut can land mid-record. `-z` records end at NUL; drop the
+/// dangling fragment so parsers never invent a path that was not in the tree.
+fn complete_nul_terminated_records(raw: &[u8], truncated: bool) -> &[u8] {
+    if !truncated {
+        return raw;
+    }
+    match raw.iter().rposition(|byte| *byte == 0) {
+        Some(end) => &raw[..=end],
+        None => &[],
+    }
 }
 
 fn parse_name_status(raw: &[u8]) -> Vec<ChangedFile> {
@@ -2041,10 +2089,20 @@ mod tests {
         for index in 0..80 {
             std::fs::write(tree.join(format!("file-{index:02}.txt")), "changed\n").unwrap();
         }
-        let recorded =
-            record_checkpoint(&tree, ws(), sess(), 1, TurnStatus::Completed, None, "main")
-                .await
-                .unwrap();
+        let recorded = record_checkpoint_with_output_budget(
+            &tree,
+            ws(),
+            sess(),
+            1,
+            TurnStatus::Completed,
+            None,
+            "main",
+            OutputBudget::head(64, 4),
+        )
+        .await
+        .expect("a truncating budget must still record a checkpoint");
+        assert!(recorded.diffstat.truncated);
+        assert!(recorded.diffstat.files > 0);
         let from = merge_base(&tree, "main").await.unwrap();
         let listed = collect_changes_inner(
             &tree,
@@ -2059,6 +2117,13 @@ mod tests {
         assert!(listed.truncated);
         assert!(listed.stat.truncated);
         assert!(!listed.files.is_empty());
+        for file in &listed.files {
+            let path = file.path.to_wire();
+            assert!(
+                path.starts_with("file-") && path.ends_with(".txt"),
+                "truncated -z stream must not keep a dangling path fragment: {path}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/clone.rs
+++ b/crates/tidebreak-server/src/code/clone.rs
@@ -40,6 +40,8 @@ const GIT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_STDERR_CHARS: usize = 4_096;
 const MAX_PROGRESS_LINE_BYTES: usize = 4_096;
 const COMPLETED_JOB_RETENTION: Duration = Duration::from_secs(30 * 60);
+/// After a failed external clone is reported, wait this long before retrying.
+const EXTERNAL_CLONE_RETRY_BACKOFF: Duration = Duration::from_secs(60);
 const MAX_COMPLETED_JOBS: usize = 256;
 pub const CLONE_PARENT_DIR_SETTING: &str = "code_clone_parent_dir";
 const HOSTED_CLONE_SCHEMES: [&str; 4] = ["git", "http", "https", "ssh"];
@@ -63,6 +65,7 @@ struct CloneJob {
     repo_id: Option<RepoId>,
     external_origin: Option<String>,
     finished_at: Option<Instant>,
+    error_surfaced: bool,
 }
 
 struct CloneJobGuard {
@@ -485,6 +488,7 @@ impl CodeRuntime {
             repo_id: None,
             external_origin,
             finished_at: None,
+            error_surfaced: false,
         };
         self.clone_jobs.insert(job.clone());
         self.publish_clone(&job);
@@ -589,6 +593,7 @@ impl CodeRuntime {
             job.phase = "failed".into();
             job.done = true;
             job.error = Some(error);
+            job.finished_at = Some(Instant::now());
         });
     }
 
@@ -1335,6 +1340,7 @@ mod tests {
             repo_id: None,
             external_origin: None,
             finished_at,
+            error_surfaced: false,
         }
     }
 
@@ -1353,9 +1359,45 @@ mod tests {
         )
     }
 
+    fn local_file_origin(dir: &tempfile::TempDir) -> String {
+        let repo = dir.path().join("origin.git");
+        std::fs::create_dir_all(&repo).unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&repo)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .status()
+            .unwrap();
+        assert!(status.success());
+        std::process::Command::new("git")
+            .args(["config", "user.email", "dev@example.com"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Dev"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        std::fs::write(repo.join("README.md"), "hello\n").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        let committed = std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(&repo)
+            .status()
+            .unwrap();
+        assert!(committed.success());
+        format!("file://{}", repo.display())
+    }
+
     #[tokio::test]
     async fn a_default_parent_clone_does_not_repoint_another_users_parent() {
         let dir = tempfile::TempDir::new().unwrap();
+        let origin = local_file_origin(&dir);
         let runtime = test_runtime(&dir).await;
         let alice = OwnerId::local();
         let bob = OwnerId::new("user:bob").unwrap();
@@ -1364,11 +1406,14 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("default-parent")).unwrap();
 
         assert_eq!(runtime.clone_defaults().await.unwrap().parent_dir, None);
+        // Named members cannot use file://; a closed local port fails immediately
+        // instead of leaving a `git clone` of GitHub running after TempDir drops.
+        let hosted_origin = "git://127.0.0.1:1/demo.git".to_string();
         runtime
             .start_clone(
                 &bob,
                 CloneRequest {
-                    url: Some("https://github.com/acme/demo.git".into()),
+                    url: Some(hosted_origin.clone()),
                     github: None,
                     parent_dir: None,
                     name: Some("bob-default".into()),
@@ -1386,7 +1431,7 @@ mod tests {
             .start_clone(
                 &alice,
                 CloneRequest {
-                    url: Some("https://github.com/acme/demo.git".into()),
+                    url: Some(origin.clone()),
                     github: None,
                     parent_dir: Some(alice_parent.display().to_string()),
                     name: Some("alice-copy".into()),
@@ -1404,7 +1449,7 @@ mod tests {
             .start_clone(
                 &bob,
                 CloneRequest {
-                    url: Some("https://github.com/acme/demo.git".into()),
+                    url: Some(hosted_origin),
                     github: None,
                     parent_dir: None,
                     name: Some("bob-copy".into()),

--- a/crates/tidebreak-server/src/code/clone/external.rs
+++ b/crates/tidebreak-server/src/code/clone/external.rs
@@ -96,9 +96,10 @@ impl CodeRuntime {
             return self.repo_by_origin(owner, origin).await;
         }
         let origin = origin.to_ascii_lowercase();
+        let now = Instant::now();
         let previous = {
             let mut jobs = self.clone_jobs.jobs.lock().expect("clone jobs");
-            prune_completed_jobs(&mut jobs, Instant::now());
+            prune_completed_jobs(&mut jobs, now);
             let matching = jobs
                 .values()
                 .filter(|job| {
@@ -110,13 +111,51 @@ impl CodeRuntime {
                 .iter()
                 .find(|job| !job.done)
                 .cloned()
-                .or_else(|| matching.into_iter().find(|job| job.error.is_none()))
+                .or_else(|| {
+                    matching
+                        .iter()
+                        .find(|job| job.done && job.error.is_none())
+                        .cloned()
+                })
+                .or_else(|| {
+                    matching
+                        .into_iter()
+                        .filter(|job| job.error.is_some())
+                        .max_by_key(|job| job.finished_at)
+                })
         };
         if let Some(job) = previous {
-            if job.done {
+            if !job.done {
+                return Err(preparing());
+            }
+            if job.error.is_none() {
                 return Err(ServerError::conflict_kind("repo_removed", "This repository registration was removed. Register it again before starting a session."));
             }
-            return Err(preparing());
+            let failed = {
+                let mut jobs = self.clone_jobs.jobs.lock().expect("clone jobs");
+                if let Some(live) = jobs.get_mut(&job.id) {
+                    let reason = live.error.clone().unwrap_or_else(|| "clone failed".into());
+                    if !live.error_surfaced {
+                        live.error_surfaced = true;
+                        Some(reason)
+                    } else {
+                        let wait = live.finished_at.map_or(Duration::ZERO, |finished_at| {
+                            now.saturating_duration_since(finished_at)
+                        });
+                        if wait < EXTERNAL_CLONE_RETRY_BACKOFF {
+                            Some(reason)
+                        } else {
+                            jobs.remove(&job.id);
+                            None
+                        }
+                    }
+                } else {
+                    None
+                }
+            };
+            if let Some(reason) = failed {
+                return Err(repository_clone_failed(reason));
+            }
         }
         let lender: Option<Arc<dyn GitCredentialLender>> = if let Some(external) = self
             .harness_llm()
@@ -151,6 +190,10 @@ impl CodeRuntime {
 
 fn preparing() -> ServerError {
     ServerError::conflict_kind("repository_preparing", "Tidebreak is cloning this repository for the session owner. Your request resumes when the checkout is ready.")
+}
+
+fn repository_clone_failed(reason: impl Into<String>) -> ServerError {
+    ServerError::conflict_kind("repository_clone_failed", reason)
 }
 
 #[cfg(test)]
@@ -283,10 +326,47 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert_eq!(
-            after_failure.kind(),
-            "repository_preparing",
-            "a failed job must not block a later clone of the same origin"
+        assert_eq!(after_failure.kind(), "repository_clone_failed");
+        assert!(
+            !after_failure.message().is_empty(),
+            "the failed job's error must be returned once"
         );
+
+        let during_backoff = runtime
+            .prepare_external_repository(
+                &owner,
+                grant,
+                "acme/tools",
+                GitForgeAttributionRequest::Installation,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            during_backoff.kind(),
+            "repository_clone_failed",
+            "a retry must wait for the backoff after a failed clone"
+        );
+        assert_eq!(runtime.clone_jobs.jobs.lock().unwrap().len(), 1);
+
+        {
+            let mut jobs = runtime.clone_jobs.jobs.lock().expect("clone jobs");
+            let job = jobs.get_mut(&job_id).expect("clone job");
+            job.finished_at = Some(Instant::now() - EXTERNAL_CLONE_RETRY_BACKOFF);
+        }
+        let after_backoff = runtime
+            .prepare_external_repository(
+                &owner,
+                grant,
+                "acme/tools",
+                GitForgeAttributionRequest::Installation,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            after_backoff.kind(),
+            "repository_preparing",
+            "a failed job must not block a later clone of the same origin after backoff"
+        );
+        assert_eq!(runtime.clone_jobs.jobs.lock().unwrap().len(), 1);
     }
 }

--- a/crates/tidebreak-server/src/code/gh.rs
+++ b/crates/tidebreak-server/src/code/gh.rs
@@ -1762,16 +1762,34 @@ pub(crate) async fn wait_command_bounded(
 fn finish_bounded_command(
     output: BoundedProcessOutput,
     accept_truncated_stdout: bool,
-) -> Result<String, String> {
+) -> Result<(Vec<u8>, bool), String> {
     let stdout_truncated = output.stdout.truncated;
+    let stderr_truncated = output.stderr.truncated;
     let stderr_empty = output.stderr.bytes.is_empty();
+    if output.status.success() && !output.terminated_for_output {
+        return if stdout_truncated && !accept_truncated_stdout {
+            Err("git output exceeded its limit".into())
+        } else {
+            Ok((output.stdout.bytes, stdout_truncated))
+        };
+    }
+    if output.terminated_for_output
+        && stdout_truncated
+        && !stderr_truncated
+        && stderr_empty
+        && accept_truncated_stdout
+    {
+        return Ok((output.stdout.bytes, true));
+    }
     let stdout = output.stdout.into_marked_text().trim().to_owned();
     let stderr = output.stderr.into_marked_text().trim().to_owned();
-    if output.status.success() && !output.terminated_for_output {
-        return Ok(stdout);
-    }
-    if output.terminated_for_output && accept_truncated_stdout && stdout_truncated && stderr_empty {
-        return Ok(stdout);
+    if output.terminated_for_output {
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(if detail.is_empty() {
+            "git output exceeded its limit".into()
+        } else {
+            detail
+        });
     }
     Err(if stderr.is_empty() { stdout } else { stderr })
 }
@@ -1811,7 +1829,8 @@ async fn git_with_credential(
         &format!("git {}", args.join(" ")),
     )
     .await?;
-    finish_bounded_command(output, true)
+    let (bytes, _) = finish_bounded_command(output, false)?;
+    Ok(String::from_utf8_lossy(&bytes).trim().to_owned())
 }
 
 /// General `gh` runner for creation, status, and comment reads — every
@@ -2284,13 +2303,18 @@ async fn spawn_gh_with_login_env(
     args: &[&str],
     limit: Duration,
 ) -> Result<String, String> {
-    let output = spawn_gh_output(cwd, binary, login_env, args, limit).await?;
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    if output.status.success() {
-        return Ok(stdout);
-    }
-    Err(if stderr.is_empty() { stdout } else { stderr })
+    let output = spawn_gh_output(
+        cwd,
+        binary,
+        login_env,
+        args,
+        limit,
+        OutputBudget::head(GIT_OUTPUT_BYTES, GIT_OUTPUT_LINES),
+        OutputBudget::tail(GIT_ERROR_BYTES, GIT_ERROR_LINES),
+    )
+    .await?;
+    let (bytes, _) = finish_bounded_command(output, false)?;
+    Ok(String::from_utf8_lossy(&bytes).trim().to_owned())
 }
 
 async fn spawn_gh_output(
@@ -2299,50 +2323,9 @@ async fn spawn_gh_output(
     login_env: Option<&[(OsString, OsString)]>,
     args: &[&str],
     limit: Duration,
-) -> Result<std::process::Output, String> {
-    let mut command = Command::new(binary);
-    if let Some(login_env) = login_env {
-        command.env_clear();
-        for (key, value) in filter_child_env(login_env.iter().cloned()) {
-            command.env(key, value);
-        }
-    }
-    command
-        .args(args)
-        .current_dir(cwd)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .env("GH_PROMPT_DISABLED", "1")
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GH_NO_UPDATE_NOTIFIER", "1");
-    let child = command
-        .spawn()
-        .map_err(|err| format!("failed to spawn gh: {err}"))?;
-    timeout(limit, child.wait_with_output())
-        .await
-        .map_err(|_| format!("gh {} timed out", args.join(" ")))?
-        .map_err(|err| format!("gh {} failed: {err}", args.join(" ")))
-}
-
-/// `gh` with bounded stdout/stderr. Job-log fetches use this so a huge log
-/// cannot grow without a cap.
-pub(crate) async fn run_gh_capped(
-    cwd: &Path,
-    binary: &Path,
-    args: &[&str],
-    limit: Duration,
     stdout_budget: OutputBudget,
     stderr_budget: OutputBudget,
 ) -> Result<BoundedProcessOutput, String> {
-    if refuse_gh_args(args) {
-        return Err("refusing to run a merge or GraphQL gh command".into());
-    }
-    let login_env = GH_LAUNCH
-        .get()
-        .filter(|launch| launch.binary == binary)
-        .and_then(|launch| launch.login_env.as_deref().map(Vec::as_slice));
     let mut command = Command::new(binary);
     if let Some(login_env) = login_env {
         command.env_clear();
@@ -2366,6 +2349,35 @@ pub(crate) async fn run_gh_capped(
         stdout_budget,
         stderr_budget,
         &format!("gh {}", args.join(" ")),
+    )
+    .await
+}
+
+/// `gh` with bounded stdout/stderr. Job-log fetches use this so a huge log
+/// cannot grow without a cap.
+pub(crate) async fn run_gh_capped(
+    cwd: &Path,
+    binary: &Path,
+    args: &[&str],
+    limit: Duration,
+    stdout_budget: OutputBudget,
+    stderr_budget: OutputBudget,
+) -> Result<BoundedProcessOutput, String> {
+    if refuse_gh_args(args) {
+        return Err("refusing to run a merge or GraphQL gh command".into());
+    }
+    let login_env = GH_LAUNCH
+        .get()
+        .filter(|launch| launch.binary == binary)
+        .and_then(|launch| launch.login_env.as_deref().map(Vec::as_slice));
+    spawn_gh_output(
+        cwd,
+        binary,
+        login_env,
+        args,
+        limit,
+        stdout_budget,
+        stderr_budget,
     )
     .await
 }
@@ -2401,12 +2413,23 @@ pub async fn run_gh_http(
         .get()
         .filter(|launch| launch.binary == binary)
         .and_then(|launch| launch.login_env.as_deref().map(Vec::as_slice));
-    let output = spawn_gh_output(cwd, binary, login_env, args, limit).await?;
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let output = spawn_gh_output(
+        cwd,
+        binary,
+        login_env,
+        args,
+        limit,
+        OutputBudget::head(GIT_OUTPUT_BYTES, GIT_OUTPUT_LINES),
+        OutputBudget::tail(GIT_ERROR_BYTES, GIT_ERROR_LINES),
+    )
+    .await?;
+    let stdout = String::from_utf8_lossy(&output.stdout.bytes).into_owned();
     match parse_raw_http(&stdout) {
         Some(response) => Ok(response),
         None => {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            let stderr = String::from_utf8_lossy(&output.stderr.bytes)
+                .trim()
+                .to_owned();
             Err(if stderr.is_empty() {
                 format!("gh {} answered no HTTP status", args.join(" "))
             } else {
@@ -2674,29 +2697,43 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn git_output_beyond_the_cap_is_truncated() {
+    async fn oversized_head_output() -> BoundedProcessOutput {
         let mut command = Command::new("head");
         command
             .args(["-c", "4096", "/dev/zero"])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        let output = wait_command_bounded(
+        wait_command_bounded(
             &mut command,
             Duration::from_secs(5),
             OutputBudget::head(64, 8),
             OutputBudget::tail(64, 8),
-            "python3",
+            "head",
         )
         .await
-        .unwrap();
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn git_output_beyond_the_cap_is_truncated() {
+        let output = oversized_head_output().await;
         assert!(output.stdout.truncated);
         assert!(output.stdout.bytes.len() <= 64);
-        let marked = output.stdout.clone().into_marked_text();
+        let marked = output.stdout.into_marked_text();
         assert!(marked.contains("[output truncated]"));
-        let finished = finish_bounded_command(output, true).unwrap();
-        assert!(finished.contains("[output truncated]"));
+        let accepted = oversized_head_output().await;
+        let (finished, truncated) = finish_bounded_command(accepted, true).unwrap();
+        assert!(truncated);
+        assert!(
+            !String::from_utf8_lossy(&finished).contains("[output truncated]"),
+            "callers parse raw bytes; the marker must not be spliced in"
+        );
+        let refused = finish_bounded_command(oversized_head_output().await, false).unwrap_err();
+        assert!(
+            refused.contains("exceeded its limit") || refused.contains("[output truncated]"),
+            "{refused}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What was wrong

PR #3366 landed with review findings still open.

- A head-budget cut on `git diff --name-status -z` / `--numstat -z` landed mid-record. Parsers split on NUL and kept the dangling fragment, so a truncated stream could invent a path that was never in the tree.
- A permanently failing external origin never surfaced `repository_clone_failed`. Every later adapter message got "cloning... resumes when ready" and started a fresh `git clone`.
- `finish_bounded_command` spliced `[output truncated]` into stdout and returned `Ok`. Callers that parse `git status --porcelain` and `git log --format=%h %s` line-wise would treat the marker as a row.
- `run_gh_capped` duplicated `spawn_gh_output`'s env/stdio setup.
- The clone parent-dir test spawned detached `git clone` tasks against `https://github.com/acme/demo.git` that outlived the TempDir.
- A `gh` test described the command as `python3` while it ran `head`.

## What changed

- When a `-z` stream is truncated, drop everything after the last NUL before parsing. Tests assert returned paths and that `record_checkpoint` still records a truncated checkpoint.
- The request that observes a failed external clone job returns `repository_clone_failed` with the reason. A retry is allowed only after a 60s backoff.
- `finish_bounded_command` now returns raw bytes plus a truncation flag, matching `finish_git_output`. `git()` and `gh` text callers that cannot tolerate truncation fail instead of parsing marked text.
- `spawn_gh_output` takes stdout/stderr budgets; `run_gh_capped` uses that runner.
- The parent-dir clone test uses a local `file://` origin for the local owner (hosted members still cannot use `file://`, so they clone a closed local `git://` port that fails immediately).
- The bounded-output test description matches the `head` command.

Part of #3347
Follows up #3366

## Checks

- `cargo fmt --all`
- `cargo check -p tidebreak-server-core`
- `cargo test -p tidebreak-server-core --lib code::clone`
- `cargo test -p tidebreak-server-core --lib code::gh`
- `cargo test -p tidebreak-server-core --lib code::ci_logs`
- `cargo test -p tidebreak-server-core --lib code::checkpoint`
- `cargo clippy -p tidebreak-server-core --all-targets -- -D warnings -A clippy::too_many_arguments`
