### PR TITLE
fix(code): list every workspace-less conversation in the rail, not only machine-side chats

### DIFF
--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -209,42 +209,58 @@ describe("CodeSidebar", () => {
     );
   });
 
-  it("hides conversations that the server does not mark as openable", async () => {
-    useCodeUpdatesStore.setState({
-      conversationsWithoutWorkspace: {
-        shared: {
-          workspace: null,
-          session: "shared",
-          can_open_chat: false,
-          kind: "interactive",
-          lifecycle: "running",
-          attention: { state: { type: "working" }, source: "lifecycle" },
-          title: "Shared conversation",
-          turn_count: 1,
-        },
-        legacy: {
-          workspace: null,
-          session: "legacy",
-          kind: "interactive",
-          lifecycle: "running",
-          attention: { state: { type: "working" }, source: "lifecycle" },
-          title: "Legacy conversation",
-          turn_count: 1,
-        },
-      },
+  it("lists conversations the server does not mark as chat-openable and opens them on the session route", async () => {
+    client.openCodeUpdates.mockImplementationOnce((onNotice) => {
+      queueMicrotask(() =>
+        onNotice({
+          type: "snapshot",
+          sessions: [
+            {
+              workspace: null,
+              session: "shared",
+              can_open_chat: false,
+              kind: "interactive",
+              harness_kind: "claude_code",
+              lifecycle: "running",
+              attention: { state: { type: "working" }, source: "lifecycle" },
+              title: "Slack thread on a sandbox engine",
+              turn_count: 1,
+            },
+            {
+              workspace: null,
+              session: "legacy",
+              kind: "interactive",
+              lifecycle: "running",
+              attention: { state: { type: "working" }, source: "lifecycle" },
+              title: "Legacy conversation",
+              turn_count: 1,
+            },
+          ],
+        }),
+      );
+      return {
+        close() {},
+        addEventListener() {},
+        removeEventListener() {},
+      } as unknown as WebSocket;
     });
-    await renderWithRouter(
+    const { router } = await renderWithRouter(
       <AppContextProvider value={app}>
         <CodeSidebar />
       </AppContextProvider>,
       { initialUrl: "/code" },
     );
     expect(
-      screen.queryByRole("button", { name: /Shared conversation/ }),
-    ).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: /Legacy conversation/ }),
-    ).toBeNull();
+      await screen.findByRole("button", { name: /Legacy conversation/ }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /Slack thread on a sandbox engine/,
+      }),
+    );
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/code/s/shared"),
+    );
   });
 
   it("renders the code rail without chat stores initialized", async () => {

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -94,9 +94,11 @@ export function CodeSidebar() {
   const childrenByWorkspace = useCodeUpdatesStore(
     (state) => state.childrenByWorkspace,
   );
-  const chatConversations = Object.values(conversationsWithoutWorkspace).filter(
-    (digest) => digest.can_open_chat === true,
-  );
+  // Every accessible workspace-less session is listed. The row opens the
+  // authorized session route, which serves sandbox-engine and shared
+  // sessions as well as machine-side chats, so `can_open_chat` does not
+  // decide whether a conversation appears here.
+  const chatConversations = Object.values(conversationsWithoutWorkspace);
   const newWorkspaceOpen = useCodeUiStore((state) => state.newWorkspaceOpen);
   const newWorkspaceRepoId = useCodeUiStore(
     (state) => state.newWorkspaceRepoId,


### PR DESCRIPTION
## Why

Slack sessions on a hosted machine never showed up in the desktop rail. The Conversations section hid any session without a workspace unless the server marked it chat-openable, and the server sets that flag only for the Internal harness. Since #3354, repository-less Slack sessions default to the runtime's admitted sandbox engine (Claude Code or Codex), so every one of them was filtered out, for owners and readers alike.

## What changed

- `CodeSidebar` lists every accessible workspace-less conversation. The row already opens the authorized session route (`/code/s/:sessionId`), which serves sandbox-engine and shared sessions, so the `can_open_chat` flag never decided where a click went. It no longer decides whether a row appears either.
- The sidebar DOM test that asserted the old hiding now asserts the opposite: a sandbox-engine digest and a legacy digest without the flag both render, and clicking the first navigates to the session route. The test fails without the sidebar change.

## Validation

- `vitest run src/code/CodeSidebar.dom.test.tsx`: 20 passed (1 failed with the sidebar change reverted).
- `biome format`, `biome lint src/code`, `tsc --noEmit`: clean.
