### PR TITLE
improve(code): own terminal process and reader lifetimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,6 +634,7 @@ jobs:
           $suites = @(
             @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-code-execution", "--locked"),
             @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-harness", "--locked"),
+            @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-server-core", "--lib", "code::terminal", "--locked"),
             @("test", "--target", "x86_64-pc-windows-msvc", "-p", "tidebreak-server", "--lib", "code::", "--locked")
           )
           foreach ($suite in $suites) {

--- a/crates/tidebreak-server-api/src/routes/code/terminals.rs
+++ b/crates/tidebreak-server-api/src/routes/code/terminals.rs
@@ -60,7 +60,11 @@ pub async fn close_workspace_terminals(
     Path(id): Path<WorkspaceId>,
 ) -> Result<StatusCode, ServerError> {
     let _ = code.get_workspace(id).await?;
-    state.terminals.close_workspace(id);
+    if !state.terminals.close_workspace_and_wait(id).await {
+        return Err(map_terminal(TerminalError::Io(
+            "terminal shutdown did not complete".into(),
+        )));
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -70,9 +74,10 @@ pub async fn close_terminal(
     Path(path): Path<WorkspaceTerminalPath>,
 ) -> Result<StatusCode, ServerError> {
     let _ = code.get_workspace(path.id).await?;
-    state
-        .terminals
-        .close(path.id, path.tid)
+    let terminals = state.terminals.clone();
+    tokio::task::spawn_blocking(move || terminals.close(path.id, path.tid))
+        .await
+        .map_err(|error| map_terminal(TerminalError::Io(error.to_string())))?
         .map_err(map_terminal)?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/tidebreak-server/Cargo.toml
+++ b/crates/tidebreak-server/Cargo.toml
@@ -118,7 +118,7 @@ portable-pty = "=0.9.0"
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Threading"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_Security", "Win32_System_Console", "Win32_System_JobObjects", "Win32_System_Pipes"] }
 # HKLM policy reads for the Windows managed-policy reader.
 winreg = "=0.56.0"
 

--- a/crates/tidebreak-server/src/code/terminal.rs
+++ b/crates/tidebreak-server/src/code/terminal.rs
@@ -7,12 +7,27 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, Weak};
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+#[cfg(unix)]
+use unix::ProcessTree;
+#[cfg(windows)]
+use windows::ProcessTree;
+#[cfg(unix)]
+type TerminalMaster = Box<dyn MasterPty + Send>;
+#[cfg(windows)]
+type TerminalMaster = windows::Master;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
-use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use portable_pty::PtySize;
+#[cfg(unix)]
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty};
 use tidebreak_core::{CodeTerminalId, OwnerId, WorkspaceId};
 use tokio::sync::broadcast;
 
