### PR TITLE
fix(code): archive every selected workspace from Cmd+Shift+A

### DIFF
--- a/crates/tidebreak-desktop/ui/src/AppShell.tsx
+++ b/crates/tidebreak-desktop/ui/src/AppShell.tsx
@@ -429,9 +429,17 @@ export function AppShell() {
     "code-view-pr": () => askWorkspace("view_pr"),
     "code-source-control": () => askWorkspace("source_control"),
     "code-archive-workspace": () => {
-      if (!codeWorkspaceIdFromPath(router.state.location.pathname))
-        return false;
-      useCodeUiStore.getState().requestArchiveWorkspace();
+      // A rail selection wins over the open workspace: the reader who
+      // cmd-clicked three cards means those three, whichever page is up. The
+      // chord is consumed either way so macOS never reads it as the
+      // "Search man Page Index" text service over a stray selection.
+      const code = useCodeUiStore.getState();
+      if (code.selectedWorkspaceIds.length > 0) {
+        code.requestArchiveSelection();
+        return;
+      }
+      if (!codeWorkspaceIdFromPath(router.state.location.pathname)) return;
+      code.requestArchiveWorkspace();
     },
     "code-prev-tab": () => applyCodeLayout((l) => stepCenterTab(l, -1)),
     "code-next-tab": () => applyCodeLayout((l) => stepCenterTab(l, 1)),

--- a/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/tidebreak-desktop/ui/src/ShellShortcuts.ts
@@ -409,7 +409,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     codes: ["KeyA"],
     mod: true,
     shift: true,
-    description: "Archive this workspace",
+    description: "Archive this workspace or the selected ones",
     group: "Ship",
     scope: "code",
     allowInEditable: true,

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import {
+  act,
   cleanup,
   fireEvent,
   screen,
@@ -833,6 +834,81 @@ describe("CodeSidebar", () => {
       "ws-channel",
     ]);
     expect(router.state.location.pathname).toBe("/code");
+  });
+
+  it("archives every selected workspace from the keyboard chord", async () => {
+    const archiveCodeWorkspace = vi.fn(
+      async (id: string) =>
+        ({
+          id,
+          repo_id: "repo-1",
+          title: id,
+          worktree_path: `/tmp/app/.worktrees/${id}`,
+          branch_name: `tidebreak/${id}`,
+          base_ref: "main",
+          status: "archived",
+          created_at: "2026-08-15T00:00:00.000Z",
+        }) as never,
+    );
+    client.listCodeWorkspaces.mockResolvedValueOnce([
+      {
+        id: "ws-1",
+        repo_id: "repo-1",
+        title: "Fix login",
+        worktree_path: "/tmp/app/.worktrees/fix-login",
+        branch_name: "tidebreak/fix-login",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-15T00:00:00.000Z",
+      },
+      {
+        id: "ws-2",
+        repo_id: "repo-1",
+        title: "Fix logout",
+        worktree_path: "/tmp/app/.worktrees/fix-logout",
+        branch_name: "tidebreak/fix-logout",
+        base_ref: "main",
+        status: "active" as const,
+        created_at: "2026-08-16T00:00:00.000Z",
+      },
+    ]);
+    await renderWithRouter(
+      <AppContextProvider
+        value={{
+          ...app,
+          client: { ...client, archiveCodeWorkspace } as never,
+        }}
+      >
+        <CodeSidebar />
+      </AppContextProvider>,
+      { initialUrl: "/code/w/ws-1" },
+    );
+    const first = await screen.findByRole("button", { name: /^Fix login/ });
+    const second = await screen.findByRole("button", { name: /^Fix logout/ });
+    fireEvent.click(second, { metaKey: true });
+    expect(first).toHaveAttribute("aria-selected", "true");
+    expect(second).toHaveAttribute("aria-selected", "true");
+
+    // Cmd+Shift+A with the rail focused must not widen the selection first.
+    fireEvent.keyDown(second, { key: "A", metaKey: true, shiftKey: true });
+    expect(useCodeUiStore.getState().selectedWorkspaceIds).toEqual([
+      "ws-1",
+      "ws-2",
+    ]);
+
+    // What the shell does with the chord when the rail holds a selection.
+    act(() => useCodeUiStore.getState().requestArchiveSelection());
+    const dialog = await screen.findByRole("alertdialog");
+    expect(
+      within(dialog).getByText("Archive 2 workspaces?"),
+    ).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Archive" }));
+    await waitFor(() => expect(archiveCodeWorkspace).toHaveBeenCalledTimes(2));
+    expect(archiveCodeWorkspace.mock.calls.map(([id]) => id)).toEqual([
+      "ws-1",
+      "ws-2",
+    ]);
+    expect(useCodeUiStore.getState().selectedWorkspaceIds).toEqual([]);
   });
 
   it("opens and clears selection on an unmodified click", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -216,6 +216,31 @@ export function CodeSidebar() {
     }
   }
 
