### PR TITLE
fix(slack): validate connection consent and surface startup failures

### DIFF
--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -410,6 +410,7 @@ mod tests {
     #[derive(Default)]
     struct FakeProvisioner {
         spawns: StdMutex<Vec<SpawnArguments>>,
+        spawn_errors: StdMutex<VecDeque<RemoteSandboxError>>,
         sends: StdMutex<Vec<String>>,
         event_reads: StdMutex<VecDeque<SandboxEvents>>,
         /// Every events read issued, scripted or not.
@@ -426,6 +427,9 @@ mod tests {
             arguments: &SpawnArguments,
         ) -> Result<SandboxLease, RemoteSandboxError> {
             self.spawns.lock().unwrap().push(arguments.clone());
+            if let Some(error) = self.spawn_errors.lock().unwrap().pop_front() {
+                return Err(error);
+            }
             Ok(SandboxLease {
                 sandbox_id: "sb-1".to_owned(),
                 state: SandboxState::Pending,
@@ -1681,6 +1685,250 @@ mod tests {
                 session_id: binding.session_id
             }
         );
+    }
+
+    #[tokio::test]
+    async fn a_repositoryless_managed_slack_message_spawns_with_native_tools_and_deduplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut spawn_settings = settings();
+        spawn_settings.engine = Some(HarnessKind::ClaudeCode);
+        spawn_settings.engines = Some(vec![HarnessKind::ClaudeCode, HarnessKind::Codex]);
+        spawn_settings.embedded_engine_registration = true;
+        let (runtime, fake, owner, _) =
+            runtime_with_remote_settings(dir.path(), spawn_settings).await;
+        let session_tools = Arc::new(crate::code::session_tools::SessionTools::default());
+        let conversation_tools =
+            Arc::new(crate::code::conversation_tools::ConversationTools::default());
+        let mut tools = tidebreak_core::ToolRegistry::new();
+        session_tools.register(&mut tools);
+        conversation_tools.register(&mut tools);
+        let runtime = Arc::new(
+            Arc::try_unwrap(runtime)
+                .unwrap_or_else(|_| panic!("fixture runtime must have one owner"))
+                .with_tool_registry(Arc::new(tools)),
+        );
+        session_tools.attach(&runtime);
+        conversation_tools.attach(&runtime);
+        runtime.remote_sessions().unwrap().with_host_tool(Arc::new(
+            crate::code::sandbox_tools::SandboxToolExecutor::new(Arc::downgrade(&runtime)),
+        ));
+        let (grant, _) = runtime
+            .mint_adapter_grant(&owner, "slack", "U1", "T1")
+            .await
+            .unwrap();
+        let (resolved, _) = runtime
+            .external_get_or_create_with_channel_context(
+                &owner,
+                None,
+                grant.id,
+                "slack",
+                "T1/C1/first",
+                None,
+                None,
+                HarnessKind::ClaudeCode,
+                session_settings(),
+                None,
+                None,
+                Some(tidebreak_core::db::code::ExternalSessionChannelContext {
+                    channel_id: Some("C1"),
+                    instructions: "Keep answers concise.",
+                }),
+            )
+            .await
+            .unwrap();
+        let tidebreak_core::ExternalSessionResolution::Created(binding) = resolved else {
+            panic!("expected a create");
+        };
+        assert!(fake.spawns.lock().unwrap().is_empty());
+        let message = || crate::code::runtime::ExternalMessage {
+            text: "Read this thread and say hello.".into(),
+            event_id: "EvFirst".into(),
+            channel_ts: "1700000001.000100".into(),
+            actor: tidebreak_core::TurnActor::default(),
+            context: None,
+        };
+        let first = runtime
+            .external_submit_message(&owner, grant.id, binding.session_id, message())
+            .await
+            .unwrap();
+        let ExternalMessageOutcome::NewTurn(turn) = first else {
+            panic!("the managed first message must spawn, got {first:?}");
+        };
+        {
+            let spawns = fake.spawns.lock().unwrap();
+            assert_eq!(spawns.len(), 1);
+            assert!(spawns[0].repository.is_none());
+            assert!(spawns[0].model.is_none(), "an unset harness model is valid");
+            assert!(spawns[0].task.contains("Keep answers concise."));
+            for name in tidebreak_core::code::supervisor_tools::TOOLS {
+                assert!(
+                    spawns[0].task.contains(name),
+                    "missing bootstrap schema {name}"
+                );
+            }
+            assert!(spawns[0].task.contains("Read this thread and say hello."));
+            assert!(spawns[0].embedded_engine.is_some());
+        }
+        let replay = runtime
+            .external_submit_message(&owner, grant.id, binding.session_id, message())
+            .await
+            .unwrap();
+        let ExternalMessageOutcome::NewTurn(replayed) = replay else {
+            panic!("the duplicate must resolve the first turn, got {replay:?}");
+        };
+        assert_eq!(turn.id, replayed.id);
+        assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn startup_failures_are_visible_safe_deduplicated_and_retryable_from_slack() {
+        for sign_in in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let (runtime, fake, owner, _) = runtime_with_remote(dir.path()).await;
+            let remote = runtime.remote_sessions().unwrap();
+            let grant = tidebreak_core::CodeGrantId::new();
+            let (resolution, _) = runtime
+                .external_get_or_create(
+                    &owner,
+                    None,
+                    grant,
+                    "slack",
+                    "T1/C1/startup",
+                    None,
+                    None,
+                    HarnessKind::ClaudeCode,
+                    session_settings(),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
+                panic!("expected creation");
+            };
+            for _ in 0..2 {
+                fake.spawn_errors.lock().unwrap().push_back(if sign_in {
+                    RemoteSandboxError::SignInRequired("private-token-and-upstream-body".into())
+                } else {
+                    RemoteSandboxError::Unavailable {
+                        operation: "spawn",
+                        detail: "private-token-and-upstream-body".into(),
+                    }
+                });
+            }
+            let message = |event: &str| crate::code::runtime::ExternalMessage {
+                text: "start work".into(),
+                event_id: event.into(),
+                channel_ts: "1.0".into(),
+                actor: tidebreak_core::TurnActor::default(),
+                context: None,
+            };
+            let first = runtime
+                .external_submit_message(&owner, grant, binding.session_id, message("Ev1"))
+                .await
+                .unwrap();
+            let ExternalMessageOutcome::Queued(first) = first else {
+                panic!("failed startup stays queued");
+            };
+            assert!(remote.promotion_held(binding.session_id));
+            assert!(latest_turn(&runtime.db, &owner, binding.session_id)
+                .await
+                .unwrap()
+                .is_none());
+            assert!(!tidebreak_core::db::code::queue_paused(
+                &runtime.db,
+                &owner,
+                binding.session_id
+            )
+            .await
+            .unwrap());
+            runtime.promote_remote_queue_heads().await.unwrap();
+            assert_eq!(
+                fake.spawns.lock().unwrap().len(),
+                1,
+                "held sweep must not retry"
+            );
+            remote.clear_promotion_hold(binding.session_id);
+            runtime.promote_remote_queue_heads().await.unwrap();
+            assert_eq!(
+                fake.spawns.lock().unwrap().len(),
+                2,
+                "automatic retry is allowed after hold"
+            );
+            let events = tidebreak_core::db::code::list_events(
+                &runtime.db,
+                &owner,
+                binding.session_id,
+                0,
+                50,
+            )
+            .await
+            .unwrap()
+            .events;
+            let notices: Vec<_> = events
+                .iter()
+                .filter_map(|row| match &row.event {
+                    tidebreak_core::Event::HarnessNotice {
+                        level: tidebreak_core::HarnessNoticeLevel::Warning,
+                        message,
+                    } => Some(message),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                notices.len(),
+                1,
+                "identical failures must not repeat a notice"
+            );
+            assert!(notices[0].contains(if sign_in {
+                "sandbox_sign_in_required"
+            } else {
+                "sandbox_start_failed:store"
+            }));
+            assert!(!serde_json::to_string(&events)
+                .unwrap()
+                .contains("private-token-and-upstream-body"));
+            let replay = runtime
+                .external_submit_message(&owner, grant, binding.session_id, message("Ev1"))
+                .await
+                .unwrap();
+            assert!(matches!(replay, ExternalMessageOutcome::Queued(_)));
+            assert_eq!(
+                fake.spawns.lock().unwrap().len(),
+                2,
+                "a transport replay cannot retry startup"
+            );
+            runtime
+                .external_submit_message(&owner, grant, binding.session_id, message("Ev2"))
+                .await
+                .unwrap();
+            assert_eq!(
+                fake.spawns.lock().unwrap().len(),
+                3,
+                "a fresh message retries immediately"
+            );
+            let started = latest_turn(&runtime.db, &owner, binding.session_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                started.id, first.id,
+                "retry promotes the original queue head"
+            );
+            assert!(!remote.promotion_held(binding.session_id));
+            let queue = tidebreak_core::db::code::list_queued_turns(
+                &runtime.db,
+                &owner,
+                binding.session_id,
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                queue.len(),
+                1,
+                "the retry message follows the original turn"
+            );
+        }
     }
 
     /// External messages are idempotent on the event id: an idle session

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -89,6 +89,11 @@ pub struct RemoteSessions {
     /// after a machine-side refusal. In-memory on purpose: a restart retries
     /// once and re-arms the hold from the fresh refusal.
     promotion_holds: Mutex<HashMap<SessionId, std::time::Instant>>,
+    /// The last published startup failure, independent of display attention.
+    /// A successful promotion clears it; expiring a retry hold does not.
+    startup_failures: Mutex<HashMap<SessionId, String>>,
+    /// Serialize promotion through failure publication for each session.
+    promotion_locks: Mutex<HashMap<SessionId, Weak<tokio::sync::Mutex<()>>>>,
     /// Wakes the sweep for an immediate pass. A wake with no waiter is kept
     /// until the sweep next listens, so none is lost between passes.
     sweep_wake: Notify,
@@ -105,6 +110,8 @@ impl RemoteSessions {
             host_tool: std::sync::OnceLock::new(),
             pumps: Mutex::new(HashMap::new()),
             promotion_holds: Mutex::new(HashMap::new()),
+            startup_failures: Mutex::new(HashMap::new()),
+            promotion_locks: Mutex::new(HashMap::new()),
             sweep_wake: Notify::new(),
         })
     }
@@ -168,6 +175,51 @@ impl RemoteSessions {
         let now = std::time::Instant::now();
         holds.retain(|_, until| *until > now);
         holds.remove(&session);
+    }
+
+    pub(crate) fn promotion_lock(&self, session: SessionId) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.promotion_locks.lock().expect("promotion locks");
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(&session).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(session, Arc::downgrade(&lock));
+        lock
+    }
+
+    pub(crate) fn startup_failure_matches(&self, session: SessionId, message: &str) -> bool {
+        self.startup_failures
+            .lock()
+            .expect("startup failures")
+            .get(&session)
+            .is_some_and(|last| last == message)
+    }
+
+    pub(crate) fn record_startup_failure(&self, session: SessionId, message: String) {
+        self.startup_failures
+            .lock()
+            .expect("startup failures")
+            .insert(session, message);
+    }
+
+    pub(crate) fn clear_startup_failure(&self, session: SessionId) {
+        self.startup_failures
+            .lock()
+            .expect("startup failures")
+            .remove(&session);
+    }
+
+    /// Fresh input retries startup failures but does not bypass capacity holds.
+    pub(crate) fn retry_startup_failure(&self, session: SessionId) {
+        if self
+            .startup_failures
+            .lock()
+            .expect("startup failures")
+            .contains_key(&session)
+        {
+            self.clear_promotion_hold(session);
+        }
     }
 
     /// Make sure `session` has a pump task, spawning one when it has none.
@@ -1782,7 +1834,7 @@ mod tests {
 
     #[tokio::test]
     async fn startup_failures_are_visible_safe_deduplicated_and_retryable_from_slack() {
-        for sign_in in [false, true] {
+        for (sign_in, pinned) in [(false, false), (true, false), (false, true), (true, true)] {
             let dir = tempfile::tempdir().unwrap();
             let (runtime, fake, owner, _) = runtime_with_remote(dir.path()).await;
             let remote = runtime.remote_sessions().unwrap();
@@ -1806,6 +1858,18 @@ mod tests {
             let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
                 panic!("expected creation");
             };
+            if pinned {
+                crate::code::attention::apply_attention(
+                    &runtime.db,
+                    &runtime.bus,
+                    &owner,
+                    binding.session_id,
+                    tidebreak_core::Attention::manual("Keep this pinned"),
+                    true,
+                )
+                .await
+                .unwrap();
+            }
             for _ in 0..2 {
                 fake.spawn_errors.lock().unwrap().push_back(if sign_in {
                     RemoteSandboxError::SignInRequired("private-token-and-upstream-body".into())
@@ -1916,6 +1980,17 @@ mod tests {
                 "retry promotes the original queue head"
             );
             assert!(!remote.promotion_held(binding.session_id));
+            if pinned {
+                assert_eq!(
+                    runtime
+                        .get_session(&owner, binding.session_id)
+                        .await
+                        .unwrap()
+                        .attention,
+                    tidebreak_core::Attention::manual("Keep this pinned"),
+                    "startup and recovery preserve the manual pin"
+                );
+            }
             let queue = tidebreak_core::db::code::list_queued_turns(
                 &runtime.db,
                 &owner,
@@ -1928,6 +2003,129 @@ mod tests {
                 1,
                 "the retry message follows the original turn"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_startup_retries_publish_failure_before_the_next_attempt() {
+        for failures in [1, 2] {
+            let dir = tempfile::tempdir().unwrap();
+            let (runtime, fake, owner, _) = runtime_with_remote(dir.path()).await;
+            let remote = runtime.remote_sessions().unwrap();
+            let grant = tidebreak_core::CodeGrantId::new();
+            let (resolution, _) = runtime
+                .external_get_or_create(
+                    &owner,
+                    None,
+                    grant,
+                    "slack",
+                    "T1/C1/concurrent-startup",
+                    None,
+                    None,
+                    HarnessKind::ClaudeCode,
+                    session_settings(),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
+                panic!("expected creation");
+            };
+            for _ in 0..failures {
+                fake.spawn_errors
+                    .lock()
+                    .unwrap()
+                    .push_back(RemoteSandboxError::Unavailable {
+                        operation: "spawn",
+                        detail: "private transport failure".into(),
+                    });
+            }
+            let message = |event: &str| crate::code::runtime::ExternalMessage {
+                text: "start work".into(),
+                event_id: event.into(),
+                channel_ts: "1.0".into(),
+                actor: tidebreak_core::TurnActor::default(),
+                context: None,
+            };
+            let lock = remote.promotion_lock(binding.session_id);
+            let guard = lock.lock().await;
+            let (first, second, ()) =
+                tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                    tokio::join!(
+                        runtime.external_submit_message(
+                            &owner,
+                            grant,
+                            binding.session_id,
+                            message("Ev1")
+                        ),
+                        runtime.external_submit_message(
+                            &owner,
+                            grant,
+                            binding.session_id,
+                            message("Ev2")
+                        ),
+                        async {
+                            // Both requests must queue before either can attempt startup.
+                            loop {
+                                let queue = tidebreak_core::db::code::list_queued_turns(
+                                    &runtime.db,
+                                    &owner,
+                                    binding.session_id,
+                                )
+                                .await
+                                .unwrap();
+                                if queue.len() == 2 {
+                                    break;
+                                }
+                                tokio::task::yield_now().await;
+                            }
+                            assert!(fake.spawns.lock().unwrap().is_empty());
+                            drop(guard);
+                        }
+                    )
+                })
+                .await
+                .expect("concurrent retries must finish");
+            first.unwrap();
+            second.unwrap();
+            assert_eq!(fake.spawns.lock().unwrap().len(), 2);
+            let events = tidebreak_core::db::code::list_events(
+                &runtime.db,
+                &owner,
+                binding.session_id,
+                0,
+                50,
+            )
+            .await
+            .unwrap()
+            .events;
+            assert_eq!(
+                events
+                    .iter()
+                    .filter(|row| matches!(
+                        row.event,
+                        tidebreak_core::Event::HarnessNotice {
+                            level: tidebreak_core::HarnessNoticeLevel::Warning,
+                            ..
+                        }
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(remote.promotion_held(binding.session_id), failures == 2);
+            assert_eq!(
+                remote
+                    .startup_failures
+                    .lock()
+                    .unwrap()
+                    .contains_key(&binding.session_id),
+                failures == 2
+            );
+            let turn = latest_turn(&runtime.db, &owner, binding.session_id)
+                .await
+                .unwrap();
+            assert_eq!(turn.is_some(), failures == 1);
         }
     }
 

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -8,16 +8,6 @@ use tidebreak_core::ExecutionLocation;
 const MACHINE_PROMOTION_POLL: std::time::Duration = std::time::Duration::from_millis(50);
 const MACHINE_PROMOTION_POLLS: usize = 40;
 
-fn external_delegation_error(error: tidebreak_core::AgentError) -> ServerError {
-    match error {
-        tidebreak_core::AgentError::SignInRequired(_) | tidebreak_core::AgentError::InvalidTarget(_) => ServerError::conflict_kind(
-            "external_reconnect_required",
-            "Your Slack connection needs approval again. Send `reconnect` to Tidebreak, then approve the connection.",
-        ),
-        error => ServerError::from(error),
-    }
-}
-
 /// What get-or-create decided the session acts as, for the adapter to render.
 /// `acting_login`, `app_name`, and `connect_url` are known at create when the
 /// forge answered; an existing session reports `acts_as` from the row and
@@ -31,6 +21,79 @@ pub struct ExternalActsAsView {
 }
 
 impl CodeRuntime {
+    /// Resolve the original Slack consent before creating or queueing work.
+    async fn validated_external_delegation(
+        &self,
+        owner: &OwnerId,
+        grant_id: tidebreak_core::CodeGrantId,
+    ) -> Result<Option<Arc<crate::obo_gateway::OboGateway>>, ServerError> {
+        let Some(external) = self
+            .harness_llm
+            .as_ref()
+            .and_then(|relay| relay.external_delegations())
+        else {
+            return Ok(None);
+        };
+        match external.for_grant(owner, grant_id).await {
+            Ok(delegated) => Ok(Some(delegated)),
+            Err(
+                tidebreak_core::AgentError::SignInRequired(_)
+                | tidebreak_core::AgentError::InvalidTarget(_),
+            ) => {
+                let workspace =
+                    tidebreak_core::db::code::get_external_grant(&self.db, owner, grant_id)
+                        .await?
+                        .is_some_and(|grant| grant.kind.is_workspace());
+                Err(ServerError::conflict_kind(
+                    "external_reconnect_required",
+                    if workspace {
+                        "Your Slack workspace connection needs administrator approval again. Ask an administrator to restore the Tidebreak connection for this Slack workspace."
+                    } else {
+                        "Your Slack connection needs approval again. Send `reconnect` to Tidebreak, then approve the connection."
+                    },
+                ))
+            }
+            Err(error) => Err(ServerError::from(error)),
+        }
+    }
+
+    /// Publish a fixed public failure summary, without transport error details.
+    async fn note_remote_startup_failure(
+        &self,
+        session: &Session,
+        attention: Attention,
+        message: String,
+    ) -> Result<(), ServerError> {
+        if session.attention == attention {
+            return Ok(());
+        }
+        let event = tidebreak_core::Event::HarnessNotice {
+            level: tidebreak_core::HarnessNoticeLevel::Warning,
+            message,
+        };
+        let seq = tidebreak_core::db::code::append_event(
+            &self.db,
+            &session.owner,
+            session.id,
+            session.spawn_epoch,
+            &event,
+        )
+        .await
+        .map_err(|error| tidebreak_core::AgentError::Store(error.to_string()))?;
+        self.bus
+            .publish(session.id, tidebreak_core::SequencedEvent { seq, event });
+        crate::code::attention::apply_attention(
+            &self.db,
+            &self.bus,
+            &session.owner,
+            session.id,
+            attention,
+            false,
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Create a workspace whose checkout lives in a sandbox, not on this
     /// machine. A per-workspace `remote:<id>` worktree marker records that
     /// state ([`CodeWorkspace::is_remote`]); nothing here touches the
@@ -263,23 +326,7 @@ impl CodeRuntime {
         } else {
             self.external_execution_location()
         };
-        let delegated = if location == ExecutionLocation::Machine {
-            match self
-                .harness_llm
-                .as_ref()
-                .and_then(|relay| relay.external_delegations())
-            {
-                Some(external) => Some(
-                    external
-                        .for_grant(owner, grant_id)
-                        .await
-                        .map_err(external_delegation_error)?,
-                ),
-                None => None,
-            }
-        } else {
-            None
-        };
+        let delegated = self.validated_external_delegation(owner, grant_id).await?;
         // The fast path costs one read and builds nothing.
         if let Some(binding) = tidebreak_core::db::code::get_external_binding(
             &self.db,
@@ -1029,7 +1076,15 @@ impl CodeRuntime {
             // notice and attention do not repeat every sweep tick. The
             // hold expiring retries on its own once the slot may be
             // free or the owner has signed in.
-            Ok(Outcome::CapExhausted { .. }) | Ok(Outcome::SignInRequired) => {
+            Ok(Outcome::SignInRequired) => {
+                remote.hold_promotion(session.id);
+                self.note_remote_startup_failure(
+                    &session,
+                    Attention::needs_you("sign in to the sandbox environment", AttentionSource::Structured),
+                    "Tidebreak cannot access the sandbox environment (sandbox_sign_in_required). Your message stays queued. Renew the connection in Tidebreak or ask your administrator for help, then send another message to retry.".into(),
+                ).await?;
+            }
+            Ok(Outcome::CapExhausted { .. }) => {
                 remote.hold_promotion(session.id);
             }
             // Busy shapes: the row stays queued for the next idle.
@@ -1041,6 +1096,11 @@ impl CodeRuntime {
                     "promoting a queued remote message failed; the row stays queued"
                 );
                 remote.hold_promotion(session.id);
+                self.note_remote_startup_failure(
+                    &session,
+                    Attention::needs_you(format!("Sandbox startup failed ({})", error.kind()), AttentionSource::Structured),
+                    format!("Tidebreak could not start the sandbox (sandbox_start_failed:{}). Your message stays queued. Tidebreak retries automatically; send another message to retry now.", error.kind()),
+                ).await?;
             }
         }
         Ok(())
@@ -1077,18 +1137,7 @@ impl CodeRuntime {
             ));
         }
         let session = self.get_session(owner, session_id).await?;
-        if session.execution_location == ExecutionLocation::Machine {
-            if let Some(external) = self
-                .harness_llm
-                .as_ref()
-                .and_then(|relay| relay.external_delegations())
-            {
-                external
-                    .for_grant(owner, grant_id)
-                    .await
-                    .map_err(external_delegation_error)?;
-            }
-        }
+        self.validated_external_delegation(owner, grant_id).await?;
         match session.lifecycle {
             SessionLifecycle::Ended => {
                 return Err(ServerError::conflict_kind(
@@ -1128,6 +1177,13 @@ impl CodeRuntime {
         if fresh {
             // Best effort: a refusal leaves the row queued for the sweep.
             let session = self.get_session(owner, session_id).await?;
+            if matches!(&session.attention.state, tidebreak_core::AttentionState::NeedsYou { prompt, .. }
+                if prompt.starts_with("Sandbox startup failed (") || prompt == "sign in to the sandbox environment")
+            {
+                if let Some(remote) = self.remote_sessions() {
+                    remote.clear_promotion_hold(session_id);
+                }
+            }
             if let Err(error) = self.promote_external_head(session, turn_id).await {
                 tracing::warn!(
                     session = %session_id,

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -64,12 +64,15 @@ impl CodeRuntime {
         attention: Attention,
         message: String,
     ) -> Result<(), ServerError> {
-        if session.attention == attention {
+        let Some(remote) = self.remote_sessions() else {
+            return Ok(());
+        };
+        if remote.startup_failure_matches(session.id, &message) {
             return Ok(());
         }
         let event = tidebreak_core::Event::HarnessNotice {
             level: tidebreak_core::HarnessNoticeLevel::Warning,
-            message,
+            message: message.clone(),
         };
         let seq = tidebreak_core::db::code::append_event(
             &self.db,
@@ -82,6 +85,7 @@ impl CodeRuntime {
         .map_err(|error| tidebreak_core::AgentError::Store(error.to_string()))?;
         self.bus
             .publish(session.id, tidebreak_core::SequencedEvent { seq, event });
+        remote.record_startup_failure(session.id, message);
         crate::code::attention::apply_attention(
             &self.db,
             &self.bus,
@@ -979,7 +983,7 @@ impl CodeRuntime {
         turn_id: tidebreak_core::TurnId,
     ) -> Result<(), ServerError> {
         match session.execution_location {
-            ExecutionLocation::Sandbox => self.try_promote_remote_head(session).await,
+            ExecutionLocation::Sandbox => self.promote_remote_head(session, true).await,
             ExecutionLocation::Machine => {
                 let owner = session.owner.clone();
                 let session_id = session.id;
@@ -1006,11 +1010,31 @@ impl CodeRuntime {
     /// rather than waiting out a sweep tick.
     pub(super) async fn try_promote_remote_head(
         &self,
-        mut session: Session,
+        session: Session,
+    ) -> Result<(), ServerError> {
+        self.promote_remote_head(session, false).await
+    }
+
+    async fn promote_remote_head(
+        &self,
+        session: Session,
+        fresh_input: bool,
     ) -> Result<(), ServerError> {
         let Some(remote) = self.remote_sessions() else {
             return Ok(());
         };
+        let lock = remote.promotion_lock(session.id);
+        let _guard = lock.lock().await;
+        let mut session = self.get_session(&session.owner, session.id).await?;
+        if fresh_input {
+            remote.retry_startup_failure(session.id);
+        }
+        if matches!(
+            session.lifecycle,
+            SessionLifecycle::Ended | SessionLifecycle::Fenced
+        ) {
+            remote.clear_startup_failure(session.id);
+        }
         if session.execution_location != ExecutionLocation::Sandbox
             || session.lifecycle != SessionLifecycle::Idle
         {
@@ -1024,6 +1048,7 @@ impl CodeRuntime {
             return Ok(());
         }
         let Some(head) = queued_turn_head(&self.db, &session.owner, session.id).await? else {
+            remote.clear_startup_failure(session.id);
             return Ok(());
         };
         let repo = match workspace.as_ref() {
@@ -1057,6 +1082,7 @@ impl CodeRuntime {
             // looks again now rather than at its next floor.
             Ok(Outcome::Delivered { .. }) | Ok(Outcome::Reincarnated { .. }) => {
                 remote.clear_promotion_hold(session.id);
+                remote.clear_startup_failure(session.id);
                 remote.wake_sweep();
             }
             // Permanent for this session: nothing exposes a way to raise
@@ -1085,6 +1111,7 @@ impl CodeRuntime {
                 ).await?;
             }
             Ok(Outcome::CapExhausted { .. }) => {
+                remote.clear_startup_failure(session.id);
                 remote.hold_promotion(session.id);
             }
             // Busy shapes: the row stays queued for the next idle.
@@ -1177,13 +1204,6 @@ impl CodeRuntime {
         if fresh {
             // Best effort: a refusal leaves the row queued for the sweep.
             let session = self.get_session(owner, session_id).await?;
-            if matches!(&session.attention.state, tidebreak_core::AttentionState::NeedsYou { prompt, .. }
-                if prompt.starts_with("Sandbox startup failed (") || prompt == "sign in to the sandbox environment")
-            {
-                if let Some(remote) = self.remote_sessions() {
-                    remote.clear_promotion_hold(session_id);
-                }
-            }
             if let Err(error) = self.promote_external_head(session, turn_id).await {
                 tracing::warn!(
                     session = %session_id,

--- a/crates/tidebreak-server/src/obo_gateway/external/tests.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external/tests.rs
@@ -272,6 +272,207 @@ async fn browser_credentials_cannot_mask_missing_or_unconfirmed_delegation() {
 }
 
 #[tokio::test]
+async fn sandbox_admission_requires_durable_external_consent_before_accepting_work() {
+    use crate::code::remote::{
+        driver::RemoteSpawnSettings, gateway::GatewayProvisioner, service::RemoteSessions,
+    };
+    use crate::code::runtime::{ExternalMessage, NewSessionSettings};
+    use tidebreak_core::{ExecutionLocation, HarnessKind, PermissionMode, SessionLifecycle};
+
+    let (_dir, db, runtime, browser, base, state, owner) = setup().await;
+    let tokens = browser
+        .runtime_tokens("tidebreak")
+        .with_external_delegations(db.clone());
+    let provisioner = GatewayProvisioner::new(&base, "tidebreak", tokens).unwrap();
+    let runtime = runtime.with_remote_sessions(RemoteSessions::new(
+        Arc::new(provisioner),
+        RemoteSpawnSettings {
+            profile: "tidebreak".into(),
+            engine: Some(HarnessKind::ClaudeCode),
+            engines: None,
+            embedded_engine_registration: false,
+            incarnation_cap: 2,
+            spend_ceiling_microusd: None,
+            session_spend_ceiling_microusd: None,
+        },
+    ));
+    let (grant, _) = runtime
+        .mint_adapter_grant(&owner, "slack", "U2", "T1")
+        .await
+        .unwrap();
+    let error = runtime
+        .external_get_or_create(
+            &owner,
+            None,
+            grant.id,
+            "slack",
+            "T1/C1/unconfirmed",
+            None,
+            None,
+            HarnessKind::ClaudeCode,
+            NewSessionSettings::default(),
+            None,
+            None,
+        )
+        .await
+        .expect_err("a live adapter grant alone does not carry runtime consent");
+    assert_eq!(error.kind(), "external_reconnect_required");
+    assert!(tidebreak_core::db::code::get_external_binding(
+        &db,
+        &owner,
+        "slack",
+        "T1/C1/unconfirmed"
+    )
+    .await
+    .unwrap()
+    .is_none());
+
+    // A session persisted before this check must refuse the message before queueing it.
+    let mut session = crate::code::remote::fixtures::session_value();
+    session.owner = owner.clone();
+    session.workspace_id = None;
+    session.execution_location = ExecutionLocation::Sandbox;
+    session.lifecycle = SessionLifecycle::Idle;
+    session.permission_mode = PermissionMode::Allow;
+    tidebreak_core::db::code::insert_session(&db, &session)
+        .await
+        .unwrap();
+    tidebreak_core::db::code::bind_external_session(
+        &db,
+        &owner,
+        grant.id,
+        "slack",
+        "T1/C1/legacy",
+        session.id,
+    )
+    .await
+    .unwrap();
+    let error = runtime
+        .external_submit_message(
+            &owner,
+            grant.id,
+            session.id,
+            ExternalMessage {
+                text: "hello".into(),
+                event_id: "Ev1".into(),
+                channel_ts: "1.0".into(),
+                actor: tidebreak_core::TurnActor::default(),
+                context: None,
+            },
+        )
+        .await
+        .expect_err("missing consent must not become a silently held queue row");
+    assert_eq!(error.kind(), "external_reconnect_required");
+    assert!(
+        tidebreak_core::db::code::list_queued_turns(&db, &owner, session.id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(state.mints.load(Ordering::SeqCst), 0);
+
+    let workspace_grant = tidebreak_core::db::code::mint_external_grant(
+        &db,
+        &owner,
+        tidebreak_core::db::code::MintGrantSubject {
+            channel_kind: "slack",
+            external_identity: "workspace:T1",
+            workspace_identity: "T1",
+            kind: tidebreak_core::CodeGrantKind::Workspace,
+        },
+        &"a".repeat(64),
+        &"b".repeat(64),
+    )
+    .await
+    .unwrap();
+    let error = runtime
+        .external_get_or_create(
+            &owner,
+            None,
+            workspace_grant.id,
+            "slack",
+            "T1/C1/workspace",
+            None,
+            None,
+            HarnessKind::ClaudeCode,
+            NewSessionSettings::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "external_reconnect_required");
+    assert!(error.message().contains("administrator"));
+    assert!(error.message().contains("this Slack workspace"));
+    assert!(
+        !error.message().contains("`reconnect`"),
+        "personal reconnect cannot repair workspace consent"
+    );
+    assert_eq!(state.mints.load(Ordering::SeqCst), 0);
+
+    let confirmed = connect(&runtime, &owner).await;
+    let (created, _) = runtime
+        .external_get_or_create(
+            &owner,
+            None,
+            confirmed.id,
+            "slack",
+            "T1/C1/confirmed",
+            None,
+            None,
+            HarnessKind::ClaudeCode,
+            NewSessionSettings::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let tidebreak_core::ExternalSessionResolution::Created(binding) = created else {
+        panic!("completed consent must admit the session");
+    };
+    assert_eq!(state.mints.load(Ordering::SeqCst), 1);
+    tidebreak_core::db::code::record_external_message_with_context(
+        &db,
+        &owner,
+        binding.session_id,
+        "EvBeforeRevocation",
+        "1.0",
+        "accepted before revocation",
+        &tidebreak_core::TurnActor::default(),
+        None,
+    )
+    .await
+    .unwrap();
+    runtime
+        .revoke_adapter_grant(&owner, confirmed.id, "disconnect")
+        .await
+        .unwrap();
+    let error = runtime
+        .external_submit_message(
+            &owner,
+            confirmed.id,
+            binding.session_id,
+            ExternalMessage {
+                text: "accepted before revocation".into(),
+                event_id: "EvBeforeRevocation".into(),
+                channel_ts: "1.0".into(),
+                actor: tidebreak_core::TurnActor::default(),
+                context: None,
+            },
+        )
+        .await
+        .expect_err("a delivery replay cannot bypass revoked consent");
+    assert_eq!(error.kind(), "external_reconnect_required");
+    assert_eq!(state.mints.load(Ordering::SeqCst), 1);
+    assert!(
+        tidebreak_core::db::code::latest_turn(&db, &owner, binding.session_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn revocation_denies_cached_authority_and_retries_after_restart() {
     let (_dir, db, runtime, browser, base, state, owner) = setup().await;
     let grant = connect(&runtime, &owner).await;

--- a/deploy/compose/slack/README.md
+++ b/deploy/compose/slack/README.md
@@ -29,7 +29,10 @@ for how the adapter behaves once it is up.
 - `adapter-postgres`: the adapter's own store. The adapter is a shared,
   stateful service; do not point it at the machine's database.
 
-The adapter needs no Model Gateway variables.
+The adapter needs no Model Gateway variables. Create a custom Slack app and
+install it in your workspace; this setup uses one workspace's bot token and
+requires no distributed OAuth app. Enable event subscriptions, slash commands,
+and interactivity using the manifest in the self-hosting guide.
 
 ## Files you create
 
@@ -88,3 +91,13 @@ everything `missing` names before you invite the app into a workspace.
 Point Slack event and slash-command request URLs at the adapter's public
 origin, not at the machine. Point browsers at the machine's public origin for
 the workspace grant approval.
+
+After the workspace grant is approved, invite Tidebreak into a channel and
+mention it with a task. A repository default is optional. Use the Configure link
+to set channel behavior in Tidebreak. Shared GitHub App repository access applies
+across connected channels, so you do not approve repositories per channel.
+
+This Compose example does not provision a sandbox runtime. Repository-less
+sessions therefore use Internal on the machine unless you add a runtime and
+select its admitted harness. Gateway-hosted installations can provision that
+runtime through Gateway's Slack setup page.

--- a/docs/decisions/0094-repository-optional-conversations-on-the-internal-engine.md
+++ b/docs/decisions/0094-repository-optional-conversations-on-the-internal-engine.md
@@ -76,3 +76,27 @@ frozen model selection, original-grant revocation, empty catalogs, binding retri
 and attached channels. Child-session tests cover two repositories, permission modes,
 request-key recovery, foreign-parent refusal, final output, and failures. Migration
 tests cover fresh databases and stepwise upgrades for `code_session_context`.
+
+## Amendment 2026-09-10: configured sandbox default and channel preferences
+
+The original machine-side Internal path remains available. For a repository-less
+Slack session, the request's harness wins, then the channel's harness preference.
+When neither is set, the server selects the configured runtime's admitted default
+engine. No runtime, or a legacy runtime without engine declarations, keeps the
+Internal fallback. Explicit Internal always stays on the machine. An invalid
+runtime default refuses admission instead of silently falling back.
+
+Tidebreak stores channel harness, model, automatic-reply, and instruction settings.
+Harness, model, and instructions are frozen when a session starts. Automatic
+replies remain live for established threads. Gateway continues to own execution
+credentials, subscription admission, resources, and spend limits.
+
+Managed supervised harnesses receive the authenticated native tool bridge,
+including conversation reads, export, attachments, and the session tools described
+here. This supplies the external-harness path without requiring a separate MCP
+server. Durable child wait/resume, research children, tree budgets, and tree UI
+remain the follow-up work named in this record.
+
+Decision 96 supersedes this record's per-channel repository scope. Shared channel
+sessions discover and use the instance's live GitHub App access. A channel default
+selects a repository; it never grants access or creates another allowlist.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -351,7 +351,9 @@ DMs in your own Slack app to drive sessions on that machine. The public
 image is `ghcr.io/brightwave-inc/tidebreak-slack-adapter` (tags `v<version>`).
 It listens on 8080. It needs its own PostgreSQL (`DATABASE_URL`), a
 token-sealing key, Slack credentials, and a machine directory. It does not
-need Model Gateway variables.
+need Model Gateway variables. One adapter instance uses one Slack workspace's
+bot token. Create and install a custom Slack app in that workspace; a distributed
+OAuth app is not required for this setup.
 
 A Compose example that starts the machine, PostgreSQL, the adapter, and the
 adapter's database lives in
@@ -363,12 +365,13 @@ store.
 
 Create a Slack app from a manifest. Give the bot scopes that let it read
 mentions and DMs, post in threads, add and read reactions, and read channel
-membership. Point the Events API request URL and the slash-command request
-URL at the adapter's public origin — not at the machine. Fill the exact
-paths from the adapter image you pin; they are not defined in this
-repository.
+membership. Channel history scopes let the agent read thread context; `files:read`
+lets it retrieve supported attachments. Point event subscriptions, slash commands,
+and interactivity at `https://<your adapter host>/webhooks/slack`. The adapter
+handles all three payload types on that route. Reinstall the app after changing
+its scopes.
 
-A sketch (replace the host and the request paths):
+A sketch (replace the host):
 
 ```yaml
 display_information:
@@ -379,13 +382,20 @@ features:
     always_online: true
   slash_commands:
     - command: /tidebreak
-      url: https://<your adapter host>/<slash-command path>
+      url: https://<your adapter host>/webhooks/slack
       description: Help, repository defaults, and session commands
       should_escape: false
 oauth_config:
   scopes:
     bot:
       - app_mentions:read
+      - assistant:write
+      - commands
+      - channels:history
+      - groups:history
+      - mpim:history
+      - files:read
+      - users:read
       - im:history
       - im:read
       - im:write
@@ -396,12 +406,22 @@ oauth_config:
       - groups:read
       - mpim:read
 settings:
+  interactivity:
+    is_enabled: true
+    request_url: https://<your adapter host>/webhooks/slack
   event_subscriptions:
-    request_url: https://<your adapter host>/<events path>
+    request_url: https://<your adapter host>/webhooks/slack
     bot_events:
       - app_mention
+      - message.channels
+      - message.groups
+      - message.mpim
       - message.im
-      - member_joined_channel
+      - app_home_opened
+      - team_join
+      - user_change
+      - app_uninstalled
+      - tokens_revoked
   org_deploy_enabled: false
   socket_mode_enabled: false
 ```
@@ -482,11 +502,37 @@ administrator, and approve the Slack workspace grant on that page. The
 approval names the workspace being linked. Until you approve it, channel
 sessions do not run.
 
-`/tidebreak help` lists the command surface once the grant is live. Set a
-channel default with `/tidebreak repo set owner/name` so a mention can
-choose a repository without a `repo:` directive. See
-[Slack sessions](slack-sessions.md) for identity, repository choice, and
-commands.
+Once the grant is live, invite the app into a channel and mention it with a task.
+No repository is required. A channel default set with
+`/tidebreak repo set owner/name` is optional; it selects where work starts.
+The configured GitHub App controls repository access across the instance.
+Connected channels need no separate repository approval.
+
+To set a channel's harness, model, automatic replies, or instructions, open its
+Configure link in Tidebreak. New sessions use its harness, model, and instructions;
+automatic replies apply to existing threads too. `/tidebreak help` lists commands.
+See [Slack sessions](slack-sessions.md) for identity and repository choice.
+
+### When Gateway hosts the machine
+
+Use Gateway's Slack setup page to create the custom app manifest, supply the bot
+token and signing secret, connect the GitHub identities, and pair the adapter
+with Tidebreak. Use its runtime provisioning action to configure a sandbox
+profile and the matching supervised-agent image. This path still installs a
+custom app in one Slack workspace; it does not require distributing an OAuth app.
+
+Tidebreak stores channel behavior preferences. Gateway controls credentials,
+GitHub App access, model and subscription admission, sandbox resources, and spend
+limits. Configure shared repository access once through the GitHub App
+installation; changing channel preferences never expands that access.
+
+For a repository-less Slack session with no chosen harness, Tidebreak uses the
+configured runtime's admitted default engine. Without a runtime, or with a legacy
+runtime that declares no engines, it uses Internal on the machine. Explicit
+Internal also stays on the machine. Invalid declared runtime settings refuse
+the session instead of silently moving
+it. Pin the supervised-agent image and coordinate its version with the server;
+[the runtime guide](slack-sessions.md#packaged-sandbox-runtime) describes upgrades.
 
 ## What the image provides
 

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -5,29 +5,29 @@ record. Where a later record disagrees, the record wins. This revision
 follows an adversarial review pass; the largest changes are recorded in
 "Bets and exit criteria" and "Open questions".
 
-Since this revision, repository-less conversations are no longer deferred:
-`POST /external/code/sessions` accepts no repository selector and creates
-an internal-engine session on the machine, with a nullable workspace and
-the native self-drive tools registered in the foreground tool set. The
-adapter-side default that omits the selector, and the durable retry of
-`repository_preparing`, land with the gateway's Slack work
-(brightwave-inc/model-gateway#1980). Machine-side behavior here is the
-floor; Slack adapter wiring, live Slack acceptance, durable child wait/resume,
-and the thread/web tree remain follow-up. The machine contract is recorded in [0094](decisions/0094-repository-optional-conversations-on-the-internal-engine.md).
+No repository is required to start. A repository-less Slack session with no
+explicit harness uses the channel's harness preference, then the configured
+runtime's admitted default engine. Without a runtime, or with a legacy runtime
+that declares no engines, it uses Internal on the machine. An explicit Internal
+choice also stays on the machine. Invalid runtime settings refuse admission
+instead of silently changing the execution location.
+See [Repository-less sessions](#repository-less-sessions) and the amendment to
+[decision 94](decisions/0094-repository-optional-conversations-on-the-internal-engine.md).
+Durable child wait/resume and the thread/web tree remain follow-up work.
 
 A person talks to Tidebreak in Slack — in the agent's own chat (Slack's
 primary and split view for AI agents) or in a channel thread. Tidebreak
 runs a session for that conversation on that person's hosted machine.
-The session's engine runs in a confined sandbox. Progress streams back
-into the conversation through Slack's agent surfaces. The same session
-appears in the desktop inbox.
+The session runs in a configured sandbox or on the machine, according to its
+selected harness and execution location. Progress returns to the conversation
+through Slack's agent surfaces. The same session appears in the desktop inbox.
 
 Version one ships both surfaces: the agent DM and channel threads.
 Getting the agent into a conversation uses Slack's own affordances —
 "Add agent", the channel's Agents & apps tab, @mention — and none of it
 is custom chrome. No repository is required to start. A conversation
-with no repository runs on the machine's internal engine; a task that
-names repositories starts child sessions in independent workspaces under
+with no repository can answer and discover repositories; a task that
+names repositories can start child sessions in independent workspaces under
 the same conversation, and the conversation can wait on those children
 and read their results. Grant-bound children follow the configured external
 placement. Remaining adapter and orchestration work is recorded below.
@@ -336,18 +336,18 @@ agent, teammates, and a native "working / needs your attention" status —
 are the fast follow, not v1: one code channel maps to one session and
 `AttentionState` feeds the channel status directly.
 
-The session uses the code-shaped journal and attention model, not a chat
-row. A repository-less ask through chat stays refused: chat is the
-internal engine on the machine, and Slack wants a confined sandbox.
+The session uses the code-shaped journal and attention model. Repository-less
+Slack conversations use this same code session surface, including when Internal
+runs on the machine; they do not create a separate chat row.
 
 | Slack | Tidebreak |
 | --- | --- |
 | First @mention in a thread | Get-or-create the external session; submit the message as the first turn |
-| Later owner reply | Submit to the messages endpoint; outcome is `new_turn` or `queued` (see Ingestion) |
-| Owner reply `stop` | Interrupt. The status message gets a terminal edit: "Stopped by you" |
+| Later eligible contributor reply | Submit to the messages endpoint when automatic replies are enabled and the thread is awake; outcome is `new_turn` or `queued` (see Ingestion) |
+| Eligible contributor reply `stop` | Interrupt the active turn |
 | Reply while `Fenced` | Owner sees the reason and an owner-only reap button; anyone else sees the fenced notice |
 | Reply while `Ended` | Refuse, with the context-correct next step: "send `new`" in a DM, "start a new thread and mention me" in a channel |
-| Non-owner reply | Reaction plus one ephemeral notice; dropped |
+| Reply from someone without contributor access | Refuse without submitting a turn |
 | Bare @mention with no task text | Prompt for the task; no sandbox spawns |
 | Channel @mention outside a thread | The adapter replies in a new thread; that thread is the session |
 
@@ -425,16 +425,16 @@ conflicting spec in the retry is reported, never applied.
 
 ## Choosing the repository
 
-Stage 1 requires a repository. Resolution at first contact, then pinned
-on the workspace:
+A repository selector is optional. On first contact, the adapter resolves it
+in this order:
 
 1. A `repo:owner/name` directive in the first message. A near-miss —
    wrong spacing, an inaccessible or misspelled name — refuses loudly
    before anything is created ("Did you mean `repo:owner/name`?"), never
    falls through.
 2. Else the channel default. A DM has no default.
-3. Else refuse, with the directive syntax and a pointer to
-   `/tidebreak help`. Nothing spawns.
+3. Otherwise start a repository-less code session. The agent can answer,
+   discover accessible repositories, and start repository work when needed.
 
 Bare GitHub URLs in prose are context, never clone intent.
 
@@ -447,12 +447,13 @@ visible notice naming who changed it. Engine action approvals remain separate.
 The GitHub App installation intersected with the person's access is the
 allowlist, refused with a human-readable rendering: outside the App
 installation → "ask an admin to add it to the Tidebreak GitHub App";
-no personal access → "you don't have access to `org/name`". No second
-Slack-only allowlist until someone needs stricter than the App.
+no personal access → "you don't have access to `org/name`". Shared channel
+sessions use the installation identity's access. There is no separate channel
+repository allowlist.
 
-Changing the repository means a new thread. The first status message
-carries the recovery inline: "Wrong repo? Reply `stop`, then start a new
-thread with `repo:owner/name`."
+An explicit selector pins the session's workspace; a retry cannot replace it.
+A repository-less conversation can create children in several repositories
+without changing threads. Each child workspace still belongs to one repository.
 
 ## Packaged sandbox runtime
 
@@ -496,7 +497,8 @@ to a dedicated Direct endpoint and grants only the
 `runtime:tidebreak` audience and resource with `runtime:execute`. Git and
 PR API requests use that app's existing identity and policy. A DM does not
 change installation-only credentials into a personal GitHub identity.
-Channel contribution remains owner-only until explicit sharing is enabled.
+Channel sessions use the shared service identity. The channel membership gate
+determines who can contribute; each submitted turn retains its actor.
 
 An ordinary custom harness keeps Gateway's generic client identity. A managed
 Tidebreak runtime can use an eligible subscription after the registered Tidebreak
@@ -506,10 +508,12 @@ admitted image and the live sandbox before inference starts. Subscription sharin
 provider compatibility, sandbox exclusions, and quota limits still apply. A
 missing or mismatched confirmation refuses the run.
 
-The default repositoryless Slack coordinator still uses Tidebreak's Internal
-engine. It does not acquire subscription eligibility from a child harness. The
-profile uses one pod incarnation because the image does not restore the harness
-conversation across pod replacement.
+A repository-less Slack session also uses the admitted runtime default when
+neither the request nor its channel selects a harness. The selected managed
+harness can use eligible subscriptions under Gateway policy. Explicit Internal
+sessions stay on the machine and do not inherit subscription eligibility from
+a child harness. The managed profile limits each sandbox to one pod incarnation;
+the image does not restore the harness conversation across pod replacement.
 
 The profile pins a supervised-agent digest; it does not track server releases.
 For an upgrade, publish both images from the same release, update the profile
@@ -519,8 +523,8 @@ its update or pin it until the matching supervised image is ready.
 
 ## Execution
 
-The session's engine runs in a per-session confined sandbox driven by
-`tidebreak-supervised-agent`
+For sandbox sessions, `tidebreak-supervised-agent` drives the selected engine
+inside a confined sandbox for that session
 ([`0079`](decisions/0079-supervised-agent-declines-the-sandbox-protocol.md)).
 Tidebreak calls the confining environment's runtime API. That contract
 is pinned in `crates/tidebreak-server/src/code/remote/`: spawn on
@@ -798,15 +802,20 @@ fenced reap button works and is refused for non-owners.
 The provenance banner, the thread link, and desktop-submitted-turn
 attribution in the thread.
 
-## Repository-less sessions on the machine's engine
+## Repository-less sessions
 
-No repository is required to start, and the scratch stage above is
-retired. `POST /external/code/sessions` accepts neither `repo_id` nor
-`repository` and creates a workspace-less internal-engine session on the
-machine, with no sandbox and no clone. An explicit selector preserves the
-existing repository-backed path exactly. The same conversation can then
-choose repositories with `code_repos`, start independent child sessions in
-new workspaces with `code_session_create` (each with a stable
+`POST /external/code/sessions` accepts a request that omits both `repo_id` and
+`repository`. It creates a code session without a workspace or an initial clone.
+An explicit request harness wins over the channel preference. When both are
+unset, a Slack session uses the configured runtime's admitted default engine.
+No runtime, or a legacy runtime without engine declarations, falls back to
+Internal on the machine. An explicit Internal selection stays on the machine.
+A configured but invalid default refuses admission; it does not fall back.
+An explicit repository selector preserves the repository-backed path.
+
+The same conversation can then choose repositories with `code_repos`, start
+independent child sessions in new workspaces with `code_session_create` (each
+with a stable
 `request_key`), send follow-ups with `code_run_turn`, list children with
 `code_sessions`, and poll for results with `code_wait`. Children inherit
 the parent's owner, grant, and forge identity. Machine children keep the parent's
@@ -830,7 +839,6 @@ keeps the current list of work that remains for self-drive child sessions.
   as specified in the preceding section.
 - Collaborator steer, and an owner relay affordance ("forward this to
   the session") as its cheaper predecessor.
-- A Slack-only allowlist narrower than the GitHub App.
 - Local-desktop Slack via a relay.
 - [`0048`](decisions/0048-one-interaction-model.md) step 5.
 
@@ -944,8 +952,10 @@ and model catalogs. A human administrator can read or change shared settings.
 A personal Slack connection does not prove membership in a private channel, so
 it does not grant access to that channel's instructions.
 
-A new session freezes its harness, model, and channel instructions. Later channel
-changes leave existing sessions intact. Session creation returns the stored
+A new session freezes its harness, model, and channel instructions. Changes to
+those defaults apply to new sessions. Automatic replies remain live for existing
+threads; a quiet thread resumes when an authorized person mentions the app.
+Quiet leaves already accepted work running. Session creation returns the stored
 `harness` and `model`; a null model means no model has been pinned, rather than
 an inferred default presented as observed execution. The adapter should render
 these values and link to Configure without adding another status message.


### PR DESCRIPTION
Slack sandbox sessions could accept a message without completed durable connection consent, then leave the message queued with no transcript notice when startup failed. Validate the original grant at session creation and message intake for both execution locations, including delivery replays after revocation. Workspace failures request administrator recovery instead of the personal reconnect command.

Journal a fixed warning and safe error code for sandbox startup failures. Keep the original message queued, suppress repeated identical notices, and let a fresh Slack message retry immediately while duplicate deliveries remain idempotent. Track failures independently of manual attention pins, and serialize promotion through failure publication so concurrent attempts cannot duplicate notices or restore stale failure state after success. Update Slack setup and runtime documentation for custom apps, shared GitHub App access, channel preferences, and sandbox defaults; preserve the documented one-pod limitation.

Validation:
- `cargo test -p tidebreak-server-core obo_gateway::external::tests --locked -- --nocapture`: 13 passed.
- `cargo test -p tidebreak-server-core code::remote::service::tests --lib`: 23 passed.
- The tests cover repositoryless native bootstrap without a selected model, missing and revoked consent, safe authentication and transport notices, deduplication, retry order, manual pins, and concurrent failure/failure and failure/success attempts.
- `cargo check -p tidebreak-server-core --locked`, `cargo fmt --all -- --check`, and `git diff --check`: passed.
- Documentation links, fences, whitespace, and YAML parsing passed on the included documentation commit.

The Gateway adapter companion is deployed in alpha.211 and renders warning harness notices. This change reproduces and fixes an admission gap; it does not establish the cause of the live stalled session without production evidence.