@@ -55,6 +70,7 @@ pub struct TerminalHub {
 struct HubInner {
     by_id: HashMap<CodeTerminalId, Arc<Mutex<LiveTerminal>>>,
     by_workspace: HashMap<WorkspaceId, Vec<CodeTerminalId>>,
+    reservations: HashMap<WorkspaceId, usize>,
 }
 
 struct LiveTerminal {
@@ -75,14 +91,17 @@ struct LiveTerminal {
     producing: bool,
     created_at: DateTime<Utc>,
     writer: Option<Box<dyn Write + Send>>,
-    master: Option<Box<dyn MasterPty + Send>>,
-    killer: Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
+    master: Option<TerminalMaster>,
+    tree: Option<Arc<ProcessTree>>,
+    reader_exit: Arc<TerminalExit>,
+    reader_thread: Option<thread::JoinHandle<()>>,
+    reaper_thread: Option<thread::JoinHandle<()>>,
     exit: Arc<TerminalExit>,
     coalesce: Coalesce,
 }
 
 struct TerminalExit {
-    done: Mutex<bool>,
+    done: Mutex<Option<bool>>,
     changed: Condvar,
 }
 
@@ -137,6 +156,7 @@ impl TerminalHub {
             inner: Mutex::new(HubInner {
                 by_id: HashMap::new(),
                 by_workspace: HashMap::new(),
+                reservations: HashMap::new(),
             }),
             notices: Mutex::new(HashMap::new()),
         }
@@ -166,7 +186,7 @@ impl TerminalHub {
     ) -> Result<TerminalSnapshot, TerminalError> {
         let cols = clamp_size(cols.unwrap_or(DEFAULT_COLS))?;
         let rows = clamp_size(rows.unwrap_or(DEFAULT_ROWS))?;
-        self.reserve_slot(workspace_id)?;
+        let reservation = self.reserve_slot(workspace_id)?;
         let spawned = spawn_pty(cwd, cols, rows)?;
         let id = CodeTerminalId::new();
         let live = LiveTerminal {
@@ -181,20 +201,28 @@ impl TerminalHub {
             created_at: Utc::now(),
             writer: Some(spawned.writer),
             master: Some(spawned.master),
-            killer: Some(spawned.killer),
+            tree: Some(spawned.tree),
+            reader_exit: Arc::new(TerminalExit::new(false)),
+            reader_thread: None,
+            reaper_thread: None,
             exit: Arc::new(TerminalExit::new(false)),
             coalesce: Coalesce::new(),
         };
         let handle = Arc::new(Mutex::new(live));
-        self.insert(workspace_id, id, handle.clone());
         let notices = self.notices_sender(owner);
-        start_reader(handle.clone(), notices.clone(), spawned.reader);
-        start_reaper(
+        let reader_thread = start_reader(handle.clone(), notices.clone(), spawned.reader);
+        let reaper_thread = start_reaper(
             handle.clone(),
             notices,
             spawned.child,
             handle.lock().expect("terminal").exit.clone(),
         );
+        {
+            let mut live = handle.lock().expect("terminal");
+            live.reader_thread = Some(reader_thread);
+            live.reaper_thread = Some(reaper_thread);
+        }
+        reservation.insert(id, handle.clone());
         Ok(lock_snapshot(&handle))
     }
 
@@ -209,7 +237,7 @@ impl TerminalHub {
     ) -> Result<TerminalSnapshot, TerminalError> {
         let cols = clamp_size(cols)?;
         let rows = clamp_size(rows)?;
-        self.reserve_slot(workspace_id)?;
+        let reservation = self.reserve_slot(workspace_id)?;
         let id = CodeTerminalId::new();
         let live = LiveTerminal {
             id,
@@ -223,12 +251,15 @@ impl TerminalHub {
             created_at: Utc::now(),
             writer: None,
             master: None,
-            killer: None,
+            tree: None,
+            reader_exit: Arc::new(TerminalExit::new(true)),
+            reader_thread: None,
+            reaper_thread: None,
             exit: Arc::new(TerminalExit::new(true)),
             coalesce: Coalesce::new(),
         };
         let handle = Arc::new(Mutex::new(live));
-        self.insert(workspace_id, id, handle.clone());
+        reservation.insert(id, handle.clone());
         Ok(lock_snapshot(&handle))
     }
 
@@ -350,34 +381,18 @@ impl TerminalHub {
         let handle = self
             .handle(workspace_id, id)
             .ok_or(TerminalError::NotFound)?;
-        {
-            let mut live = handle.lock().expect("terminal");
-            live.kill_and_end();
-        }
+        shutdown(&handle, Instant::now() + TERMINAL_EXIT_GRACE)?;
         self.remove(workspace_id, id);
         Ok(())
     }
 
-    pub fn close_workspace(&self, workspace_id: WorkspaceId) {
-        let ids = {
-            let inner = self.inner.lock().expect("terminal hub");
-            inner
-                .by_workspace
-                .get(&workspace_id)
-                .cloned()
-                .unwrap_or_default()
-        };
-        for id in ids {
-            let _ = self.close(workspace_id, id);
-        }
-    }
-
-    /// Stop every terminal and prove that each shell process exited.
-    ///
-    /// Archive treats a timeout as uncertainty and preserves the checkout.
+    /// Stop terminals and retain any uncertain shutdown so archive can retry it.
     pub async fn close_workspace_and_wait(&self, workspace_id: WorkspaceId) -> bool {
         let handles = {
             let inner = self.inner.lock().expect("terminal hub");
+            if inner.reservations.get(&workspace_id).copied().unwrap_or(0) != 0 {
+                return false;
+            }
             inner
                 .by_workspace
                 .get(&workspace_id)
@@ -386,24 +401,29 @@ impl TerminalHub {
                 .filter_map(|id| inner.by_id.get(id).cloned())
                 .collect::<Vec<_>>()
         };
-        let exits = handles
-            .iter()
-            .map(|handle| {
-                let mut live = handle.lock().expect("terminal");
-                live.kill_and_end();
-                live.exit.clone()
-            })
-            .collect::<Vec<_>>();
-        for handle in handles {
-            let id = handle.lock().expect("terminal").id;
-            self.remove(workspace_id, id);
-        }
-        tokio::task::spawn_blocking(move || {
+        let result = tokio::task::spawn_blocking(move || {
             let deadline = Instant::now() + TERMINAL_EXIT_GRACE;
-            exits.into_iter().all(|exit| exit.wait_until(deadline))
+            handles
+                .into_iter()
+                .map(|handle| {
+                    let id = handle.lock().expect("terminal").id;
+                    (id, shutdown(&handle, deadline).is_ok())
+                })
+                .collect::<Vec<_>>()
         })
-        .await
-        .unwrap_or(false)
+        .await;
+        let Ok(results) = result else {
+            return false;
+        };
+        let mut complete = true;
+        for (id, stopped) in results {
+            if stopped {
+                self.remove(workspace_id, id);
+            } else {
+                complete = false;
+            }
+        }
+        complete
     }
 
     /// Append output as if the PTY had produced it. Tests and the reader thread.
@@ -423,28 +443,22 @@ impl TerminalHub {
         apply_coalesce(&mut live, &handle, &notices, workspace_id, id);
     }
 
-    fn reserve_slot(&self, workspace_id: WorkspaceId) -> Result<(), TerminalError> {
-        let inner = self.inner.lock().expect("terminal hub");
+    fn reserve_slot(&self, workspace_id: WorkspaceId) -> Result<Reservation<'_>, TerminalError> {
+        let mut inner = self.inner.lock().expect("terminal hub");
         let count = inner
             .by_workspace
             .get(&workspace_id)
             .map(Vec::len)
-            .unwrap_or(0);
+            .unwrap_or(0)
+            + inner.reservations.get(&workspace_id).copied().unwrap_or(0);
         if count >= MAX_TERMINALS_PER_WORKSPACE {
             return Err(TerminalError::WorkspaceCap);
         }
-        Ok(())
-    }
-
-    fn insert(
-        &self,
-        workspace_id: WorkspaceId,
-        id: CodeTerminalId,
-        handle: Arc<Mutex<LiveTerminal>>,
-    ) {
-        let mut inner = self.inner.lock().expect("terminal hub");
-        inner.by_id.insert(id, handle);
-        inner.by_workspace.entry(workspace_id).or_default().push(id);
+        *inner.reservations.entry(workspace_id).or_default() += 1;
+        Ok(Reservation {
+            hub: self,
+            workspace_id,
+        })
     }
 
     fn remove(&self, workspace_id: WorkspaceId, id: CodeTerminalId) {
@@ -480,34 +494,102 @@ impl Default for TerminalHub {
     }
 }
 
-impl LiveTerminal {
-    fn kill_and_end(&mut self) {
-        if let Some(mut killer) = self.killer.take() {
-            let _ = killer.kill();
-        }
-        self.writer = None;
-        self.master = None;
-        self.ended = true;
-        self.producing = false;
+struct Reservation<'a> {
+    hub: &'a TerminalHub,
+    workspace_id: WorkspaceId,
+}
+
+impl Reservation<'_> {
+    fn insert(self, id: CodeTerminalId, handle: Arc<Mutex<LiveTerminal>>) {
+        let mut inner = self.hub.inner.lock().expect("terminal hub");
+        inner.by_id.insert(id, handle);
+        inner
+            .by_workspace
+            .entry(self.workspace_id)
+            .or_default()
+            .push(id);
     }
+}
+
+impl Drop for Reservation<'_> {
+    fn drop(&mut self) {
+        let mut inner = self.hub.inner.lock().expect("terminal hub");
+        if let Some(count) = inner.reservations.get_mut(&self.workspace_id) {
+            *count -= 1;
+            if *count == 0 {
+                inner.reservations.remove(&self.workspace_id);
+            }
+        }
+    }
+}
+
+fn shutdown(handle: &Arc<Mutex<LiveTerminal>>, deadline: Instant) -> Result<(), TerminalError> {
+    let (tree, exit, reader_exit) = {
+        let mut live = handle.lock().expect("terminal");
+        live.ended = true;
+        (
+            live.tree.clone(),
+            Arc::clone(&live.exit),
+            Arc::clone(&live.reader_exit),
+        )
+    };
+    if let Some(tree) = &tree {
+        if !tree
+            .terminate_and_wait(deadline)
+            .map_err(|error| TerminalError::Io(error.to_string()))?
+        {
+            return Err(TerminalError::Io("terminal processes did not stop".into()));
+        }
+        tree.cancel_reader();
+    }
+    if !exit.wait_until(deadline) || !reader_exit.wait_until(deadline) {
+        return Err(TerminalError::Io(
+            "terminal shutdown did not complete".into(),
+        ));
+    }
+    #[cfg(windows)]
+    if tree.as_ref().is_some_and(|tree| !tree.reader_done()) {
+        return Err(TerminalError::Io(
+            "terminal reader handle remains open".into(),
+        ));
+    }
+    let (reader, reaper, writer, master) = {
+        let mut live = handle.lock().expect("terminal");
+        (
+            live.reader_thread.take(),
+            live.reaper_thread.take(),
+            live.writer.take(),
+            live.master.take(),
+        )
+    };
+    // Completion is signaled after the blocking handles are released. Join
+    // outside the terminal mutex because each worker uses it on its way out.
+    for worker in [reader, reaper].into_iter().flatten() {
+        worker
+            .join()
+            .map_err(|_| TerminalError::Io("terminal worker failed".into()))?;
+    }
+    drop(writer);
+    drop(master);
+    Ok(())
 }
 
 impl TerminalExit {
     fn new(done: bool) -> Self {
         Self {
-            done: Mutex::new(done),
+            done: Mutex::new(done.then_some(true)),
             changed: Condvar::new(),
         }
     }
 
-    fn mark_done(&self) {
-        *self.done.lock().expect("terminal exit") = true;
+    fn mark_done(&self, succeeded: bool) {
+        *self.done.lock().expect("terminal exit") = Some(succeeded);
         self.changed.notify_all();
     }
 
     fn wait_until(&self, deadline: Instant) -> bool {
         let mut done = self.done.lock().expect("terminal exit");
-        while !*done {
+        while done.is_none() {
             let now = Instant::now();
             if now >= deadline {
                 return false;
@@ -517,22 +599,23 @@ impl TerminalExit {
                 .wait_timeout(done, deadline.saturating_duration_since(now))
                 .expect("terminal exit");
             done = waited.0;
-            if waited.1.timed_out() && !*done {
+            if waited.1.timed_out() && done.is_none() {
                 return false;
             }
         }
-        true
+        *done == Some(true)
     }
 }
 
 struct Spawned {
-    master: Box<dyn MasterPty + Send>,
+    master: TerminalMaster,
     writer: Box<dyn Write + Send>,
     reader: Box<dyn Read + Send>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
-    killer: Box<dyn portable_pty::ChildKiller + Send + Sync>,
+    tree: Arc<ProcessTree>,
 }
 
+#[cfg(unix)]
 fn spawn_pty(cwd: &Path, cols: u16, rows: u16) -> Result<Spawned, TerminalError> {
     let system = native_pty_system();
     let pair = system
@@ -548,25 +631,59 @@ fn spawn_pty(cwd: &Path, cols: u16, rows: u16) -> Result<Spawned, TerminalError>
     for (key, value) in embedded_terminal_env() {
         cmd.env(key, value);
     }
-    let child = pair
+    let mut child = pair
         .slave
         .spawn_command(cmd)
         .map_err(|err| TerminalError::Spawn(err.to_string()))?;
-    let killer = child.clone_killer();
-    let reader = pair
-        .master
-        .try_clone_reader()
-        .map_err(|err| TerminalError::Spawn(err.to_string()))?;
-    let writer = pair
-        .master
-        .take_writer()
-        .map_err(|err| TerminalError::Spawn(err.to_string()))?;
+    let setup = (|| {
+        let tree = ProcessTree::new(
+            child
+                .process_id()
+                .ok_or_else(|| std::io::Error::other("terminal process id unavailable"))?,
+        )?;
+        let fd = pair
+            .master
+            .as_raw_fd()
+            .ok_or_else(|| std::io::Error::other("terminal reader handle unavailable"))?;
+        let reader = tree.reader(fd)?;
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        Ok::<_, std::io::Error>((tree, reader, writer))
+    })();
+    let (tree, reader, writer) = match setup {
+        Ok(parts) => parts,
+        Err(error) => {
+            if let Some(pid) = child.process_id() {
+                if let Ok(tree) = ProcessTree::new(pid) {
+                    let _ = tree.terminate_and_wait(Instant::now() + TERMINAL_EXIT_GRACE);
+                }
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(TerminalError::Spawn(error.to_string()));
+        }
+    };
     Ok(Spawned {
         master: pair.master,
         writer,
         reader,
         child,
-        killer,
+        tree,
+    })
+}
+
+#[cfg(windows)]
+fn spawn_pty(cwd: &Path, cols: u16, rows: u16) -> Result<Spawned, TerminalError> {
+    let spawned = windows::spawn(&user_shell(), cwd, cols, rows, &embedded_terminal_env())
+        .map_err(|error| TerminalError::Spawn(error.to_string()))?;
+    Ok(Spawned {
+        master: spawned.master,
+        writer: spawned.writer,
+        reader: spawned.reader,
+        child: spawned.child,
+        tree: spawned.tree,
     })
 }
 
@@ -612,7 +729,7 @@ fn start_reader(
     handle: Arc<Mutex<LiveTerminal>>,
     notices: broadcast::Sender<TerminalNotice>,
     mut reader: Box<dyn Read + Send>,
-) {
+) -> thread::JoinHandle<()> {
     thread::Builder::new()
         .name("code-terminal-read".into())
         .spawn(move || {
@@ -639,7 +756,9 @@ fn start_reader(
                     Err(_) => break,
                 }
             }
+            drop(reader);
             if let Ok(mut live) = handle.lock() {
+                live.reader_exit.mark_done(true);
                 live.ended = true;
                 live.producing = false;
                 let workspace_id = live.workspace_id;
@@ -648,7 +767,7 @@ fn start_reader(
                 publish_notice(&notices, workspace_id, id);
             }
         })
-        .expect("code-terminal-read thread");
+        .expect("code-terminal-read thread")
 }
 
 fn start_reaper(
@@ -656,12 +775,29 @@ fn start_reaper(
     notices: broadcast::Sender<TerminalNotice>,
     mut child: Box<dyn portable_pty::Child + Send + Sync>,
     exit: Arc<TerminalExit>,
-) {
+) -> thread::JoinHandle<()> {
     thread::Builder::new()
         .name("code-terminal-wait".into())
         .spawn(move || {
-            let _ = child.wait();
-            exit.mark_done();
+            #[cfg(unix)]
+            let succeeded = {
+                let tree = handle.lock().expect("terminal").tree.clone().expect("process tree");
+                // Keep the unreaped shell as the session identity until every
+                // descendant stops. A failed cleanup must retain that anchor.
+                loop {
+                    match tree.wait_and_reap(child.as_mut()) {
+                        Ok(_) => break true,
+                        Err(error) => {
+                            tracing::warn!(%error, "terminal process cleanup failed; retaining session ownership");
+                            thread::sleep(Duration::from_secs(1));
+                        }
+                    }
+                }
+            };
+            #[cfg(windows)]
+            let succeeded = child.wait().is_ok();
+            drop(child);
+            exit.mark_done(succeeded);
             if let Ok(mut live) = handle.lock() {
                 if !live.ended {
                     // The shell is gone, so nothing can be typed at it. Leave
@@ -677,7 +813,7 @@ fn start_reaper(
                 }
             }
         })
-        .expect("code-terminal-wait thread");
+        .expect("code-terminal-wait thread")
 }
 
 fn publish_notice(
@@ -691,31 +827,77 @@ fn publish_notice(
     });
 }
 
+struct PendingNotice {
+    due: Instant,
+    handle: Weak<Mutex<LiveTerminal>>,
+    notices: broadcast::Sender<TerminalNotice>,
+    workspace_id: WorkspaceId,
+    terminal_id: CodeTerminalId,
+}
+
 fn schedule_trailing_notice(
     handle: Arc<Mutex<LiveTerminal>>,
     notices: broadcast::Sender<TerminalNotice>,
     workspace_id: WorkspaceId,
     terminal_id: CodeTerminalId,
 ) {
-    thread::Builder::new()
-        .name("code-terminal-notice".into())
-        .spawn(move || {
-            thread::sleep(TERMINAL_NOTICE_COALESCE);
-            let mut live = match handle.lock() {
-                Ok(live) => live,
-                Err(_) => return,
-            };
-            if !live.coalesce.dirty {
-                live.coalesce.scheduled = false;
-                return;
-            }
-            live.coalesce.dirty = false;
-            live.coalesce.scheduled = false;
-            live.coalesce.quiet_until = Instant::now() + TERMINAL_NOTICE_COALESCE;
-            drop(live);
-            publish_notice(&notices, workspace_id, terminal_id);
-        })
-        .ok();
+    static SCHEDULER: std::sync::OnceLock<std::sync::mpsc::Sender<PendingNotice>> =
+        std::sync::OnceLock::new();
+    let scheduler = SCHEDULER.get_or_init(|| {
+        let (sender, receiver) = std::sync::mpsc::channel::<PendingNotice>();
+        thread::Builder::new()
+            .name("code-terminal-notice".into())
+            .spawn(move || {
+                let mut pending = Vec::<PendingNotice>::new();
+                loop {
+                    let received = match pending.iter().map(|notice| notice.due).min() {
+                        Some(due) => {
+                            receiver.recv_timeout(due.saturating_duration_since(Instant::now()))
+                        }
+                        None => receiver
+                            .recv()
+                            .map_err(|_| std::sync::mpsc::RecvTimeoutError::Disconnected),
+                    };
+                    match received {
+                        Ok(notice) => pending.push(notice),
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                    }
+                    let now = Instant::now();
+                    pending.retain(|notice| {
+                        if notice.due > now {
+                            return true;
+                        }
+                        if let Some(handle) = notice.handle.upgrade() {
+                            if let Ok(mut live) = handle.lock() {
+                                let dirty = live.coalesce.dirty;
+                                live.coalesce.dirty = false;
+                                live.coalesce.scheduled = false;
+                                if dirty {
+                                    live.coalesce.quiet_until = now + TERMINAL_NOTICE_COALESCE;
+                                    drop(live);
+                                    publish_notice(
+                                        &notice.notices,
+                                        notice.workspace_id,
+                                        notice.terminal_id,
+                                    );
+                                }
+                            }
+                        }
+                        false
+                    });
+                }
+            })
+            .expect("code-terminal-notice thread");
+        sender
+    });
+    let _ = scheduler.send(PendingNotice {
+        due: Instant::now() + TERMINAL_NOTICE_COALESCE,
+        handle: Arc::downgrade(&handle),
+        notices,
+        workspace_id,
+        terminal_id,
+    });
 }
 
 fn apply_coalesce(
@@ -818,16 +1000,22 @@ impl ByteRing {
     }
 
     fn write(&mut self, bytes: &[u8]) {
-        for &byte in bytes {
-            if self.len == self.cap {
-                self.head = (self.head + 1) % self.cap;
-                self.start += 1;
-                self.len -= 1;
-            }
-            let idx = (self.head + self.len) % self.cap;
-            self.buf[idx] = byte;
-            self.len += 1;
+        if bytes.len() >= self.cap {
+            self.start = self.end() + bytes.len() as u64 - self.cap as u64;
+            self.buf.copy_from_slice(&bytes[bytes.len() - self.cap..]);
+            self.head = 0;
+            self.len = self.cap;
+            return;
         }
+        let discard = (self.len + bytes.len()).saturating_sub(self.cap);
+        self.start += discard as u64;
+        self.head = (self.head + discard) % self.cap;
+        self.len -= discard;
+        let tail = (self.head + self.len) % self.cap;
+        let first = bytes.len().min(self.cap - tail);
+        self.buf[tail..tail + first].copy_from_slice(&bytes[..first]);
+        self.buf[..bytes.len() - first].copy_from_slice(&bytes[first..]);
+        self.len += bytes.len();
     }
 
     fn read(&self, cursor: u64, max: usize) -> (Vec<u8>, u64, bool, bool) {
@@ -847,10 +1035,10 @@ impl ByteRing {
         }
         if take > 0 {
             let offset = (pos - self.start) as usize;
-            for i in 0..take {
-                let idx = (self.head + offset + i) % self.cap;
-                out.push(self.buf[idx]);
-            }
+            let first_index = (self.head + offset) % self.cap;
+            let first = take.min(self.cap - first_index);
+            out.extend_from_slice(&self.buf[first_index..first_index + first]);
+            out.extend_from_slice(&self.buf[..take - first]);
         }
         (out, pos + take as u64, overflow, take < available)
     }
@@ -859,6 +1047,73 @@ impl ByteRing {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reservations_enforce_the_cap_before_any_spawn_finishes() {
+        let hub = TerminalHub::new();
+        let workspace = workspace();
+        let reservations = (0..MAX_TERMINALS_PER_WORKSPACE)
+            .map(|_| hub.reserve_slot(workspace).unwrap())
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            hub.reserve_slot(workspace),
+            Err(TerminalError::WorkspaceCap)
+        ));
+        drop(reservations);
+        assert!(hub.reserve_slot(workspace).is_ok());
+    }
+
+    #[tokio::test]
+    async fn failed_shutdown_stays_registered_for_the_next_archive_attempt() {
+        let hub = TerminalHub::new();
+        let workspace = workspace();
+        let snapshot = hub
+            .open_memory(&OwnerId::local(), workspace, 80, 24)
+            .unwrap();
+        let handle = handle_of(&hub, snapshot.id);
+        handle.lock().unwrap().exit = Arc::new(TerminalExit::new(false));
+        handle.lock().unwrap().exit.mark_done(false);
+        assert!(!hub.close_workspace_and_wait(workspace).await);
+        assert!(hub.get(workspace, snapshot.id).is_some());
+        handle.lock().unwrap().exit.mark_done(true);
+        assert!(hub.close_workspace_and_wait(workspace).await);
+        assert!(hub.get(workspace, snapshot.id).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn closing_a_terminal_stops_background_jobs_and_joins_the_reader() {
+        let root = tempfile::tempdir().unwrap();
+        let hub = TerminalHub::new();
+        let workspace = workspace();
+        let snapshot = hub
+            .open(&OwnerId::local(), workspace, root.path(), None, None)
+            .unwrap();
+        let handle = handle_of(&hub, snapshot.id);
+        hub.write(
+            workspace,
+            snapshot.id,
+            b"/bin/sh -c 'trap \"\" HUP; sleep 60 & echo $! > terminal-child.pid; wait' &\n",
+        )
+        .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !root.path().join("terminal-child.pid").exists() {
+            assert!(Instant::now() < deadline, "terminal job never started");
+            thread::sleep(Duration::from_millis(10));
+        }
+        hub.close(workspace, snapshot.id).unwrap();
+        let live = handle.lock().unwrap();
+        assert!(!live.producing);
+        assert!(live.reader_thread.is_none());
+        assert!(live.reaper_thread.is_none());
+        assert!(live.master.is_none());
+        assert!(live
+            .tree
+            .as_ref()
+            .unwrap()
+            .terminate_and_wait(Instant::now())
+            .unwrap());
+    }
 
     fn workspace() -> WorkspaceId {
         WorkspaceId::new()

--- a/crates/tidebreak-server/src/code/terminal/unix.rs
+++ b/crates/tidebreak-server/src/code/terminal/unix.rs
@@ -1,0 +1,385 @@
+//! Own the PTY session, including foreground and background job-control groups.
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+pub(super) struct ProcessTree {
+    session: libc::pid_t,
+    cancelled: AtomicBool,
+    lifetime: Mutex<Lifetime>,
+    #[cfg(test)]
+    scans: std::sync::atomic::AtomicUsize,
+}
+
+#[derive(Clone, Copy)]
+enum Lifetime {
+    Owned,
+    Retired,
+    Uncertain,
+}
+
+impl ProcessTree {
+    pub(super) fn new(pid: u32) -> io::Result<Arc<Self>> {
+        let session = libc::pid_t::try_from(pid)
+            .ok()
+            .filter(|pid| *pid > 0)
+            .ok_or_else(|| io::Error::other("terminal shell has no process identity"))?;
+        Ok(Arc::new(Self {
+            session,
+            cancelled: AtomicBool::new(false),
+            lifetime: Mutex::new(Lifetime::Owned),
+            #[cfg(test)]
+            scans: std::sync::atomic::AtomicUsize::new(0),
+        }))
+    }
+
+    pub(super) fn reader(self: &Arc<Self>, fd: libc::c_int) -> io::Result<Box<dyn Read + Send>> {
+        // SAFETY: fd belongs to the live PTY master. The duplicate is owned here.
+        let duplicate = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+        if duplicate < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: fcntl returned a fresh descriptor which File now owns.
+        let file = unsafe { File::from_raw_fd(duplicate) };
+        Ok(Box::new(Reader {
+            file,
+            tree: Arc::clone(self),
+        }))
+    }
+
+    pub(super) fn cancel_reader(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    pub(super) fn terminate_and_wait(&self, deadline: Instant) -> io::Result<bool> {
+        let lifetime = self
+            .lifetime
+            .lock()
+            .map_err(|_| io::Error::other("terminal lifetime lock failed"))?;
+        match *lifetime {
+            Lifetime::Owned => self.terminate_owned_session(deadline),
+            Lifetime::Retired => Ok(true),
+            Lifetime::Uncertain => Err(io::Error::other("terminal session ownership is uncertain")),
+        }
+    }
+
+    /// Observe exit without releasing the shell PID, then stop its remaining
+    /// jobs before reaping. The zombie leader keeps the session ID unavailable
+    /// for reuse throughout cleanup. On error the caller must retain the child.
+    pub(super) fn wait_and_reap(
+        &self,
+        child: &mut dyn portable_pty::Child,
+    ) -> io::Result<portable_pty::ExitStatus> {
+        {
+            let lifetime = self
+                .lifetime
+                .lock()
+                .map_err(|_| io::Error::other("terminal lifetime lock failed"))?;
+            match *lifetime {
+                Lifetime::Retired => return child.wait(),
+                Lifetime::Uncertain => {
+                    return Err(io::Error::other("terminal session ownership is uncertain"))
+                }
+                Lifetime::Owned => {}
+            }
+        }
+        let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::zeroed();
+        loop {
+            // SAFETY: session is the positive PID of the child this reaper
+            // owns. WNOWAIT leaves its exit status and PID reserved for wait().
+            let observed = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    self.session as libc::id_t,
+                    info.as_mut_ptr(),
+                    libc::WEXITED | libc::WNOWAIT,
+                )
+            };
+            if observed == 0 {
+                break;
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            *self
+                .lifetime
+                .lock()
+                .map_err(|_| io::Error::other("terminal lifetime lock failed"))? =
+                Lifetime::Uncertain;
+            return Err(error);
+        }
+        let mut lifetime = self
+            .lifetime
+            .lock()
+            .map_err(|_| io::Error::other("terminal lifetime lock failed"))?;
+        match *lifetime {
+            Lifetime::Uncertain => {
+                return Err(io::Error::other("terminal session ownership is uncertain"))
+            }
+            Lifetime::Retired => return child.wait(),
+            Lifetime::Owned => {}
+        }
+        if !self.terminate_owned_session(Instant::now() + Duration::from_secs(5))? {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "terminal session did not stop",
+            ));
+        }
+        // Retirement and reaping share the lock used by every terminator. Once
+        // wait releases the numeric PID, no caller can scan that session again.
+        *lifetime = Lifetime::Retired;
+        child.wait()
+    }
+
+    fn terminate_owned_session(&self, deadline: Instant) -> io::Result<bool> {
+        loop {
+            #[cfg(test)]
+            self.scans.fetch_add(1, Ordering::Relaxed);
+            let members = session_members(self.session)?;
+            if members.is_empty() {
+                return Ok(true);
+            }
+            // Freeze every observed job before killing it. Re-enumeration catches
+            // children forked between the snapshot and the stop signal.
+            for pid in &members {
+                signal_member(self.session, *pid, libc::SIGSTOP)?;
+            }
+            for pid in &members {
+                signal_member(self.session, *pid, libc::SIGKILL)?;
+            }
+            if Instant::now() >= deadline {
+                return Ok(false);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+struct Reader {
+    file: File,
+    tree: Arc<ProcessTree>,
+}
+
+impl Read for Reader {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            if self.tree.cancelled.load(Ordering::Acquire) {
+                return Ok(0);
+            }
+            let mut poll = libc::pollfd {
+                fd: self.file.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            // SAFETY: poll points to one initialized descriptor owned by this reader.
+            let ready = unsafe { libc::poll(&mut poll, 1, 50) };
+            if ready < 0 {
+                let error = io::Error::last_os_error();
+                if error.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error);
+            }
+            if ready == 0 {
+                continue;
+            }
+            // This is the only reader of the master, so no competing read can
+            // consume the readiness before this call. EIO denotes a closed PTY.
+            return match self.file.read(buffer) {
+                Err(error) if error.raw_os_error() == Some(libc::EIO) => Ok(0),
+                result => result,
+            };
+        }
+    }
+}
+
+fn signal_member(session: libc::pid_t, pid: libc::pid_t, signal: libc::c_int) -> io::Result<()> {
+    // SAFETY: getsid only reads process metadata. Recheck membership before
+    // sending a signal so an exited/reused pid cannot target another session.
+    if unsafe { libc::getsid(pid) } != session {
+        return Ok(());
+    }
+    // SAFETY: pid is positive and still belongs to the session we spawned.
+    if unsafe { libc::kill(pid, signal) } == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn session_members(session: libc::pid_t) -> io::Result<Vec<libc::pid_t>> {
+    let mut members = Vec::new();
+    for entry in std::fs::read_dir("/proc")? {
+        let entry = entry?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<libc::pid_t>().ok())
+        else {
+            continue;
+        };
+        let stat = match std::fs::read(entry.path().join("stat")) {
+            Ok(stat) => stat,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied
+                ) =>
+            {
+                continue
+            }
+            Err(error) => return Err(error),
+        };
+        let (state, observed) = parse_process_stat(&stat)?;
+        if observed == session && state != b'Z' {
+            members.push(pid);
+        }
+    }
+    Ok(members)
+}
+
+// The process name is arbitrary bytes and can itself contain closing
+// parentheses. Only the state and session fields after its last delimiter
+// have an ASCII contract; decoding the entire record rejects valid names.
+#[cfg(any(target_os = "linux", test))]
+fn parse_process_stat(stat: &[u8]) -> io::Result<(u8, libc::pid_t)> {
+    let end = stat
+        .windows(2)
+        .rposition(|bytes| bytes == b") ")
+        .ok_or_else(|| io::Error::other("invalid terminal process status"))?;
+    let mut fields = stat[end + 2..]
+        .split(u8::is_ascii_whitespace)
+        .filter(|field| !field.is_empty());
+    let state = fields
+        .next()
+        .filter(|field| field.len() == 1)
+        .map(|field| field[0])
+        .ok_or_else(|| io::Error::other("invalid terminal process state"))?;
+    let session = fields
+        .nth(2)
+        .and_then(|field| std::str::from_utf8(field).ok())
+        .and_then(|field| field.parse::<libc::pid_t>().ok())
+        .ok_or_else(|| io::Error::other("invalid terminal process session"))?;
+    Ok((state, session))
+}
+
+#[cfg(target_os = "macos")]
+fn session_members(session: libc::pid_t) -> io::Result<Vec<libc::pid_t>> {
+    // Grow with room for concurrent process creation; a full buffer is not a
+    // complete observation and must never prove that the session is empty.
+    let mut pids = vec![0_i32; 1024];
+    loop {
+        let bytes = (pids.len() * std::mem::size_of::<libc::pid_t>()) as libc::c_int;
+        // SAFETY: the buffer holds bytes writable by proc_listallpids.
+        let count = unsafe { libc::proc_listallpids(pids.as_mut_ptr().cast(), bytes) };
+        if count < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if (count as usize) < pids.len() {
+            pids.truncate(count as usize);
+            break;
+        }
+        if pids.len() >= 1_048_576 {
+            return Err(io::Error::other("terminal process list exceeds limit"));
+        }
+        pids.resize(pids.len() * 2, 0);
+    }
+    let mut members = Vec::new();
+    for pid in pids.into_iter().filter(|pid| *pid > 0) {
+        // SAFETY: getsid reads metadata for a positive pid.
+        if unsafe { libc::getsid(pid) } != session {
+            continue;
+        }
+        let mut info = std::mem::MaybeUninit::<libc::proc_bsdinfo>::uninit();
+        let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+        // SAFETY: proc_pidinfo writes at most size bytes to the matching struct.
+        let read = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                info.as_mut_ptr().cast(),
+                size,
+            )
+        };
+        if read != size {
+            // An exit between getsid and proc_pidinfo is safe to ignore.
+            if unsafe { libc::getsid(pid) } != session {
+                continue;
+            }
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: a complete proc_bsdinfo was returned above.
+        if unsafe { info.assume_init() }.pbi_status != libc::SZOMB {
+            members.push(pid);
+        }
+    }
+    Ok(members)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn session_members(_session: libc::pid_t) -> io::Result<Vec<libc::pid_t>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "terminal session cleanup is unavailable on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::process::CommandExt;
+
+    #[test]
+    fn linux_process_status_accepts_non_utf8_names_and_embedded_parentheses() {
+        let stat = b"42 (worker\xff) name) R 1 42 42 0 -1 0";
+        assert_eq!(parse_process_stat(stat).unwrap(), (b'R', 42));
+        assert_eq!(
+            parse_process_stat(b"42 (worker\xfe) Z 1 42 42 0").unwrap(),
+            (b'Z', 42)
+        );
+        assert!(parse_process_stat(b"42 (worker) R 1 42").is_err());
+        assert!(parse_process_stat(b"42 (worker) R 1 42 invalid").is_err());
+    }
+
+    #[test]
+    fn an_exited_shell_retires_its_session_before_a_later_close() {
+        let mut command = std::process::Command::new("/bin/sh");
+        command.args(["-c", "exit 0"]);
+        // SAFETY: setsid is async-signal-safe and touches no Rust state in the
+        // post-fork child. It reproduces portable-pty's separate session.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() < 0 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            });
+        }
+        let mut child = command.spawn().unwrap();
+        let tree = ProcessTree::new(child.id()).unwrap();
+        assert!(tree.wait_and_reap(&mut child).unwrap().success());
+        let scans = tree.scans.load(Ordering::Relaxed);
+        assert!(scans > 0, "the owned session was never checked");
+        assert!(tree.terminate_and_wait(Instant::now()).unwrap());
+        assert_eq!(
+            tree.scans.load(Ordering::Relaxed),
+            scans,
+            "a reaped session ID must never be scanned again"
+        );
+    }
+}

--- a/crates/tidebreak-server/src/code/terminal/windows.rs
+++ b/crates/tidebreak-server/src/code/terminal/windows.rs
@@ -1,0 +1,725 @@
+//! Windows terminals join a kill-on-close job before their first instruction.
+//!
+//! The sole output reader polls pipe availability so cancellation never relies
+//! on closing another thread's handle. Its handle closes before ConPTY does.
+
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::mem::size_of;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
+use std::path::Path;
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+use portable_pty::{Child, ChildKiller, ExitStatus, PtySize};
+use windows_sys::Win32::Foundation::{
+    ERROR_BROKEN_PIPE, ERROR_NO_DATA, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
+use windows_sys::Win32::Storage::FileSystem::SearchPathW;
+use windows_sys::Win32::System::Console::{
+    ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole, COORD, HPCON,
+};
+use windows_sys::Win32::System::JobObjects::{
+    CreateJobObjectW, JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
+    QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
+    JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+use windows_sys::Win32::System::Pipes::{CreatePipe, PeekNamedPipe};
+use windows_sys::Win32::System::Threading::{
+    CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
+    InitializeProcThreadAttributeList, UpdateProcThreadAttribute, WaitForSingleObject,
+    CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, INFINITE,
+    LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_JOB_LIST,
+    PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+};
+
+const PIPE_POLL: Duration = Duration::from_millis(10);
+
+pub(super) struct Spawned {
+    pub master: Master,
+    pub reader: Box<dyn Read + Send>,
+    pub writer: Box<dyn Write + Send>,
+    pub child: Box<dyn Child + Send + Sync>,
+    pub tree: Arc<ProcessTree>,
+}
+
+pub(super) struct Master {
+    console: Arc<Console>,
+    size: Mutex<PtySize>,
+    tree: Arc<ProcessTree>,
+}
+
+impl Master {
+    pub fn resize(&self, size: PtySize) -> io::Result<()> {
+        let mut current = self
+            .size
+            .lock()
+            .map_err(|_| io::Error::other("terminal size lock failed"))?;
+        // SAFETY: the Arc owns the console throughout the call; size is validated.
+        hresult(unsafe { ResizePseudoConsole(self.console.0, coordinates(size)?) })?;
+        *current = size;
+        Ok(())
+    }
+}
+
+impl Drop for Master {
+    fn drop(&mut self) {
+        // Reader keeps the console alive until it has closed the output pipe.
+        let _ = self.tree.terminate();
+        self.tree.cancel_reader();
+    }
+}
+
+struct Console(HPCON);
+
+impl Drop for Console {
+    fn drop(&mut self) {
+        // SAFETY: this value owns the console; no reader handle remains when
+        // the last Arc drops. Closing the pipe first avoids ConPTY drain deadlock.
+        unsafe { ClosePseudoConsole(self.0) };
+    }
+}
+
+#[derive(Debug, Default)]
+struct ReaderState {
+    stopped: Mutex<bool>,
+    changed: Condvar,
+    done: AtomicBool,
+}
+
+#[derive(Debug)]
+pub(super) struct ProcessTree {
+    job: OwnedHandle,
+    reader: Arc<ReaderState>,
+}
+
+impl ProcessTree {
+    fn new() -> io::Result<Self> {
+        // SAFETY: null arguments create an unnamed, non-inheritable job.
+        let job = owned(unsafe { CreateJobObjectW(ptr::null(), ptr::null()) })?;
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        // SAFETY: limits has the layout and size required for this information class.
+        win32(unsafe {
+            SetInformationJobObject(
+                raw(&job),
+                JobObjectExtendedLimitInformation,
+                ptr::from_ref(&limits).cast(),
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        })?;
+        Ok(Self {
+            job,
+            reader: Arc::new(ReaderState::default()),
+        })
+    }
+
+    fn terminate(&self) -> io::Result<()> {
+        // SAFETY: this value owns a live job handle. No breakaway flag is enabled.
+        win32(unsafe { TerminateJobObject(raw(&self.job), 1) })
+    }
+
+    pub fn terminate_and_wait(&self, deadline: Instant) -> io::Result<bool> {
+        self.terminate()?;
+        loop {
+            if self.active_processes()? == 0 {
+                return Ok(true);
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return Ok(false);
+            }
+            std::thread::sleep(PIPE_POLL.min(deadline.saturating_duration_since(now)));
+        }
+    }
+
+    pub fn cancel_reader(&self) {
+        let mut stopped = self
+            .reader
+            .stopped
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        *stopped = true;
+        self.reader.changed.notify_all();
+    }
+
+    pub fn reader_done(&self) -> bool {
+        self.reader.done.load(Ordering::Acquire)
+    }
+
+    fn active_processes(&self) -> io::Result<u32> {
+        let mut info = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
+        // SAFETY: info is writable storage of the exact queried type and size.
+        win32(unsafe {
+            QueryInformationJobObject(
+                raw(&self.job),
+                JobObjectBasicAccountingInformation,
+                ptr::from_mut(&mut info).cast(),
+                size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as u32,
+                ptr::null_mut(),
+            )
+        })?;
+        Ok(info.ActiveProcesses)
+    }
+}
+
+struct Reader {
+    file: Option<File>,
+    // Keeps ConPTY alive until the owned read handle closes, including cancellation.
+    _console: Arc<Console>,
+    state: Arc<ReaderState>,
+}
+
+impl Reader {
+    fn close(&mut self) {
+        self.file.take();
+        self.state.done.store(true, Ordering::Release);
+        self.state.changed.notify_all();
+    }
+}
+
+impl Read for Reader {
+    fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+        if bytes.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            let stopped = self
+                .state
+                .stopped
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            if *stopped || self.file.is_none() {
+                drop(stopped);
+                self.close();
+                return Ok(0);
+            }
+            drop(stopped);
+            let mut available = 0;
+            // SAFETY: this is the only reader of this pipe. Peek does not consume
+            // bytes; read below requests no more than the available byte count.
+            let peeked = unsafe {
+                PeekNamedPipe(
+                    self.file
+                        .as_ref()
+                        .expect("open reader")
+                        .as_raw_handle()
+                        .cast(),
+                    ptr::null_mut(),
+                    0,
+                    ptr::null_mut(),
+                    &mut available,
+                    ptr::null_mut(),
+                )
+            };
+            if peeked == 0 {
+                let error = io::Error::last_os_error();
+                self.close();
+                return match error.raw_os_error().map(|value| value as u32) {
+                    Some(ERROR_BROKEN_PIPE | ERROR_NO_DATA) => Ok(0),
+                    _ => Err(error),
+                };
+            }
+            if available > 0 {
+                let length = bytes.len().min(available as usize);
+                let result = self
+                    .file
+                    .as_mut()
+                    .expect("open reader")
+                    .read(&mut bytes[..length]);
+                if matches!(&result, Ok(0) | Err(_)) {
+                    self.close();
+                }
+                return result;
+            }
+            let stopped = self
+                .state
+                .stopped
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            let _waited = self
+                .state
+                .changed
+                .wait_timeout_while(stopped, PIPE_POLL, |stopped| !*stopped)
+                .unwrap_or_else(|error| error.into_inner());
+        }
+    }
+}
+
+impl Drop for Reader {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+#[derive(Debug)]
+struct Process {
+    handle: OwnedHandle,
+    pid: u32,
+    tree: Arc<ProcessTree>,
+}
+
+#[derive(Debug)]
+struct Killer(Arc<ProcessTree>);
+
+impl ChildKiller for Killer {
+    fn kill(&mut self) -> io::Result<()> {
+        self.0.terminate()
+    }
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        Box::new(Self(self.0.clone()))
+    }
+}
+
+impl ChildKiller for Process {
+    fn kill(&mut self) -> io::Result<()> {
+        self.tree.terminate()
+    }
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        Box::new(Killer(self.tree.clone()))
+    }
+}
+
+impl Child for Process {
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        // SAFETY: handle identifies the process created by this module.
+        match unsafe { WaitForSingleObject(raw(&self.handle), 0) } {
+            WAIT_OBJECT_0 => self.exit_status().map(Some),
+            WAIT_TIMEOUT => Ok(None),
+            _ => Err(io::Error::last_os_error()),
+        }
+    }
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        // SAFETY: handle remains owned throughout this blocking wait.
+        if unsafe { WaitForSingleObject(raw(&self.handle), INFINITE) } != WAIT_OBJECT_0 {
+            return Err(io::Error::last_os_error());
+        }
+        self.exit_status()
+    }
+    fn process_id(&self) -> Option<u32> {
+        Some(self.pid)
+    }
+    fn as_raw_handle(&self) -> Option<RawHandle> {
+        Some(self.handle.as_raw_handle())
+    }
+}
+
+impl Process {
+    fn exit_status(&self) -> io::Result<ExitStatus> {
+        let mut code = 0;
+        // SAFETY: code is writable; the process has already signaled completion.
+        win32(unsafe { GetExitCodeProcess(raw(&self.handle), &mut code) })?;
+        Ok(ExitStatus::with_exit_code(code))
+    }
+}
+
+pub(super) fn spawn(
+    shell: &Path,
+    cwd: &Path,
+    cols: u16,
+    rows: u16,
+    env: &[(&str, &str)],
+) -> io::Result<Spawned> {
+    spawn_with_args(shell, &[], cwd, cols, rows, env)
+}
+
+fn spawn_with_args(
+    shell: &Path,
+    args: &[&OsStr],
+    cwd: &Path,
+    cols: u16,
+    rows: u16,
+    env: &[(&str, &str)],
+) -> io::Result<Spawned> {
+    let size = PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    };
+    let executable = resolve_executable(shell)?;
+    let mut command = quoted_command(&executable, args)?;
+    let cwd = wide(cwd.as_os_str())?;
+    let environment = environment(env)?;
+    let tree = Arc::new(ProcessTree::new()?);
+    let (input_read, input_write) = pipe()?;
+    let (output_read, output_write) = pipe()?;
+    let mut console = 0;
+    // SAFETY: the pipe handles remain live during creation and size is validated.
+    hresult(unsafe {
+        CreatePseudoConsole(
+            coordinates(size)?,
+            raw(&input_read),
+            raw(&output_write),
+            0,
+            &mut console,
+        )
+    })?;
+    let console = Arc::new(Console(console));
+    // ConPTY owns duplicates. Keeping these copies would prevent EOF detection.
+    drop(input_read);
+    drop(output_write);
+    // Keep failure cleanup in the same order as normal shutdown: the output
+    // pipe closes before the last console reference, even if attributes fail.
+    let reader = Reader {
+        file: Some(File::from(output_read)),
+        _console: console.clone(),
+        state: tree.reader.clone(),
+    };
+    let mut attributes = Attributes::new()?;
+    attributes.set(
+        PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+        console.0 as *const _,
+        size_of::<HPCON>(),
+    )?;
+    let jobs = [raw(&tree.job)];
+    attributes.set(
+        PROC_THREAD_ATTRIBUTE_JOB_LIST,
+        jobs.as_ptr().cast(),
+        size_of_val(&jobs),
+    )?;
+    let mut startup = STARTUPINFOEXW::default();
+    startup.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as u32;
+    startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup.StartupInfo.hStdInput = INVALID_HANDLE_VALUE;
+    startup.StartupInfo.hStdOutput = INVALID_HANDLE_VALUE;
+    startup.StartupInfo.hStdError = INVALID_HANDLE_VALUE;
+    startup.lpAttributeList = attributes.pointer();
+    let mut info = PROCESS_INFORMATION::default();
+    // SAFETY: all buffers and both attribute payloads stay live until creation
+    // completes. JOB_LIST assigns the job atomically before any child code runs.
+    // No fallback starts an uncontained process if this call fails.
+    win32(unsafe {
+        CreateProcessW(
+            executable.as_ptr(),
+            command.as_mut_ptr(),
+            ptr::null(),
+            ptr::null(),
+            0,
+            EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+            environment.as_ptr().cast(),
+            cwd.as_ptr(),
+            &startup.StartupInfo,
+            &mut info,
+        )
+    })?;
+    // SAFETY: successful CreateProcessW transfers both handles to this caller.
+    let process = unsafe { OwnedHandle::from_raw_handle(info.hProcess.cast()) };
+    let thread = unsafe { OwnedHandle::from_raw_handle(info.hThread.cast()) };
+    drop(thread);
+    Ok(Spawned {
+        master: Master {
+            console,
+            size: Mutex::new(size),
+            tree: tree.clone(),
+        },
+        reader: Box::new(reader),
+        writer: Box::new(File::from(input_write)),
+        child: Box::new(Process {
+            handle: process,
+            pid: info.dwProcessId,
+            tree: tree.clone(),
+        }),
+        tree,
+    })
+}
+
+struct Attributes(Vec<usize>);
+
+impl Attributes {
+    fn new() -> io::Result<Self> {
+        let mut size = 0;
+        // SAFETY: the first call only obtains the allocation size.
+        unsafe { InitializeProcThreadAttributeList(ptr::null_mut(), 2, 0, &mut size) };
+        if size == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let mut storage = vec![0usize; size.div_ceil(size_of::<usize>())];
+        // SAFETY: usize storage has pointer alignment and at least size bytes.
+        win32(unsafe {
+            InitializeProcThreadAttributeList(storage.as_mut_ptr().cast(), 2, 0, &mut size)
+        })?;
+        Ok(Self(storage))
+    }
+    fn pointer(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.0.as_mut_ptr().cast()
+    }
+    fn set(
+        &mut self,
+        attribute: u32,
+        value: *const std::ffi::c_void,
+        bytes: usize,
+    ) -> io::Result<()> {
+        // SAFETY: callers retain the correctly sized attribute payload through spawn.
+        win32(unsafe {
+            UpdateProcThreadAttribute(
+                self.pointer(),
+                0,
+                attribute as usize,
+                value,
+                bytes,
+                ptr::null_mut(),
+                ptr::null(),
+            )
+        })
+    }
+}
+
+impl Drop for Attributes {
+    fn drop(&mut self) {
+        // SAFETY: this is the initialized list owned by this allocation.
+        unsafe { DeleteProcThreadAttributeList(self.pointer()) };
+    }
+}
+
+fn pipe() -> io::Result<(OwnedHandle, OwnedHandle)> {
+    let (mut read, mut write) = (ptr::null_mut(), ptr::null_mut());
+    // SAFETY: null security attributes create non-inheritable handles.
+    win32(unsafe { CreatePipe(&mut read, &mut write, ptr::null(), 0) })?;
+    Ok((owned(read)?, owned(write)?))
+}
+
+fn owned(handle: HANDLE) -> io::Result<OwnedHandle> {
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: caller transfers a freshly created handle after checking success.
+    Ok(unsafe { OwnedHandle::from_raw_handle(handle.cast()) })
+}
+
+fn raw(handle: &OwnedHandle) -> HANDLE {
+    handle.as_raw_handle().cast()
+}
+fn win32(result: i32) -> io::Result<()> {
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+fn hresult(result: i32) -> io::Result<()> {
+    if result < 0 {
+        Err(io::Error::other(format!(
+            "Windows terminal failed (HRESULT {result:#x})"
+        )))
+    } else {
+        Ok(())
+    }
+}
+fn coordinates(size: PtySize) -> io::Result<COORD> {
+    if size.cols == 0 || size.rows == 0 {
+        return Err(io::Error::other("terminal size must be positive"));
+    }
+    Ok(COORD {
+        X: i16::try_from(size.cols).map_err(|_| io::Error::other("terminal is too wide"))?,
+        Y: i16::try_from(size.rows).map_err(|_| io::Error::other("terminal is too tall"))?,
+    })
+}
+fn wide(value: &OsStr) -> io::Result<Vec<u16>> {
+    let mut value: Vec<_> = value.encode_wide().collect();
+    if value.contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "terminal argument contains NUL",
+        ));
+    }
+    value.push(0);
+    Ok(value)
+}
+fn resolve_executable(shell: &Path) -> io::Result<Vec<u16>> {
+    let name = wide(shell.as_os_str())?;
+    let extension = wide(OsStr::new(".exe"))?;
+    // SAFETY: the first call reports the required UTF-16 buffer length.
+    let needed = unsafe {
+        SearchPathW(
+            ptr::null(),
+            name.as_ptr(),
+            extension.as_ptr(),
+            0,
+            ptr::null_mut(),
+            ptr::null_mut(),
+        )
+    };
+    if needed == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut resolved = vec![0u16; needed as usize];
+    // SAFETY: resolved has the reported capacity and all input strings are NUL terminated.
+    let length = unsafe {
+        SearchPathW(
+            ptr::null(),
+            name.as_ptr(),
+            extension.as_ptr(),
+            needed,
+            resolved.as_mut_ptr(),
+            ptr::null_mut(),
+        )
+    };
+    if length == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if length >= needed {
+        return Err(io::Error::other(
+            "terminal executable path changed during lookup",
+        ));
+    }
+    resolved.truncate(length as usize + 1);
+    Ok(resolved)
+}
+fn quoted_command(executable: &[u16], args: &[&OsStr]) -> io::Result<Vec<u16>> {
+    let mut command = Vec::new();
+    for argument in std::iter::once(OsString::from_wide(&executable[..executable.len() - 1]))
+        .chain(args.iter().map(|arg| arg.to_os_string()))
+    {
+        let argument = wide(&argument)?;
+        if !command.is_empty() {
+            command.push(b' ' as u16);
+        }
+        command.push(b'"' as u16);
+        let mut slashes = 0;
+        for &unit in &argument[..argument.len() - 1] {
+            if unit == b'\\' as u16 {
+                slashes += 1;
+                continue;
+            }
+            command.extend(std::iter::repeat_n(
+                b'\\' as u16,
+                if unit == b'"' as u16 {
+                    2 * slashes + 1
+                } else {
+                    slashes
+                },
+            ));
+            command.push(unit);
+            slashes = 0;
+        }
+        command.extend(std::iter::repeat_n(b'\\' as u16, 2 * slashes));
+        command.push(b'"' as u16);
+    }
+    command.push(0);
+    Ok(command)
+}
+fn environment(overrides: &[(&str, &str)]) -> io::Result<Vec<u16>> {
+    let mut values: BTreeMap<OsString, (OsString, OsString)> = std::env::vars_os()
+        .map(|(key, value)| (key.to_ascii_uppercase(), (key, value)))
+        .collect();
+    for &(key, value) in overrides {
+        values.insert(
+            OsString::from(key).to_ascii_uppercase(),
+            (key.into(), value.into()),
+        );
+    }
+    let mut block = Vec::new();
+    for (key, value) in values.into_values() {
+        let key = wide(&key)?;
+        block.extend_from_slice(&key[..key.len() - 1]);
+        block.push(b'=' as u16);
+        block.extend(wide(&value)?);
+    }
+    if block.is_empty() {
+        block.push(0);
+    }
+    block.push(0);
+    Ok(block)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quoting_preserves_trailing_backslashes_and_embedded_quotes() {
+        let executable = wide(OsStr::new(r"C:\Program Files\shell.exe")).unwrap();
+        let command = quoted_command(
+            &executable,
+            &[OsStr::new("a\\\"b"), OsStr::new("C:\\end\\")],
+        )
+        .unwrap();
+        assert_eq!(
+            OsString::from_wide(&command[..command.len() - 1]),
+            OsStr::new("\"C:\\Program Files\\shell.exe\" \"a\\\\\\\"b\" \"C:\\end\\\\\"")
+        );
+    }
+
+    #[test]
+    fn canceling_a_quiet_reader_closes_its_pipe() {
+        let mut spawned = spawn_with_args(
+            Path::new("powershell.exe"),
+            &[
+                OsStr::new("-NoProfile"),
+                OsStr::new("-Command"),
+                OsStr::new("Start-Sleep -Seconds 30"),
+            ],
+            &std::env::temp_dir(),
+            80,
+            24,
+            &[],
+        )
+        .unwrap();
+        let reader = std::thread::spawn(move || {
+            let mut bytes = [0u8; 1024];
+            while spawned.reader.read(&mut bytes).unwrap() > 0 {}
+        });
+        spawned.tree.cancel_reader();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !reader.is_finished() && Instant::now() < deadline {
+            std::thread::sleep(PIPE_POLL);
+        }
+        let finished = reader.is_finished();
+        let closed = spawned.tree.reader_done();
+        assert!(spawned.tree.terminate_and_wait(deadline).unwrap());
+        assert!(finished, "reader did not honor cancellation");
+        reader.join().unwrap();
+        assert!(
+            closed,
+            "reader reported completion before releasing its pipe"
+        );
+    }
+
+    #[test]
+    fn the_job_contains_descendants_from_process_creation() {
+        // The root exits immediately after starting its child. Shell-only
+        // termination cannot satisfy this test once the root has been reaped.
+        let script = "Start-Process powershell.exe -NoNewWindow -ArgumentList \
+                      '-NoProfile','-Command','Start-Sleep -Seconds 30'";
+        let mut spawned = spawn_with_args(
+            Path::new("powershell.exe"),
+            &[
+                OsStr::new("-NoProfile"),
+                OsStr::new("-Command"),
+                OsStr::new(script),
+            ],
+            &std::env::temp_dir(),
+            80,
+            24,
+            &[],
+        )
+        .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut root_exited = false;
+        while Instant::now() < deadline {
+            if spawned.child.try_wait().unwrap().is_some() {
+                root_exited = true;
+                break;
+            }
+            std::thread::sleep(PIPE_POLL);
+        }
+        let contained = spawned.tree.active_processes().unwrap() > 0;
+        assert!(spawned
+            .tree
+            .terminate_and_wait(Instant::now() + Duration::from_secs(5))
+            .unwrap());
+        assert!(root_exited, "the terminal shell did not exit");
+        assert!(
+            contained,
+            "the descendant did not remain in the terminal job"
+        );
+        assert_eq!(spawned.tree.active_processes().unwrap(), 0);
+    }
+}


### PR DESCRIPTION
Closing a terminal can leave background jobs or a blocked reader alive, and concurrent opens can exceed the workspace limit. This change reserves capacity before spawning, owns the process tree and worker handles, and reports shutdown success only after processes and readers stop. Failed cleanup stays registered so workspace archive can retry.

Unix cleanup covers shell session jobs and retains the unreaped shell as a session identity until cleanup finishes. Windows creates ConPTY children inside a kill-on-close Job Object atomically. A shared scheduler coalesces output notices, and ring copies use contiguous slices.

The terminal API and output cursor format stay unchanged. The main risk is platform-specific process teardown. Windows terminal runtime tests now run explicitly in CI and pass on the native Windows runner.

Validation: 15 terminal tests and the terminal API regression pass on macOS. Focused server/core Clippy passes with warnings denied. All 15 native Windows terminal tests pass in CI, including quiet-reader cancellation and descendant containment. The Windows helper and its tests also pass cross-target compilation and Clippy. Formatting and diff checks pass.

Closes #3341.