+  const archiveSelectionPending = useCodeUiStore(
+    (state) => state.archiveSelectionPending,
+  );
+  useEffect(() => {
+    if (!archiveSelectionPending) return;
+    if (!useCodeUiStore.getState().takeArchiveSelection()) return;
+    if (selectedWorkspaces.length === 0) return;
+    // One selected card takes the single-workspace path so the dialog and
+    // the dirty-worktree escalation read the same as the context menu's.
+    if (selectedWorkspaces.length === 1) {
+      const workspace = selectedWorkspaces[0];
+      const digest = digests[workspace.id];
+      run("archive", {
+        workspace,
+        title: digest?.title ?? workspace.title,
+        pr: digest?.pr_state ?? workspace.pr,
+        session: sessions[workspace.id],
+      });
+      return;
+    }
+    runBulk("archive", selectedWorkspaces);
+    // The chord is the trigger; the rest is state read when it arrives.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [archiveSelectionPending]);
+
   useEffect(() => {
     function onPointerDown(event: PointerEvent) {
       if (useCodeUiStore.getState().selectedWorkspaceIds.length === 0) return;
@@ -280,8 +305,13 @@ export function CodeSidebar() {
             clearWorkspaceSelection();
             return;
           }
+          // Plain Cmd+A only. Cmd+Shift+A is the archive chord, and
+          // selecting everything a beat before it fires would archive the
+          // whole rail.
           if (
             (event.metaKey || event.ctrlKey) &&
+            !event.shiftKey &&
+            !event.altKey &&
             event.key.toLowerCase() === "a"
           ) {
             event.preventDefault();

--- a/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUiStore.ts
@@ -482,6 +482,14 @@ export type CodeUiStore = {
   requestArchiveWorkspace: () => void;
   takeArchiveWorkspace: () => boolean;
   /**
+   * The same chord while the rail holds a selection, taken by the sidebar
+   * that owns the selected cards. The shell routes here first so Cmd+Shift+A
+   * over three selected workspaces archives three, not the one on screen.
+   */
+  archiveSelectionPending: boolean;
+  requestArchiveSelection: () => void;
+  takeArchiveSelection: () => boolean;
+  /**
    * What the workspace header says the next step is, republished for the
    * command palette.
    *
@@ -607,6 +615,13 @@ export const useCodeUiStore = create<CodeUiStore>()((set, get) => ({
   takeArchiveWorkspace: () => {
     if (!get().archivePending) return false;
     set({ archivePending: false });
+    return true;
+  },
+  archiveSelectionPending: false,
+  requestArchiveSelection: () => set({ archiveSelectionPending: true }),
+  takeArchiveSelection: () => {
+    if (!get().archiveSelectionPending) return false;
+    set({ archiveSelectionPending: false });
     return true;
   },
   workflowSuggestion: null,
@@ -770,6 +785,7 @@ export function resetCodeUiHostState(): void {
     filesSearchPending: false,
     workflowShortcutPending: null,
     archivePending: false,
+    archiveSelectionPending: false,
     workflowSuggestion: null,
     openFilePending: null,
     selectedWorkspaceIds: [],

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -297,6 +297,18 @@ export function WorkspaceCard({
                   HOVER_TINT,
                   creating && "cursor-wait",
                 )}
+                onMouseDown={(event) => {
+                  // Shift-click would otherwise extend the page's text
+                  // selection from wherever the caret last sat, and with
+                  // text selected macOS hands the next Cmd+Shift+A to its
+                  // man-page text service instead of to the app.
+                  if (
+                    onSelectPointer &&
+                    pointerSelectIntent(event) !== "open"
+                  ) {
+                    event.preventDefault();
+                  }
+                }}
                 onClick={(event) => {
                   if (creating) return;
                   if (


### PR DESCRIPTION
## Problem

With several workspaces selected in the rail, Cmd+Shift+A archived one workspace at most. The chord only set the page-level flag the open workspace page consumes, so the selection never took part.

Two related traps sat next to it:

- The rail's select-all handler matched Cmd+Shift+A too, so with the rail focused the chord selected every workspace a beat before the archive fired.
- Shift-clicking a card extended the page's text selection onto the window title. With page text selected, macOS routes Shift+Cmd+A to its "Search man Page Index in Terminal" text service, which is the `man Tidebreak;type=a` Terminal window that popped up.

## Change

- The shell routes the chord to the rail selection when one exists. The sidebar consumes it and runs the same bulk archive its context menu uses, with the "Archive N workspaces?" confirmation. A single selected card takes the single-workspace path so the dirty-worktree escalation reads the same as the menu's.
- Select-all in the rail requires plain Cmd+A.
- Cards cancel the mousedown default on modifier clicks so no text is selected, and the shell consumes the chord even when there is nothing to archive.
- The shortcut description now says "Archive this workspace or the selected ones".

## Tests

`CodeSidebar.dom.test.tsx` pins the two-workspace archive through the chord and that Cmd+Shift+A leaves the selection untouched. Typecheck, biome, and the covering test files pass locally.