### PR TITLE
feat(slack): persist and reconcile steering admissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7251,6 +7251,7 @@ dependencies = [
  "tidebreak-core",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/tidebreak-code-remote/Cargo.toml
+++ b/crates/tidebreak-code-remote/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 workspace = true
 
 [dependencies]
+uuid.workspace = true
 tidebreak-core = { path = "../tidebreak-core" }
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -90,8 +90,8 @@ impl RemoteSpawnSettings {
                 })
         {
             return Err(format!(
-                "this sandbox profile does not admit {}; select an engine declared by the operator (default {engine})", session.harness_kind
-
+                "this sandbox profile does not admit {}; select an engine declared by the operator (default {engine})",
+                session.harness_kind
             ));
         }
         if session.permission_mode != tidebreak_core::PermissionMode::Allow {
@@ -438,7 +438,126 @@ async fn settle_turn_rows(
     Ok(false)
 }
 
+/// Settle durable steering admissions from supervised sandbox lifecycle
+/// events. The agent emits `steer_ack` only when the native engine
+/// acknowledged the instruction; `steer_refused` keeps the queue row intact
+/// and records the explicit fallback.
+fn steer_ack_matches_target(
+    payload: &serde_json::Value,
+    source_sandbox: &str,
+    target: &tidebreak_core::db::code::ExternalSteerTarget,
+) -> bool {
+    target.sandbox_id == source_sandbox
+        && payload
+            .get("runtime_id")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|value| uuid::Uuid::parse_str(value).ok())
+            == Some(target.runtime_id)
+        && payload
+            .get("sandbox_id")
+            .and_then(serde_json::Value::as_str)
+            == Some(target.sandbox_id.as_str())
+        && payload
+            .get("native_turn")
+            .and_then(serde_json::Value::as_u64)
+            == Some(u64::from(target.native_turn))
+        && payload
+            .get("expected_turn_id")
+            .and_then(serde_json::Value::as_str)
+            == Some(target.expected_turn_id.to_string().as_str())
+        && payload
+            .get("correlation_uuid")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|value| uuid::Uuid::parse_str(value).ok())
+            == Some(target.correlation_uuid)
+}
+
+async fn settle_sandbox_steer_admissions(
+    db: &Arc<DbStore>,
+    owner: &OwnerId,
+    session_id: SessionId,
+    source_sandbox: &str,
+    events: &[super::wire::SandboxEvent],
+) -> Result<(), tidebreak_core::AgentError> {
+    use tidebreak_core::code::{ExternalSteerAdmission, ExternalSteerQueuedReason};
+    for event in events {
+        if !matches!(event.kind.as_str(), "steer_ack" | "steer_refused") {
+            continue;
+        }
+        let Some(correlation) = event
+            .payload
+            .get("correlation_uuid")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|value| uuid::Uuid::parse_str(value).ok())
+        else {
+            continue;
+        };
+        let Some(target) = tidebreak_core::db::code::external_steer_target_by_correlation(
+            db,
+            owner,
+            session_id,
+            correlation,
+        )
+        .await?
+        else {
+            continue;
+        };
+        if !steer_ack_matches_target(&event.payload, source_sandbox, &target) {
+            continue;
+        }
+        let (outcome, reason) = if event.kind == "steer_ack" {
+            (ExternalSteerAdmission::Steered, None)
+        } else {
+            (
+                ExternalSteerAdmission::Queued,
+                Some(ExternalSteerQueuedReason::SteerUnsupported),
+            )
+        };
+        tidebreak_core::db::code::settle_external_steer_admission(
+            db,
+            owner,
+            session_id,
+            &target.event_id,
+            target.expected_turn_id,
+            outcome,
+            reason,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
 impl RemoteDriver<'_> {
+    /// Return the process that advertises the steering protocol in this incarnation.
+    pub async fn steering_runtime(
+        &self,
+        owner: &OwnerId,
+        session_id: SessionId,
+    ) -> Result<Option<uuid::Uuid>, tidebreak_core::AgentError> {
+        use tidebreak_core::storage::Store;
+        let Some(row) = latest_incarnation(self.db, owner, session_id).await? else {
+            return Ok(None);
+        };
+        if row.state != IncarnationState::Active {
+            return Ok(None);
+        }
+        let key = format!("code.incarnations.{}.steering_protocol", row.id);
+        let Some(value) = self.db.get_setting(&key).await? else {
+            return Ok(None);
+        };
+        if value.get("version").and_then(serde_json::Value::as_u64) != Some(1)
+            || value.get("sandbox_id").and_then(serde_json::Value::as_str)
+                != row.sandbox_id.as_deref()
+        {
+            return Ok(None);
+        }
+        Ok(value
+            .get("runtime_id")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|value| uuid::Uuid::parse_str(value).ok())
+            .filter(|id| !id.is_nil()))
+    }
+
     /// Submit one user turn to a remote session.
     ///
     /// The session row is updated (lifecycle, attention) on success; the caller
@@ -843,6 +962,69 @@ impl RemoteDriver<'_> {
         }
     }
 
+    /// Send one durable steering frame into the live sandbox's inbox.
+    ///
+    /// This is transport-only: no turn row is created, and the caller owns
+    /// the durable admission row. The supervised agent acknowledges only
+    /// after the native engine accepts the instruction.
+    pub async fn send_steer_frame(
+        &self,
+        owner: &OwnerId,
+        session_id: SessionId,
+        body: String,
+    ) -> Result<(), tidebreak_core::AgentError> {
+        let Some(row) = latest_incarnation(self.db, owner, session_id).await? else {
+            return Err(tidebreak_core::AgentError::Store(
+                "cannot steer a sandbox with no incarnation".into(),
+            ));
+        };
+        if row.state != IncarnationState::Active {
+            return Err(tidebreak_core::AgentError::Store(
+                "the sandbox is not active; steering is unavailable".into(),
+            ));
+        }
+        let Some(sandbox_id) = row.sandbox_id.as_deref() else {
+            return Err(tidebreak_core::AgentError::Store(
+                "active incarnation has no sandbox id".into(),
+            ));
+        };
+        let frame = tidebreak_core::code::supervisor_tools::decode_steer_frame(&body)
+            .ok_or_else(|| tidebreak_core::AgentError::Store("invalid steering frame".into()))?;
+        let frame_runtime = uuid::Uuid::parse_str(&frame.runtime_id).ok();
+        if frame_runtime.is_none()
+            || frame_runtime != self.steering_runtime(owner, session_id).await?
+        {
+            return Err(tidebreak_core::AgentError::Store(
+                "the target runtime changed before steering dispatch".into(),
+            ));
+        }
+        if frame.sandbox_id != sandbox_id {
+            return Err(tidebreak_core::AgentError::Store(
+                "the target sandbox changed before steering dispatch".into(),
+            ));
+        }
+        let message = SandboxMessage {
+            body: SupervisorMessageBody::Input(body),
+            interrupt: false,
+        };
+        message
+            .validate()
+            .map_err(tidebreak_core::AgentError::Store)?;
+        match self
+            .provisioner
+            .send(owner, session_id, sandbox_id, &message)
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(RemoteSandboxError::SignInRequired(detail)) => {
+                Err(tidebreak_core::AgentError::Store(format!(
+                    "sandbox steering needs a sign-in: {detail}"
+                )))
+            }
+            Err(error) => Err(tidebreak_core::AgentError::Store(error.to_string())),
+        }
+    }
+
     /// Read and apply everything new from the session's live sandbox.
     ///
     /// Idle when no incarnation is active. The caller schedules pumps; this
@@ -991,6 +1173,40 @@ impl RemoteDriver<'_> {
             }
             read.events.truncate(accepted_prefix);
         }
+        for event in &read.events {
+            if event.kind == "supervisor_started" {
+                use tidebreak_core::storage::Store;
+                let runtime_id = event
+                    .payload
+                    .get("runtime_id")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|value| uuid::Uuid::parse_str(value).ok())
+                    .filter(|id| !id.is_nil());
+                let compatible = event
+                    .payload
+                    .get("agent")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("tidebreak-supervised-agent")
+                    && event
+                        .payload
+                        .get("steering_protocol")
+                        .and_then(serde_json::Value::as_u64)
+                        == Some(1)
+                    && runtime_id.is_some();
+                db.set_setting(
+                    &format!("code.incarnations.{}.steering_protocol", row.id),
+                    &serde_json::json!({
+                        "version": if compatible {1} else {0},
+                        "sandbox_id": sandbox_id,
+                        "runtime_id": runtime_id,
+                    }),
+                )
+                .await?;
+            }
+        }
+        // Commit native admission before advancing the event cursor. A failed
+        // ingest can replay this idempotently; the inverse order loses ACKs.
+        settle_sandbox_steer_admissions(db, &owner, session.id, &sandbox_id, &read.events).await?;
         let outcome: IngestOutcome = ingest_events(db, bus, &binding, &read).await?;
         report.ingested = outcome.ingested;
 
@@ -1271,6 +1487,48 @@ mod tests {
     };
     use super::*;
 
+    #[test]
+    fn steering_ack_requires_the_persisted_target_and_source() {
+        let target = tidebreak_core::db::code::ExternalSteerTarget {
+            event_id: "delivery-1".into(),
+            turn_id: TurnId::new(),
+            expected_turn_id: TurnId::new(),
+            correlation_uuid: uuid::Uuid::new_v4(),
+            sandbox_id: "sandbox-1".into(),
+            runtime_id: uuid::Uuid::new_v4(),
+            native_turn: 2,
+        };
+        let payload = json!({
+            "sandbox_id": target.sandbox_id,
+            "runtime_id": target.runtime_id.to_string(),
+            "native_turn": target.native_turn,
+            "expected_turn_id": target.expected_turn_id.to_string(),
+            "correlation_uuid": target.correlation_uuid.to_string(),
+        });
+        assert!(steer_ack_matches_target(&payload, "sandbox-1", &target));
+        assert!(!steer_ack_matches_target(&payload, "sandbox-2", &target));
+        for (key, wrong) in [
+            ("sandbox_id", json!("sandbox-2")),
+            ("runtime_id", json!(uuid::Uuid::new_v4().to_string())),
+            ("native_turn", json!(1)),
+            ("expected_turn_id", json!(TurnId::new().to_string())),
+            ("correlation_uuid", json!(uuid::Uuid::new_v4().to_string())),
+        ] {
+            let mut mismatch = payload.clone();
+            mismatch[key] = wrong;
+            assert!(
+                !steer_ack_matches_target(&mismatch, "sandbox-1", &target),
+                "{key}"
+            );
+            let mut missing = payload.clone();
+            missing.as_object_mut().unwrap().remove(key);
+            assert!(
+                !steer_ack_matches_target(&missing, "sandbox-1", &target),
+                "missing {key}"
+            );
+        }
+    }
+
     type SpawnHook = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
 
     #[derive(Default)]
@@ -1415,6 +1673,7 @@ mod tests {
         accepted: Mutex<Vec<String>>,
         queued: Mutex<usize>,
         serviced: Mutex<usize>,
+        fail_service: bool,
     }
 
     #[async_trait]
@@ -1458,6 +1717,11 @@ mod tests {
             Vec<tidebreak_core::code::supervisor_tools::SupervisorToolResult>,
             tidebreak_core::AgentError,
         > {
+            if self.fail_service {
+                return Err(tidebreak_core::AgentError::Store(
+                    "injected host service failure".into(),
+                ));
+            }
             *self.queued.lock().unwrap() = 0;
             *self.serviced.lock().unwrap() += 1;
             Ok(Vec::new())
@@ -1479,6 +1743,195 @@ mod tests {
             "host_tool_request",
             json!({"request_id": request_id, "tool":"code_repos", "arguments":{}}),
         )
+    }
+
+    #[tokio::test]
+    async fn steering_runtime_rotates_on_restart_and_refuses_old_process_frames() {
+        use tidebreak_core::code::supervisor_tools::{encode_steer_frame, SupervisorSteerFrame};
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, _, _) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        let fake = FakeProvisioner::default();
+        let settings = settings();
+        let driver = RemoteDriver {
+            db: &db,
+            bus: &bus,
+            provisioner: &fake,
+            settings: &settings,
+            host_tool: None,
+        };
+        assert_eq!(
+            driver
+                .steering_runtime(&session.owner, session.id)
+                .await
+                .unwrap(),
+            None
+        );
+        let first_runtime = uuid::Uuid::new_v4();
+        let second_runtime = uuid::Uuid::new_v4();
+        for (seq, runtime_id) in [(1, first_runtime), (2, second_runtime)] {
+            fake.event_reads.lock().unwrap().push_back(read(
+                SandboxState::Running,
+                seq,
+                vec![event(
+                    seq,
+                    "supervisor_started",
+                    json!({
+                        "agent": "tidebreak-supervised-agent",
+                        "steering_protocol": 1,
+                        "runtime_id": runtime_id.to_string(),
+                    }),
+                )],
+            ));
+            driver.pump(&mut session, 0).await.unwrap();
+            assert_eq!(
+                driver
+                    .steering_runtime(&session.owner, session.id)
+                    .await
+                    .unwrap(),
+                Some(runtime_id)
+            );
+        }
+        let mut frame = SupervisorSteerFrame {
+            expected_turn_id: TurnId::new().to_string(),
+            sandbox_id: "sb-1".into(),
+            runtime_id: first_runtime.to_string(),
+            native_turn: 1,
+            correlation_uuid: uuid::Uuid::new_v4().to_string(),
+            body: "guidance".into(),
+        };
+        assert!(driver
+            .send_steer_frame(&session.owner, session.id, encode_steer_frame(&frame))
+            .await
+            .is_err());
+        assert!(fake.sends.lock().unwrap().is_empty());
+        frame.runtime_id = second_runtime.to_string();
+        driver
+            .send_steer_frame(&session.owner, session.id, encode_steer_frame(&frame))
+            .await
+            .unwrap();
+        assert_eq!(fake.sends.lock().unwrap().len(), 1);
+
+        // Every unsupported startup clears the old process capability.
+        for (offset, payload) in [
+            json!({"agent":"tidebreak-supervised-agent","steering_protocol":1}),
+            json!({"agent":"tidebreak-supervised-agent","steering_protocol":1,"runtime_id":"invalid"}),
+            json!({"agent":"tidebreak-supervised-agent","steering_protocol":1,"runtime_id":uuid::Uuid::nil().to_string()}),
+            json!({"agent":"tidebreak-supervised-agent","steering_protocol":2,"runtime_id":second_runtime.to_string()}),
+            json!({"agent":"custom","steering_protocol":1,"runtime_id":second_runtime.to_string()}),
+        ].into_iter().enumerate() {
+            let seq = i64::try_from(offset).unwrap() + 3;
+            fake.event_reads.lock().unwrap().push_back(read(SandboxState::Running, seq, vec![event(seq, "supervisor_started", payload)]));
+            driver.pump(&mut session, 0).await.unwrap();
+            assert_eq!(driver.steering_runtime(&session.owner, session.id).await.unwrap(), None);
+        }
+    }
+
+    #[tokio::test]
+    async fn steering_ack_survives_failure_after_event_cursor_advances() {
+        use tidebreak_core::db::code::{
+            claim_external_steer_target, external_steer_admission, list_queued_turns,
+            record_external_message_with_steer, ExternalSteerAdmissionInput,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, mut session, _, _) = seed(dir.path()).await;
+        super::super::fixtures::seeded_incarnation(&db, &session).await;
+        let target = TurnId::new();
+        let correlation = uuid::Uuid::new_v4();
+        let runtime_id = uuid::Uuid::new_v4();
+        record_external_message_with_steer(
+            &db,
+            &session.owner,
+            session.id,
+            "ev-steer",
+            "1.1",
+            "follow up",
+            &Default::default(),
+            None,
+            ExternalSteerAdmissionInput {
+                request_steer: true,
+                expected_turn_id: Some(target),
+                correlation_uuid: Some(correlation),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(claim_external_steer_target(
+            &db,
+            &session.owner,
+            session.id,
+            "ev-steer",
+            target,
+            correlation,
+            "sb-1",
+            1,
+            runtime_id
+        )
+        .await
+        .unwrap());
+        let fake = FakeProvisioner::default();
+        let host = BoundedHost {
+            fail_service: true,
+            ..Default::default()
+        };
+        let settings = settings();
+        let driver = RemoteDriver {
+            db: &db,
+            bus: &bus,
+            provisioner: &fake,
+            settings: &settings,
+            host_tool: Some(&host),
+        };
+        fake.event_reads.lock().unwrap().push_back(read(SandboxState::Running,1,vec![event(1,"steer_ack",json!({
+            "sandbox_id":"sb-1","runtime_id":runtime_id.to_string(),"native_turn":1,"expected_turn_id":target.to_string(),"correlation_uuid":correlation.to_string()
+        }))]));
+        assert!(driver.pump(&mut session, 0).await.is_err());
+        assert_eq!(
+            latest_incarnation(&db, &session.owner, session.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .events_cursor,
+            1
+        );
+        let receipt = external_steer_admission(&db, &session.owner, session.id, "ev-steer")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            receipt,
+            tidebreak_core::ExternalMessageRecord::Replay {
+                admission: Some(tidebreak_core::code::ExternalSteerAdmission::Steered),
+                ..
+            }
+        ));
+        assert!(list_queued_turns(&db, &session.owner, session.id)
+            .await
+            .unwrap()
+            .is_empty());
+        // A restarted pump reads beyond the acknowledged event and keeps its result.
+        let driver = RemoteDriver {
+            db: &db,
+            bus: &bus,
+            provisioner: &fake,
+            settings: &settings,
+            host_tool: None,
+        };
+        fake.event_reads
+            .lock()
+            .unwrap()
+            .push_back(read(SandboxState::Running, 1, vec![]));
+        driver.pump(&mut session, 0).await.unwrap();
+        assert!(matches!(
+            external_steer_admission(&db, &session.owner, session.id, "ev-steer")
+                .await
+                .unwrap()
+                .unwrap(),
+            tidebreak_core::ExternalMessageRecord::Replay {
+                admission: Some(tidebreak_core::code::ExternalSteerAdmission::Steered),
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -474,6 +474,7 @@ fn steer_ack_matches_target(
 
 async fn settle_sandbox_steer_admissions(
     db: &Arc<DbStore>,
+    bus: &dyn RemoteSessionHost,
     owner: &OwnerId,
     session_id: SessionId,
     source_sandbox: &str,
@@ -513,16 +514,13 @@ async fn settle_sandbox_steer_admissions(
                 Some(ExternalSteerQueuedReason::SteerUnsupported),
             )
         };
-        tidebreak_core::db::code::settle_external_steer_admission(
-            db,
-            owner,
-            session_id,
-            &target.event_id,
-            target.expected_turn_id,
-            outcome,
-            reason,
+        let (_, journal) = tidebreak_core::db::code::settle_sandbox_external_steer_admission(
+            db, owner, session_id, &target, outcome, reason,
         )
         .await?;
+        if let Some(event) = journal {
+            bus.publish(session_id, event);
+        }
     }
     Ok(())
 }
@@ -1206,7 +1204,8 @@ impl RemoteDriver<'_> {
         }
         // Commit native admission before advancing the event cursor. A failed
         // ingest can replay this idempotently; the inverse order loses ACKs.
-        settle_sandbox_steer_admissions(db, &owner, session.id, &sandbox_id, &read.events).await?;
+        settle_sandbox_steer_admissions(db, bus, &owner, session.id, &sandbox_id, &read.events)
+            .await?;
         let outcome: IngestOutcome = ingest_events(db, bus, &binding, &read).await?;
         report.ingested = outcome.ingested;
 
@@ -1481,7 +1480,7 @@ mod tests {
     use tidebreak_core::db::code::get_session;
     use tidebreak_core::{AttentionState, CodeIncarnationId};
 
-    use super::super::fixtures::seed;
+    use super::super::fixtures::{seed, TestEvents};
     use super::super::wire::{
         MessageReceipt, SandboxEvent, SandboxEvents, SandboxLease, SandboxState, SandboxStatus,
     };
@@ -1526,6 +1525,86 @@ mod tests {
                 !steer_ack_matches_target(&missing, "sandbox-1", &target),
                 "missing {key}"
             );
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingHost {
+        inner: TestEvents,
+        published: Mutex<Vec<(SessionId, tidebreak_core::code::SequencedEvent)>>,
+        fail_after_publish: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait]
+    impl RemoteSessionHost for RecordingHost {
+        fn publish(&self, session: SessionId, event: tidebreak_core::code::SequencedEvent) {
+            self.published.lock().unwrap().push((session, event));
+            if self
+                .fail_after_publish
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                panic!(
+                    "simulated process failure after publishing and before advancing the cursor"
+                );
+            }
+        }
+
+        async fn persist_session(
+            &self,
+            store: &DbStore,
+            session: &Session,
+        ) -> Result<bool, tidebreak_core::AgentError> {
+            self.inner.persist_session(store, session).await
+        }
+
+        async fn apply_attention(
+            &self,
+            store: &DbStore,
+            owner: &OwnerId,
+            session_id: SessionId,
+            next: Attention,
+        ) -> Result<(), tidebreak_core::AgentError> {
+            self.inner
+                .apply_attention(store, owner, session_id, next)
+                .await
+        }
+
+        async fn journal_event(
+            &self,
+            store: &DbStore,
+            owner: &OwnerId,
+            session_id: SessionId,
+            spawn_epoch: i64,
+            event: tidebreak_core::Event,
+        ) {
+            self.inner
+                .journal_event(store, owner, session_id, spawn_epoch, event)
+                .await;
+        }
+
+        async fn fence_session(
+            &self,
+            store: &DbStore,
+            session: &mut Session,
+            reason: FenceReason,
+        ) -> Result<(), tidebreak_core::AgentError> {
+            self.inner.fence_session(store, session, reason).await
+        }
+
+        async fn recover_dead_worker(
+            &self,
+            store: &DbStore,
+            session: &Session,
+        ) -> Result<Option<Session>, tidebreak_core::AgentError> {
+            self.inner.recover_dead_worker(store, session).await
+        }
+
+        async fn reap_session(
+            &self,
+            store: &DbStore,
+            session: Session,
+        ) -> Result<Session, RemoteReapError> {
+            self.inner.reap_session(store, session).await
         }
     }
 
@@ -1835,6 +1914,11 @@ mod tests {
         };
         let dir = tempfile::tempdir().unwrap();
         let (db, bus, mut session, _, _) = seed(dir.path()).await;
+        session.id = SessionId::new();
+        session.execution_location = tidebreak_core::ExecutionLocation::Sandbox;
+        tidebreak_core::db::code::insert_session(&db, &session)
+            .await
+            .unwrap();
         super::super::fixtures::seeded_incarnation(&db, &session).await;
         let target = TurnId::new();
         let correlation = uuid::Uuid::new_v4();
@@ -1932,6 +2016,179 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn steering_transcript_survives_failure_before_cursor_and_replays_once() {
+        use tidebreak_core::code::{ExternalMessageRecord, ExternalSteerAdmission};
+        use tidebreak_core::db::code::{
+            claim_external_steer_target, external_steer_admission, insert_session, list_events,
+            list_queued_turns, record_external_message_with_steer, ExternalSteerAdmissionInput,
+        };
+        for fail_before_cursor in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let (db, _, mut session, _, _) = seed(dir.path()).await;
+            session.id = SessionId::new();
+            session.execution_location = tidebreak_core::ExecutionLocation::Sandbox;
+            insert_session(&db, &session).await.unwrap();
+            super::super::fixtures::seeded_incarnation(&db, &session).await;
+            let target = TurnId::new();
+            let correlation = uuid::Uuid::new_v4();
+            let runtime_id = uuid::Uuid::new_v4();
+            let original = "Preserve the exact original message.\nInclude the tests.";
+            let record = record_external_message_with_steer(
+                &db,
+                &session.owner,
+                session.id,
+                "ev-transcript",
+                "1.1",
+                original,
+                &Default::default(),
+                None,
+                ExternalSteerAdmissionInput {
+                    request_steer: true,
+                    expected_turn_id: Some(target),
+                    correlation_uuid: Some(correlation),
+                },
+            )
+            .await
+            .unwrap();
+            let ExternalMessageRecord::Recorded(queued) = record else {
+                panic!("first delivery must be recorded");
+            };
+            assert!(claim_external_steer_target(
+                &db,
+                &session.owner,
+                session.id,
+                "ev-transcript",
+                target,
+                correlation,
+                "sb-1",
+                1,
+                runtime_id
+            )
+            .await
+            .unwrap());
+            let acknowledgment = event(
+                1,
+                "steer_ack",
+                json!({
+                    "sandbox_id": "sb-1",
+                    "runtime_id": runtime_id.to_string(),
+                    "native_turn": 1,
+                    "expected_turn_id": target.to_string(),
+                    "correlation_uuid": correlation.to_string(),
+                    "text": "Do not trust a transcript supplied by the sandbox.",
+                }),
+            );
+            let fake = Arc::new(FakeProvisioner::default());
+            fake.event_reads.lock().unwrap().push_back(read(
+                SandboxState::Running,
+                1,
+                vec![acknowledgment.clone()],
+            ));
+            let bus = Arc::new(RecordingHost::default());
+            bus.fail_after_publish
+                .store(fail_before_cursor, std::sync::atomic::Ordering::SeqCst);
+            let settings = settings();
+            let task = tokio::spawn({
+                let db = db.clone();
+                let bus = bus.clone();
+                let fake = fake.clone();
+                let settings = settings.clone();
+                let mut session = session.clone();
+                async move {
+                    RemoteDriver {
+                        db: &db,
+                        bus: bus.as_ref(),
+                        provisioner: fake.as_ref(),
+                        settings: &settings,
+                        host_tool: None,
+                    }
+                    .pump(&mut session, 0)
+                    .await
+                }
+            });
+            let result = task.await;
+            if fail_before_cursor {
+                assert!(result.unwrap_err().is_panic());
+            } else {
+                result.unwrap().unwrap();
+            }
+            assert_eq!(
+                latest_incarnation(&db, &session.owner, session.id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .events_cursor,
+                if fail_before_cursor { 0 } else { 1 }
+            );
+            assert!(matches!(
+                external_steer_admission(&db, &session.owner, session.id, "ev-transcript")
+                    .await
+                    .unwrap(),
+                Some(ExternalMessageRecord::Replay {
+                    admission: Some(ExternalSteerAdmission::Steered),
+                    ..
+                })
+            ));
+            assert!(list_queued_turns(&db, &session.owner, session.id)
+                .await
+                .unwrap()
+                .is_empty());
+            let stored = list_events(&db, &session.owner, session.id, 0, 100)
+                .await
+                .unwrap()
+                .events;
+            assert_eq!(stored.len(), 1);
+            assert_eq!(
+                stored[0].event,
+                tidebreak_core::Event::UserSteered {
+                    text: original.into(),
+                    message_id: Some(queued.id.0)
+                }
+            );
+            assert_eq!(
+                *bus.published.lock().unwrap(),
+                vec![(session.id, stored[0].clone())]
+            );
+
+            // Restart from the durable cursor; repeated native evidence must not duplicate text or publication.
+            let driver = RemoteDriver {
+                db: &db,
+                bus: bus.as_ref(),
+                provisioner: fake.as_ref(),
+                settings: &settings,
+                host_tool: None,
+            };
+            for _ in 0..2 {
+                fake.event_reads.lock().unwrap().push_back(read(
+                    SandboxState::Running,
+                    1,
+                    vec![acknowledgment.clone()],
+                ));
+                driver.pump(&mut session, 0).await.unwrap();
+            }
+            assert_eq!(
+                latest_incarnation(&db, &session.owner, session.id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .events_cursor,
+                1
+            );
+            assert_eq!(
+                list_events(&db, &session.owner, session.id, 0, 100)
+                    .await
+                    .unwrap()
+                    .events,
+                stored
+            );
+            assert_eq!(
+                *bus.published.lock().unwrap(),
+                vec![(session.id, stored[0].clone())]
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -43,6 +43,15 @@ use super::{
 /// does not hold a concurrency slot for an afternoon.
 const STALE_INTENT_AGE: chrono::Duration = chrono::Duration::minutes(10);
 
+/// Whether a steering failure proves that transport never received the frame.
+#[derive(Debug)]
+pub enum SteerDispatchError {
+    /// The caller may release its first-claim receipt to the ordinary queue.
+    NotSent(tidebreak_core::AgentError),
+    /// Transport began; only native evidence may settle the receipt.
+    Unconfirmed(tidebreak_core::AgentError),
+}
+
 /// Spawn-time settings for one remote session's sandboxes.
 #[derive(Clone, Debug)]
 pub struct RemoteSpawnSettings {
@@ -970,56 +979,65 @@ impl RemoteDriver<'_> {
         owner: &OwnerId,
         session_id: SessionId,
         body: String,
-    ) -> Result<(), tidebreak_core::AgentError> {
-        let Some(row) = latest_incarnation(self.db, owner, session_id).await? else {
-            return Err(tidebreak_core::AgentError::Store(
-                "cannot steer a sandbox with no incarnation".into(),
-            ));
-        };
-        if row.state != IncarnationState::Active {
-            return Err(tidebreak_core::AgentError::Store(
-                "the sandbox is not active; steering is unavailable".into(),
-            ));
+    ) -> Result<(), SteerDispatchError> {
+        let prepared: Result<_, tidebreak_core::AgentError> = async {
+            let Some(row) = latest_incarnation(self.db, owner, session_id).await? else {
+                return Err(tidebreak_core::AgentError::Store(
+                    "cannot steer a sandbox with no incarnation".into(),
+                ));
+            };
+            if row.state != IncarnationState::Active {
+                return Err(tidebreak_core::AgentError::Store(
+                    "the sandbox is not active; steering is unavailable".into(),
+                ));
+            }
+            let Some(sandbox_id) = row.sandbox_id.as_deref() else {
+                return Err(tidebreak_core::AgentError::Store(
+                    "active incarnation has no sandbox id".into(),
+                ));
+            };
+            let frame = tidebreak_core::code::supervisor_tools::decode_steer_frame(&body)
+                .ok_or_else(|| {
+                    tidebreak_core::AgentError::Store("invalid steering frame".into())
+                })?;
+            let frame_runtime = uuid::Uuid::parse_str(&frame.runtime_id).ok();
+            if frame_runtime.is_none()
+                || frame_runtime != self.steering_runtime(owner, session_id).await?
+            {
+                return Err(tidebreak_core::AgentError::Store(
+                    "the target runtime changed before steering dispatch".into(),
+                ));
+            }
+            if frame.sandbox_id != sandbox_id {
+                return Err(tidebreak_core::AgentError::Store(
+                    "the target sandbox changed before steering dispatch".into(),
+                ));
+            }
+            let message = SandboxMessage {
+                body: SupervisorMessageBody::Input(body),
+                interrupt: false,
+            };
+            message
+                .validate()
+                .map_err(tidebreak_core::AgentError::Store)?;
+            Ok((sandbox_id.to_owned(), message))
         }
-        let Some(sandbox_id) = row.sandbox_id.as_deref() else {
-            return Err(tidebreak_core::AgentError::Store(
-                "active incarnation has no sandbox id".into(),
-            ));
-        };
-        let frame = tidebreak_core::code::supervisor_tools::decode_steer_frame(&body)
-            .ok_or_else(|| tidebreak_core::AgentError::Store("invalid steering frame".into()))?;
-        let frame_runtime = uuid::Uuid::parse_str(&frame.runtime_id).ok();
-        if frame_runtime.is_none()
-            || frame_runtime != self.steering_runtime(owner, session_id).await?
-        {
-            return Err(tidebreak_core::AgentError::Store(
-                "the target runtime changed before steering dispatch".into(),
-            ));
-        }
-        if frame.sandbox_id != sandbox_id {
-            return Err(tidebreak_core::AgentError::Store(
-                "the target sandbox changed before steering dispatch".into(),
-            ));
-        }
-        let message = SandboxMessage {
-            body: SupervisorMessageBody::Input(body),
-            interrupt: false,
-        };
-        message
-            .validate()
-            .map_err(tidebreak_core::AgentError::Store)?;
+        .await;
+        let (sandbox_id, message) = prepared.map_err(SteerDispatchError::NotSent)?;
         match self
             .provisioner
-            .send(owner, session_id, sandbox_id, &message)
+            .send(owner, session_id, &sandbox_id, &message)
             .await
         {
             Ok(_) => Ok(()),
-            Err(RemoteSandboxError::SignInRequired(detail)) => {
-                Err(tidebreak_core::AgentError::Store(format!(
+            Err(RemoteSandboxError::SignInRequired(detail)) => Err(
+                SteerDispatchError::Unconfirmed(tidebreak_core::AgentError::Store(format!(
                     "sandbox steering needs a sign-in: {detail}"
-                )))
-            }
-            Err(error) => Err(tidebreak_core::AgentError::Store(error.to_string())),
+                ))),
+            ),
+            Err(error) => Err(SteerDispatchError::Unconfirmed(
+                tidebreak_core::AgentError::Store(error.to_string()),
+            )),
         }
     }
 
@@ -1879,10 +1897,12 @@ mod tests {
             correlation_uuid: uuid::Uuid::new_v4().to_string(),
             body: "guidance".into(),
         };
-        assert!(driver
-            .send_steer_frame(&session.owner, session.id, encode_steer_frame(&frame))
-            .await
-            .is_err());
+        assert!(matches!(
+            driver
+                .send_steer_frame(&session.owner, session.id, encode_steer_frame(&frame))
+                .await,
+            Err(SteerDispatchError::NotSent(_))
+        ));
         assert!(fake.sends.lock().unwrap().is_empty());
         frame.runtime_id = second_runtime.to_string();
         driver
@@ -1890,6 +1910,20 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fake.sends.lock().unwrap().len(), 1);
+        fake.send_results
+            .lock()
+            .unwrap()
+            .push_back(Err(RemoteSandboxError::Unavailable {
+                operation: "send",
+                detail: "response lost after admission".into(),
+            }));
+        assert!(matches!(
+            driver
+                .send_steer_frame(&session.owner, session.id, encode_steer_frame(&frame))
+                .await,
+            Err(SteerDispatchError::Unconfirmed(_))
+        ));
+        assert_eq!(fake.sends.lock().unwrap().len(), 2);
 
         // Every unsupported startup clears the old process capability.
         for (offset, payload) in [

--- a/crates/tidebreak-code-remote/src/ingest.rs
+++ b/crates/tidebreak-code-remote/src/ingest.rs
@@ -201,6 +201,9 @@ fn project_event(binding: &IngestBinding, kind: &str, payload: &Value) -> Projec
         "task_output" => {
             out.task_output = payload_str(payload, "body").map(str::to_owned);
         }
+        // Durable steering admissions are protocol state, not journal rows.
+        // The driver settles them from the correlation/expected-turn payload.
+        "steer_ack" | "steer_refused" => {}
         "supervisor_stopped" => {
             let reason = payload_str(payload, "reason").unwrap_or("stopped");
             out.journal.push(notice(

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -708,6 +708,7 @@ pub enum Event {
         #[ts(optional)]
         message_id: Option<uuid::Uuid>,
     },
+
     /// The turn finished successfully.
     TurnCompleted {
         /// Token accounting as reported by the engine.

--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -2167,7 +2167,90 @@ pub enum ExternalMessageRecord {
     Replay {
         /// The id shared by the queue row and the turn it promotes into.
         turn_id: TurnId,
+        /// Whether the first delivery asked to steer into the active native
+        /// turn. Absent on old rows, which means queue-default.
+        steer_requested: Option<bool>,
+        /// The native turn the admission targeted, when the caller supplied
+        /// one and the row is recent enough to hold the metadata.
+        expected_turn_id: Option<TurnId>,
+        /// The caller's correlation id, echoed so a replayed delivery can
+        /// reconcile the same admission without resending text.
+        correlation_uuid: Option<uuid::Uuid>,
+        /// Durable admission resolution. `None` means the machine is still
+        /// waiting for an engine acknowledgement; the caller must not render
+        /// the message as steered yet.
+        admission: Option<ExternalSteerAdmission>,
+        /// The bounded reason behind a queued admission, preserved for replay.
+        queued_reason: Option<ExternalSteerQueuedReason>,
     },
+}
+
+/// The durable resolution of one external steering admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalSteerAdmission {
+    /// The native engine acknowledged the instruction into the expected turn.
+    Steered,
+    /// The message did not steer; it sits (or will sit) in the durable queue.
+    Queued,
+}
+
+impl ExternalSteerAdmission {
+    /// Stable wire token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Steered => "steered",
+            Self::Queued => "queued",
+        }
+    }
+
+    /// Parse a stored token.
+    #[must_use]
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "steered" => Some(Self::Steered),
+            "queued" => Some(Self::Queued),
+            _ => None,
+        }
+    }
+}
+
+/// A bounded reason attached to a queued steering admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalSteerQueuedReason {
+    /// The harness does not support acknowledged mid-turn steering.
+    SteerUnsupported,
+    /// No active turn matched the expected id, or the turn was stale.
+    StaleTurn,
+    /// The machine could not prove the engine acknowledged the instruction.
+    Unacknowledged,
+}
+
+impl ExternalSteerQueuedReason {
+    /// Stable wire token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SteerUnsupported => "steer_unsupported",
+            Self::StaleTurn => "stale_turn",
+            Self::Unacknowledged => "unacknowledged",
+        }
+    }
+
+    /// Parse a stored token.
+    #[must_use]
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "steer_unsupported" => Some(Self::SteerUnsupported),
+            "stale_turn" => Some(Self::StaleTurn),
+            "unacknowledged" => Some(Self::Unacknowledged),
+            _ => None,
+        }
+    }
 }
 
 /// The outcome of asking for a new incarnation under the owner's cap.

--- a/crates/tidebreak-core/src/code/supervisor_tools.rs
+++ b/crates/tidebreak-core/src/code/supervisor_tools.rs
@@ -385,3 +385,49 @@ mod tests {
             .is_err());
     }
 }
+
+/// Prefix for durable steering instructions sent over the ordinary string
+/// message transport. Send only to supervisors that support this protocol.
+/// The supervisor consumes these frames without using them as ordinary input.
+pub const STEER_PREFIX: &str = "tidebreak-steer-v1\n";
+
+/// One durable steering admission framed for the supervised sandbox.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SupervisorSteerFrame {
+    /// Active Tidebreak turn the instruction targets.
+    pub expected_turn_id: String,
+    /// The sandbox incarnation that owns the target native turn. A stale
+    /// frame from an older incarnation must never steer a newer one; the
+    /// supervisor compares this against the sandbox id it was spawned with.
+    pub sandbox_id: String,
+    /// Identifies this supervisor process, including restarts within one sandbox.
+    pub runtime_id: String,
+    /// The agent's current native turn counter; the supervisor only steers
+    /// when this matches its running turn.
+    pub native_turn: u32,
+    /// Caller correlation id, echoed back in `steer_ack`. Required for
+    /// sandbox steering so admission settlement is never ambiguous.
+    pub correlation_uuid: String,
+    /// User text to inject into the running native turn.
+    pub body: String,
+}
+
+/// Encode a steering admission as an ordinary string message.
+pub fn encode_steer_frame(frame: &SupervisorSteerFrame) -> String {
+    format!(
+        "{STEER_PREFIX}{}",
+        serde_json::to_string(frame).expect("a bounded steer frame serializes")
+    )
+}
+
+/// Whether a message is a steering admission frame.
+pub fn is_steer_frame(message: &str) -> bool {
+    message.starts_with(STEER_PREFIX)
+}
+
+/// Decode a steering admission frame. `None` for malformed frames.
+pub fn decode_steer_frame(message: &str) -> Option<SupervisorSteerFrame> {
+    let payload = message.strip_prefix(STEER_PREFIX)?;
+    serde_json::from_str(payload).ok()
+}

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1747,6 +1747,15 @@ pub mod code_external_event {
         pub channel_ts: String,
         pub turn_id: Uuid,
         pub created_at: DateTimeUtc,
+        pub steer_requested: bool,
+        pub expected_turn_id: Option<Uuid>,
+        pub correlation_uuid: Option<Uuid>,
+        pub steer_sandbox_id: Option<String>,
+        pub steer_native_turn: Option<i64>,
+        pub steer_runtime_id: Option<Uuid>,
+        pub outcome: Option<String>,
+        pub outcome_reason: Option<String>,
+        pub outcome_at: Option<DateTimeUtc>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -26,6 +26,7 @@
 mod baseline;
 mod channel_repository_confirm;
 mod code_conversation_request;
+mod external_steer_admission;
 mod external_thread_context;
 mod grant_kind;
 mod idens;
@@ -109,6 +110,7 @@ impl MigratorTrait for Migrator {
             Box::new(native_tool_receipt::NativeToolReceipts),
             Box::new(native_tool_receipt::NativeToolClaimTime),
             Box::new(workspace_setup_error::WorkspaceSetupError),
+            Box::new(external_steer_admission::ExternalSteerAdmission),
         ]
     }
 }

--- a/crates/tidebreak-core/src/db/migration/external_steer_admission.rs
+++ b/crates/tidebreak-core/src/db/migration/external_steer_admission.rs
@@ -1,0 +1,92 @@
+//! Durable admission metadata for external slack steering
+//! (`docs/slack-sessions.md`, steer outcome).
+//!
+//! One external channel event already commits with its queue row; this
+//! migration records whether that delivery asked to steer, the native turn
+//! it was admitted against, the caller correlation id, and the machine's
+//! durable resolution (`steered` or `queued` with a reason). `outcome` stays
+//! null until the admission resolves, so a replay can answer honestly while
+//! the engine is still acknowledging steering.
+use sea_orm_migration::prelude::*;
+
+use super::idens::CodeExternalEvent;
+
+pub(super) struct ExternalSteerAdmission;
+
+impl MigrationName for ExternalSteerAdmission {
+    fn name(&self) -> &str {
+        "m20260911_000001_external_steer_admission"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for ExternalSteerAdmission {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for column in [
+            CodeExternalEvent::SteerRequested,
+            CodeExternalEvent::ExpectedTurnId,
+            CodeExternalEvent::CorrelationUuid,
+            CodeExternalEvent::SteerSandboxId,
+            CodeExternalEvent::SteerNativeTurn,
+            CodeExternalEvent::SteerRuntimeId,
+            CodeExternalEvent::Outcome,
+            CodeExternalEvent::OutcomeReason,
+            CodeExternalEvent::OutcomeAt,
+        ] {
+            let name = column.to_string();
+            if manager.has_column("code_external_event", &name).await? {
+                continue;
+            }
+            let column_def = {
+                let mut def = ColumnDef::new(column);
+                match name.as_str() {
+                    "steer_requested" => {
+                        def.boolean().not_null().default(false);
+                    }
+                    "expected_turn_id" | "correlation_uuid" | "steer_runtime_id" => {
+                        def.uuid();
+                    }
+                    "steer_native_turn" => {
+                        def.big_integer();
+                    }
+                    "steer_sandbox_id" | "outcome" | "outcome_reason" => {
+                        def.text();
+                    }
+                    "outcome_at" => {
+                        def.timestamp_with_time_zone();
+                    }
+                    _ => unreachable!("all new columns are handled"),
+                }
+                def
+            };
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(CodeExternalEvent::Table)
+                        .add_column_if_not_exists(column_def)
+                        .to_owned(),
+                )
+                .await?;
+        }
+        manager
+            .create_index(
+                Index::create()
+                    .name("ix_code_external_event_correlation")
+                    .table(CodeExternalEvent::Table)
+                    .col(CodeExternalEvent::Owner)
+                    .col(CodeExternalEvent::SessionId)
+                    .col(CodeExternalEvent::CorrelationUuid)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Dropping the columns would forget admitted steering and replay
+        // safety; a rolled-back release leaves harmless nullable columns.
+        Ok(())
+    }
+}

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -1172,6 +1172,15 @@ pub(crate) enum CodeExternalEvent {
     ChannelTs,
     TurnId,
     CreatedAt,
+    SteerRequested,
+    ExpectedTurnId,
+    CorrelationUuid,
+    SteerSandboxId,
+    SteerNativeTurn,
+    SteerRuntimeId,
+    Outcome,
+    OutcomeReason,
+    OutcomeAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/tidebreak-core/src/db/migration/tests.rs
+++ b/crates/tidebreak-core/src/db/migration/tests.rs
@@ -102,6 +102,7 @@ async fn a_fresh_database_records_the_whole_chain() {
             "m20260910_000025_native_tool_receipts",
             "m20260910_000026_native_tool_claim_time",
             "m20260910_000027_workspace_setup_error",
+            "m20260911_000001_external_steer_admission",
         ]
     );
     assert!(db

--- a/crates/tidebreak-core/src/db/ops/code/external_event.rs
+++ b/crates/tidebreak-core/src/db/ops/code/external_event.rs
@@ -663,6 +663,83 @@ pub struct ExternalSteerTarget {
     pub runtime_id: uuid::Uuid,
 }
 
+/// Settle the frozen sandbox delivery and preserve its admitted text together.
+/// Replays return the same outcome without adding another transcript event.
+pub async fn settle_sandbox_external_steer_admission(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    target: &ExternalSteerTarget,
+    admission: ExternalSteerAdmission,
+    reason: Option<ExternalSteerQueuedReason>,
+) -> Result<(bool, Option<crate::code::SequencedEvent>)> {
+    use crate::code::{Event, ExecutionLocation, SequencedEvent};
+
+    if (admission == ExternalSteerAdmission::Steered) != reason.is_none() {
+        return Ok((false, None));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_code_session_write_lock(&transaction, session_id).await? {
+        return Ok((false, None));
+    }
+    let session = entities::session::Entity::find_by_id(session_id.0)
+        .filter(entities::session::Column::Owner.eq(owner.as_str()))
+        .filter(
+            entities::session::Column::ExecutionLocation.eq(ExecutionLocation::Sandbox.as_str()),
+        )
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    if session.is_none() {
+        return Ok((false, None));
+    }
+    let Some(receipt) = find_event_on(&transaction, owner, session_id, &target.event_id).await?
+    else {
+        return Ok((false, None));
+    };
+    if !receipt.steer_requested
+        || receipt.turn_id != target.turn_id.0
+        || receipt.expected_turn_id != Some(target.expected_turn_id.0)
+        || receipt.correlation_uuid != Some(target.correlation_uuid)
+        || receipt.steer_sandbox_id.as_deref() != Some(target.sandbox_id.as_str())
+        || receipt.steer_native_turn != Some(i64::from(target.native_turn))
+        || receipt.steer_runtime_id != Some(target.runtime_id)
+    {
+        return Ok((false, None));
+    }
+    let original = if receipt.outcome.is_none() && admission == ExternalSteerAdmission::Steered {
+        entities::code_queued_turn::Entity::find_by_id(target.turn_id.0)
+            .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+            .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+    } else {
+        None
+    };
+    let settled =
+        settle_external_steer_on(&transaction, owner, session_id, receipt, admission, reason)
+            .await?;
+    let journaled = if settled {
+        if let Some(original) = original {
+            let event = Event::UserSteered {
+                text: original.message,
+                message_id: Some(target.turn_id.0),
+            };
+            let seq =
+                super::journal::append_event_on_locked(&transaction, owner, session_id, &event)
+                    .await?;
+            Some(SequencedEvent { seq, event })
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    transaction.commit().await.map_err(store_err)?;
+    Ok((settled, journaled))
+}
+
 /// Claim one sandbox dispatch before sending its frame.
 ///
 /// Only the first claim returns true. A retry never sends again after an

--- a/crates/tidebreak-core/src/db/ops/code/external_event.rs
+++ b/crates/tidebreak-core/src/db/ops/code/external_event.rs
@@ -16,11 +16,14 @@
 //! "B steered by A".
 
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
-    TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set, TransactionTrait,
 };
 
-use crate::code::{ExternalMessageRecord, QueuedTurn, SessionId, TurnId};
+use crate::code::{
+    ExternalMessageRecord, ExternalSteerAdmission, ExternalSteerQueuedReason, QueuedTurn,
+    SessionId, TurnId,
+};
 use crate::error::{AgentError, Result};
 use crate::OwnerId;
 
@@ -135,6 +138,18 @@ pub async fn record_external_message(
     })
 }
 
+/// Admission metadata an external message may carry when it asks to steer.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExternalSteerAdmissionInput {
+    /// Whether the delivery asked to steer into the active native turn.
+    pub request_steer: bool,
+    /// The native turn the instruction targets. Required when steering.
+    pub expected_turn_id: Option<TurnId>,
+    /// Caller correlation id; echoed in the admission response and carried
+    /// through the supervised sandbox so an engine UUID maps back here.
+    pub correlation_uuid: Option<uuid::Uuid>,
+}
+
 /// A context refusal is client input; persistence failures remain server faults.
 #[derive(Debug, thiserror::Error)]
 pub enum ExternalMessageIntakeError {
@@ -163,6 +178,33 @@ pub async fn record_external_message_with_context(
     actor: &crate::code::TurnActor,
     context: Option<&crate::code::ExternalThreadContext>,
 ) -> std::result::Result<ExternalMessageRecord, ExternalMessageIntakeError> {
+    record_external_message_with_steer(
+        store,
+        owner,
+        session_id,
+        event_id,
+        channel_ts,
+        message,
+        actor,
+        context,
+        ExternalSteerAdmissionInput::default(),
+    )
+    .await
+}
+
+/// Record one external delivery with its steering admission metadata.
+#[allow(clippy::too_many_arguments)]
+pub async fn record_external_message_with_steer(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event_id: &str,
+    channel_ts: &str,
+    message: &str,
+    actor: &crate::code::TurnActor,
+    context: Option<&crate::code::ExternalThreadContext>,
+    steering: ExternalSteerAdmissionInput,
+) -> std::result::Result<ExternalMessageRecord, ExternalMessageIntakeError> {
     if event_id.trim().is_empty() || channel_ts.trim().is_empty() {
         return Err(AgentError::Store(
             "an external message needs an event id and an ordering token".into(),
@@ -177,10 +219,32 @@ pub async fn record_external_message_with_context(
         return Err(AgentError::Store(format!("code session {session_id} not found")).into());
     }
     if let Some(event) = find_event_on(&transaction, owner, session_id, event_id).await? {
+        let record = replay_from_event(event);
         transaction.commit().await.map_err(store_err)?;
-        return Ok(ExternalMessageRecord::Replay {
-            turn_id: TurnId(event.turn_id),
+        return Ok(record);
+    }
+    // Replay above is authoritative even when the retry changes its metadata.
+    // Validate new admissions only, before creating any durable queue row.
+    if steering.request_steer && steering.expected_turn_id.is_none() {
+        return Err(ExternalMessageIntakeError::Context {
+            kind: "steer_target_required",
+            message: "Steering requires the turn that the message targets.".into(),
         });
+    }
+    if let Some(correlation) = steering.correlation_uuid {
+        let collision = entities::code_external_event::Entity::find()
+            .filter(entities::code_external_event::Column::Owner.eq(owner.as_str()))
+            .filter(entities::code_external_event::Column::SessionId.eq(session_id.0))
+            .filter(entities::code_external_event::Column::CorrelationUuid.eq(correlation))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        if correlation.is_nil() || collision.is_some() {
+            return Err(ExternalMessageIntakeError::Context {
+                kind: "steer_correlation_conflict",
+                message: "Each delivery needs its own nonempty steering correlation ID.".into(),
+            });
+        }
     }
     let existing = entities::code_queued_turn::Entity::find()
         .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
@@ -282,6 +346,15 @@ pub async fn record_external_message_with_context(
         channel_ts: Set(channel_ts.to_owned()),
         turn_id: Set(queued_id.0),
         created_at: Set(now),
+        steer_requested: Set(steering.request_steer),
+        expected_turn_id: Set(steering.expected_turn_id.map(|id| id.0)),
+        correlation_uuid: Set(steering.correlation_uuid),
+        steer_sandbox_id: Set(None),
+        steer_native_turn: Set(None),
+        steer_runtime_id: Set(None),
+        outcome: Set(None),
+        outcome_reason: Set(None),
+        outcome_at: Set(None),
     }
     .insert(&transaction)
     .await;
@@ -293,9 +366,7 @@ pub async fn record_external_message_with_context(
         let Some(event) = find_event_on(&store.conn, owner, session_id, event_id).await? else {
             return Err(store_err(error).into());
         };
-        return Ok(ExternalMessageRecord::Replay {
-            turn_id: TurnId(event.turn_id),
-        });
+        return Ok(replay_from_event(event));
     }
     order_queued_by_channel_ts(&transaction, owner, session_id).await?;
     let row = entities::code_queued_turn::Entity::find_by_id(queued_id.0)
@@ -306,4 +377,394 @@ pub async fn record_external_message_with_context(
     let row = queued_turn_from_model(row)?;
     transaction.commit().await.map_err(store_err)?;
     Ok(ExternalMessageRecord::Recorded(Box::new(row)))
+}
+
+fn replay_from_event(event: entities::code_external_event::Model) -> ExternalMessageRecord {
+    let admission = event
+        .outcome
+        .as_deref()
+        .and_then(ExternalSteerAdmission::from_str);
+    ExternalMessageRecord::Replay {
+        turn_id: TurnId(event.turn_id),
+        steer_requested: event.steer_requested.then_some(true),
+        expected_turn_id: event.expected_turn_id.map(TurnId),
+        correlation_uuid: event.correlation_uuid,
+        admission,
+        // The queued reason is part of the durable admission; a replay must
+        // reproduce it so the adapter renders the same honest substitute.
+        queued_reason: event
+            .outcome_reason
+            .as_deref()
+            .and_then(ExternalSteerQueuedReason::from_str),
+    }
+}
+
+/// Read the durable admission state of one external event.
+pub async fn external_steer_admission(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event_id: &str,
+) -> Result<Option<ExternalMessageRecord>> {
+    let Some(event) = find_event_on(&store.conn, owner, session_id, event_id).await? else {
+        return Ok(None);
+    };
+    Ok(Some(replay_from_event(event)))
+}
+
+/// Settle one steering admission durably.
+///
+/// Idempotent for the exact resolution and expected turn. `false` means the
+/// event is missing or its steering metadata cannot be reconciled with the
+/// caller's expected turn, so no outcome is invented.
+pub async fn settle_external_steer_admission(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event_id: &str,
+    expected_turn_id: TurnId,
+    admission: ExternalSteerAdmission,
+    reason: Option<ExternalSteerQueuedReason>,
+) -> Result<bool> {
+    if (admission == ExternalSteerAdmission::Steered) != reason.is_none() {
+        return Ok(false);
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_code_session_write_lock(&transaction, session_id).await? {
+        return Ok(false);
+    }
+    let Some(event) = find_event_on(&transaction, owner, session_id, event_id).await? else {
+        return Ok(false);
+    };
+    if !event.steer_requested || event.expected_turn_id != Some(expected_turn_id.0) {
+        return Ok(false);
+    }
+    let settled =
+        settle_external_steer_on(&transaction, owner, session_id, event, admission, reason).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(settled)
+}
+
+async fn settle_external_steer_on<C: ConnectionTrait>(
+    conn: &C,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event: entities::code_external_event::Model,
+    admission: ExternalSteerAdmission,
+    reason: Option<ExternalSteerQueuedReason>,
+) -> Result<bool> {
+    let requested_reason = reason.map(|reason| reason.as_str().to_owned());
+    if let Some(existing) = event.outcome.as_deref() {
+        return Ok(existing == admission.as_str() && event.outcome_reason == requested_reason);
+    }
+    let now = database_now(conn).await?;
+    entities::code_external_event::ActiveModel {
+        id: Set(event.id),
+        outcome: Set(Some(admission.as_str().to_owned())),
+        outcome_reason: Set(requested_reason),
+        outcome_at: Set(Some(now)),
+        ..Default::default()
+    }
+    .update(conn)
+    .await
+    .map_err(store_err)?;
+    if admission == ExternalSteerAdmission::Steered {
+        // The native turn has consumed this input. Its receipt survives, but
+        // the same input can no longer become a second turn after a restart.
+        entities::code_queued_turn::Entity::delete_many()
+            .filter(entities::code_queued_turn::Column::Id.eq(event.turn_id))
+            .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+            .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+            .exec(conn)
+            .await
+            .map_err(store_err)?;
+    }
+    Ok(true)
+}
+
+/// Settle a machine acknowledgment only while its original turn and worker own
+/// the session. Remote dispatch claims cannot settle through a machine sink.
+pub async fn settle_machine_external_steer_ack(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    worker_epoch: i64,
+    expected_turn_id: TurnId,
+    correlation_uuid: uuid::Uuid,
+) -> Result<bool> {
+    settle_machine_external_steer_admission(
+        store,
+        owner,
+        session_id,
+        worker_epoch,
+        expected_turn_id,
+        correlation_uuid,
+        ExternalSteerAdmission::Steered,
+        None,
+    )
+    .await
+}
+
+/// Settle a machine control response while its worker still owns the session.
+/// A successful steer also requires its exact target turn to remain running.
+#[allow(clippy::too_many_arguments)]
+pub async fn settle_machine_external_steer_admission(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    worker_epoch: i64,
+    expected_turn_id: TurnId,
+    correlation_uuid: uuid::Uuid,
+    admission: ExternalSteerAdmission,
+    reason: Option<ExternalSteerQueuedReason>,
+) -> Result<bool> {
+    use crate::code::{ExecutionLocation, SessionLifecycle, TurnStatus};
+
+    if (admission == ExternalSteerAdmission::Steered) != reason.is_none() {
+        return Ok(false);
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_code_session_write_lock(&transaction, session_id).await? {
+        return Ok(false);
+    }
+    let Some(session) = entities::session::Entity::find_by_id(session_id.0)
+        .filter(entities::session::Column::Owner.eq(owner.as_str()))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(false);
+    };
+    if session.spawn_epoch != worker_epoch
+        || session.execution_location != ExecutionLocation::Machine.as_str()
+        || (admission == ExternalSteerAdmission::Steered
+            && session.lifecycle != SessionLifecycle::Running.as_str())
+    {
+        return Ok(false);
+    }
+    let running = entities::turn::Entity::find_by_id(expected_turn_id.0)
+        .filter(entities::turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::turn::Column::SessionId.eq(session_id.0))
+        .filter(entities::turn::Column::Status.eq(TurnStatus::Running.as_str()))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    if admission == ExternalSteerAdmission::Steered && running.is_none() {
+        return Ok(false);
+    }
+    let Some(event) = entities::code_external_event::Entity::find()
+        .filter(entities::code_external_event::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_event::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_external_event::Column::CorrelationUuid.eq(correlation_uuid))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(false);
+    };
+    if !event.steer_requested
+        || event.expected_turn_id != Some(expected_turn_id.0)
+        || event.steer_sandbox_id.is_some()
+        || event.steer_native_turn.is_some()
+        || event.steer_runtime_id.is_some()
+    {
+        return Ok(false);
+    }
+    let settled =
+        settle_external_steer_on(&transaction, owner, session_id, event, admission, reason).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(settled)
+}
+
+/// Find one external event by its admission correlation id, scoped to a
+/// session. Correlation ids are minted per delivery by the adapter, so a
+/// match is the durable handle a supervised sandbox ack carries back.
+pub async fn external_event_by_correlation(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    correlation_uuid: uuid::Uuid,
+) -> Result<Option<ExternalMessageRecord>> {
+    let Some(event) = entities::code_external_event::Entity::find()
+        .filter(entities::code_external_event::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_event::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_external_event::Column::CorrelationUuid.eq(correlation_uuid))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(replay_from_event(event)))
+}
+
+/// The channel event id behind one admission correlation id.
+pub async fn external_event_key_by_correlation(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    correlation_uuid: uuid::Uuid,
+) -> Result<Option<String>> {
+    let row = entities::code_external_event::Entity::find()
+        .select_only()
+        .column(entities::code_external_event::Column::EventId)
+        .filter(entities::code_external_event::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_event::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_external_event::Column::CorrelationUuid.eq(correlation_uuid))
+        .into_tuple::<String>()
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(row)
+}
+
+/// Correlation lookup by its wire string form; invalid strings match nothing.
+pub async fn external_event_key_by_correlation_str(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    correlation_uuid: &str,
+) -> Result<Option<String>> {
+    let Ok(correlation_uuid) = uuid::Uuid::parse_str(correlation_uuid) else {
+        return Ok(None);
+    };
+    external_event_key_by_correlation(store, owner, session_id, correlation_uuid).await
+}
+
+/// Correlation record lookup by wire string; invalid strings match nothing.
+pub async fn external_event_by_correlation_str(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    correlation_uuid: &str,
+) -> Result<Option<ExternalMessageRecord>> {
+    let Ok(correlation_uuid) = uuid::Uuid::parse_str(correlation_uuid) else {
+        return Ok(None);
+    };
+    external_event_by_correlation(store, owner, session_id, correlation_uuid).await
+}
+
+/// The immutable target of one sandbox steering dispatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalSteerTarget {
+    /// Channel delivery key.
+    pub event_id: String,
+    /// Queue-row identity retained by the receipt after consumption.
+    pub turn_id: TurnId,
+    /// Tidebreak turn that may consume the instruction.
+    pub expected_turn_id: TurnId,
+    /// Correlation carried by the transport frame and acknowledgment.
+    pub correlation_uuid: uuid::Uuid,
+    /// Sandbox that owns this native turn.
+    pub sandbox_id: String,
+    /// One-based native turn within that sandbox.
+    pub native_turn: u32,
+    /// Supervisor process that owns the native turn.
+    pub runtime_id: uuid::Uuid,
+}
+
+/// Claim one sandbox dispatch before sending its frame.
+///
+/// Only the first claim returns true. A retry never sends again after an
+/// ambiguous response or a restart; its unresolved admission stays held.
+#[allow(clippy::too_many_arguments)]
+pub async fn claim_external_steer_target(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event_id: &str,
+    expected_turn_id: TurnId,
+    correlation_uuid: uuid::Uuid,
+    sandbox_id: &str,
+    native_turn: u32,
+    runtime_id: uuid::Uuid,
+) -> Result<bool> {
+    if sandbox_id.trim().is_empty()
+        || native_turn == 0
+        || correlation_uuid.is_nil()
+        || runtime_id.is_nil()
+    {
+        return Ok(false);
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_code_session_write_lock(&transaction, session_id).await? {
+        return Ok(false);
+    }
+    let Some(event) = find_event_on(&transaction, owner, session_id, event_id).await? else {
+        return Ok(false);
+    };
+    if !event.steer_requested
+        || event.expected_turn_id != Some(expected_turn_id.0)
+        || event.correlation_uuid != Some(correlation_uuid)
+        || event.outcome.is_some()
+        || event.steer_sandbox_id.is_some()
+        || event.steer_native_turn.is_some()
+        || event.steer_runtime_id.is_some()
+    {
+        return Ok(false);
+    }
+    let queued = entities::code_queued_turn::Entity::find_by_id(event.turn_id)
+        .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    if queued.is_none() {
+        return Ok(false);
+    }
+    entities::code_external_event::ActiveModel {
+        id: Set(event.id),
+        steer_sandbox_id: Set(Some(sandbox_id.to_owned())),
+        steer_native_turn: Set(Some(i64::from(native_turn))),
+        steer_runtime_id: Set(Some(runtime_id)),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(true)
+}
+
+/// Resolve an acknowledgment to the exact persisted sandbox target.
+pub async fn external_steer_target_by_correlation(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    correlation_uuid: uuid::Uuid,
+) -> Result<Option<ExternalSteerTarget>> {
+    let Some(event) = entities::code_external_event::Entity::find()
+        .filter(entities::code_external_event::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_event::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_external_event::Column::CorrelationUuid.eq(correlation_uuid))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    if !event.steer_requested {
+        return Ok(None);
+    }
+    let (Some(expected), Some(sandbox_id), Some(native_turn), Some(runtime_id)) = (
+        event.expected_turn_id,
+        event.steer_sandbox_id,
+        event.steer_native_turn,
+        event.steer_runtime_id,
+    ) else {
+        return Ok(None);
+    };
+    let native_turn = u32::try_from(native_turn)
+        .ok()
+        .filter(|turn| *turn > 0)
+        .ok_or_else(|| AgentError::Store("invalid persisted sandbox steering turn".into()))?;
+    Ok(Some(ExternalSteerTarget {
+        event_id: event.event_id,
+        turn_id: TurnId(event.turn_id),
+        expected_turn_id: TurnId(expected),
+        correlation_uuid,
+        sandbox_id,
+        native_turn,
+        runtime_id,
+    }))
 }

--- a/crates/tidebreak-core/src/db/ops/code/queued.rs
+++ b/crates/tidebreak-core/src/db/ops/code/queued.rs
@@ -92,13 +92,13 @@ pub async fn sessions_with_queued_turns_all_owners(
         .collect()
 }
 
-/// The FIFO head, or `None` when the queue is empty.
+/// The FIFO head, or `None` when the queue is empty or steering owns its head.
 pub async fn queued_turn_head(
     store: &DbStore,
     owner: &OwnerId,
     session_id: SessionId,
 ) -> Result<Option<QueuedTurn>> {
-    entities::code_queued_turn::Entity::find()
+    let Some(head) = entities::code_queued_turn::Entity::find()
         .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
         .order_by_asc(entities::code_queued_turn::Column::Position)
@@ -106,8 +106,36 @@ pub async fn queued_turn_head(
         .one(&store.conn)
         .await
         .map_err(store_err)?
-        .map(queued_turn_from_model)
-        .transpose()
+    else {
+        return Ok(None);
+    };
+    if steer_owns_queued_turn(&store.conn, owner, session_id, TurnId(head.id)).await? {
+        // Do not skip the held head: later messages retain their FIFO order.
+        return Ok(None);
+    }
+    queued_turn_from_model(head).map(Some)
+}
+
+/// A steering admission owns its queue row until a proven fallback releases it.
+async fn steer_owns_queued_turn<C>(
+    conn: &C,
+    owner: &OwnerId,
+    session_id: SessionId,
+    id: TurnId,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let receipt = entities::code_external_event::Entity::find()
+        .filter(entities::code_external_event::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_external_event::Column::SessionId.eq(session_id.0))
+        .filter(entities::code_external_event::Column::TurnId.eq(id.0))
+        .one(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(receipt.is_some_and(|receipt| {
+        receipt.steer_requested && receipt.outcome.as_deref() != Some("queued")
+    }))
 }
 
 /// Park one message at the queue tail. The caller supplies the row id, which
@@ -185,6 +213,9 @@ pub async fn promote_queued_turn(
         transaction.commit().await.map_err(store_err)?;
         return Ok(false);
     }
+    if steer_owns_queued_turn(&transaction, owner, expected.session_id, expected.id).await? {
+        return Ok(false);
+    }
     let deleted = entities::code_queued_turn::Entity::delete_many()
         .filter(entities::code_queued_turn::Column::Id.eq(expected.id.0))
         .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
@@ -222,6 +253,9 @@ pub async fn promote_moved_queued_turn(
     let transaction = store.conn.begin().await.map_err(store_err)?;
     if !acquire_code_session_write_lock(&transaction, expected.session_id).await? {
         transaction.commit().await.map_err(store_err)?;
+        return Ok(false);
+    }
+    if steer_owns_queued_turn(&transaction, owner, expected.session_id, expected.id).await? {
         return Ok(false);
     }
     let deleted = entities::code_queued_turn::Entity::delete_many()
@@ -295,6 +329,11 @@ pub async fn update_queued_turn(
     if !acquire_code_session_write_lock(&transaction, session_id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
+    }
+    if message.is_some() && steer_owns_queued_turn(&transaction, owner, session_id, id).await? {
+        return Err(AgentError::Store(
+            "a steering message cannot be edited until its admission resolves".into(),
+        ));
     }
     let now = database_now(&transaction).await?;
     let mut rows = entities::code_queued_turn::Entity::find()

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -8175,3 +8175,328 @@ async fn native_tool_receipts_survive_restart_without_reexecuting_running_work()
     assert_eq!(restored.result, Some(result));
     assert_eq!(restored.call_id, row.call_id);
 }
+
+async fn pending_sandbox_steer(
+    store: &crate::db::DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event_id: &str,
+) -> crate::db::code::ExternalSteerTarget {
+    entities::session::Entity::update_many()
+        .col_expr(
+            entities::session::Column::ExecutionLocation,
+            sea_orm::sea_query::Expr::value(crate::code::ExecutionLocation::Sandbox.as_str()),
+        )
+        .filter(entities::session::Column::Id.eq(session_id.0))
+        .filter(entities::session::Column::Owner.eq(owner.as_str()))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let (_, expected, correlation) = record_pending_steer(store, owner, session_id, event_id).await;
+    assert!(crate::db::code::claim_external_steer_target(
+        store,
+        owner,
+        session_id,
+        event_id,
+        expected,
+        correlation,
+        "sandbox-original",
+        2,
+        uuid::Uuid::new_v4(),
+    )
+    .await
+    .unwrap());
+    crate::db::code::external_steer_target_by_correlation(store, owner, session_id, correlation)
+        .await
+        .unwrap()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn sandbox_steer_ack_preserves_original_text_once() {
+    use crate::code::{ExternalMessageRecord, ExternalSteerAdmission};
+    use crate::db::code::settle_sandbox_external_steer_admission;
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "sandbox-transcript").await;
+    let target = pending_sandbox_steer(&store, &owner, session, "EvTranscript").await;
+    let tail = enqueue_queued_turn(&store, &owner, &queued_message(session, "later"))
+        .await
+        .unwrap();
+    let (settled, journaled) = settle_sandbox_external_steer_admission(
+        &store,
+        &owner,
+        session,
+        &target,
+        ExternalSteerAdmission::Steered,
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(settled);
+    let journaled = journaled.expect("first acknowledgment preserves the admitted input");
+    assert_eq!(
+        journaled.event,
+        Event::UserSteered {
+            text: "redirect".into(),
+            message_id: Some(target.turn_id.0),
+        }
+    );
+    let queue = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(queue.len(), 1);
+    assert_eq!(queue[0].id, tail.id);
+    assert!(matches!(
+        crate::db::code::external_steer_admission(&store, &owner, session, &target.event_id,)
+            .await
+            .unwrap(),
+        Some(ExternalMessageRecord::Replay {
+            admission: Some(ExternalSteerAdmission::Steered),
+            ..
+        })
+    ));
+    for _ in 0..2 {
+        assert_eq!(
+            settle_sandbox_external_steer_admission(
+                &store,
+                &owner,
+                session,
+                &target,
+                ExternalSteerAdmission::Steered,
+                None,
+            )
+            .await
+            .unwrap(),
+            (true, None)
+        );
+    }
+    let events = list_events(&store, &owner, session, 0, MAX_REPLAY_EVENTS)
+        .await
+        .unwrap()
+        .events;
+    assert_eq!(events, vec![journaled]);
+}
+
+#[tokio::test]
+async fn sandbox_steer_journal_failure_rolls_back_receipt_and_queue_consumption() {
+    use crate::code::{ExternalMessageRecord, ExternalSteerAdmission};
+    use crate::db::code::settle_sandbox_external_steer_admission;
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "sandbox-rollback").await;
+    let target = pending_sandbox_steer(&store, &owner, session, "EvRollback").await;
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_sandbox_steer_event BEFORE INSERT ON event \
+         BEGIN SELECT RAISE(ABORT, 'forced sandbox steering journal failure'); END",
+        )
+        .await
+        .unwrap();
+    assert!(settle_sandbox_external_steer_admission(
+        &store,
+        &owner,
+        session,
+        &target,
+        ExternalSteerAdmission::Steered,
+        None,
+    )
+    .await
+    .is_err());
+    assert!(matches!(
+        crate::db::code::external_steer_admission(&store, &owner, session, &target.event_id,)
+            .await
+            .unwrap(),
+        Some(ExternalMessageRecord::Replay {
+            admission: None,
+            ..
+        })
+    ));
+    let queue = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(queue.len(), 1);
+    assert_eq!(queue[0].id, target.turn_id);
+    assert!(list_events(&store, &owner, session, 0, MAX_REPLAY_EVENTS)
+        .await
+        .unwrap()
+        .events
+        .is_empty());
+    store
+        .conn
+        .execute_unprepared("DROP TRIGGER fail_sandbox_steer_event")
+        .await
+        .unwrap();
+    let (settled, journaled) = settle_sandbox_external_steer_admission(
+        &store,
+        &owner,
+        session,
+        &target,
+        ExternalSteerAdmission::Steered,
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(settled);
+    assert!(journaled.is_some());
+    assert!(list_queued_turns(&store, &owner, session)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn sandbox_steer_ack_requires_the_full_frozen_target_and_owner() {
+    use crate::code::{ExternalMessageRecord, ExternalSteerAdmission};
+    use crate::db::code::settle_sandbox_external_steer_admission;
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "sandbox-target-check").await;
+    let target = pending_sandbox_steer(&store, &owner, session, "EvTargetCheck").await;
+    for mismatch in [
+        "event",
+        "queue",
+        "expected",
+        "correlation",
+        "sandbox",
+        "native",
+        "runtime",
+        "owner",
+        "session",
+        "location",
+    ] {
+        let mut changed = target.clone();
+        let mut changed_owner = owner.clone();
+        let mut changed_session = session;
+        match mismatch {
+            "event" => changed.event_id = "different".into(),
+            "queue" => changed.turn_id = TurnId::new(),
+            "expected" => changed.expected_turn_id = TurnId::new(),
+            "correlation" => changed.correlation_uuid = uuid::Uuid::new_v4(),
+            "sandbox" => changed.sandbox_id = "different".into(),
+            "native" => changed.native_turn += 1,
+            "runtime" => changed.runtime_id = uuid::Uuid::new_v4(),
+            "owner" => changed_owner = OwnerId::new("different").unwrap(),
+            "session" => changed_session = SessionId::new(),
+            "location" => {
+                entities::session::Entity::update_many()
+                    .col_expr(
+                        entities::session::Column::ExecutionLocation,
+                        sea_orm::sea_query::Expr::value(
+                            crate::code::ExecutionLocation::Machine.as_str(),
+                        ),
+                    )
+                    .filter(entities::session::Column::Id.eq(session.0))
+                    .exec(&store.conn)
+                    .await
+                    .unwrap();
+            }
+            _ => unreachable!(),
+        }
+        assert_eq!(
+            settle_sandbox_external_steer_admission(
+                &store,
+                &changed_owner,
+                changed_session,
+                &changed,
+                ExternalSteerAdmission::Steered,
+                None,
+            )
+            .await
+            .unwrap(),
+            (false, None),
+            "{mismatch}"
+        );
+        assert!(
+            matches!(
+                crate::db::code::external_steer_admission(
+                    &store,
+                    &owner,
+                    session,
+                    &target.event_id,
+                )
+                .await
+                .unwrap(),
+                Some(ExternalMessageRecord::Replay {
+                    admission: None,
+                    ..
+                })
+            ),
+            "{mismatch}"
+        );
+        assert_eq!(
+            list_queued_turns(&store, &owner, session)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "{mismatch}"
+        );
+        assert!(
+            list_events(&store, &owner, session, 0, MAX_REPLAY_EVENTS)
+                .await
+                .unwrap()
+                .events
+                .is_empty(),
+            "{mismatch}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sandbox_steer_refusal_and_deleted_input_do_not_create_transcript_text() {
+    use crate::code::{ExternalSteerAdmission, ExternalSteerQueuedReason};
+    use crate::db::code::settle_sandbox_external_steer_admission;
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "sandbox-no-text").await;
+    let refused = pending_sandbox_steer(&store, &owner, session, "EvRefused").await;
+    assert_eq!(
+        settle_sandbox_external_steer_admission(
+            &store,
+            &owner,
+            session,
+            &refused,
+            ExternalSteerAdmission::Queued,
+            Some(ExternalSteerQueuedReason::SteerUnsupported),
+        )
+        .await
+        .unwrap(),
+        (true, None)
+    );
+    assert_eq!(
+        settle_sandbox_external_steer_admission(
+            &store,
+            &owner,
+            session,
+            &refused,
+            ExternalSteerAdmission::Steered,
+            None,
+        )
+        .await
+        .unwrap(),
+        (false, None)
+    );
+    let deleted = pending_sandbox_steer(&store, &owner, session, "EvDeleted").await;
+    assert!(delete_queued_turn(&store, &owner, session, deleted.turn_id)
+        .await
+        .unwrap());
+    assert_eq!(
+        settle_sandbox_external_steer_admission(
+            &store,
+            &owner,
+            session,
+            &deleted,
+            ExternalSteerAdmission::Steered,
+            None,
+        )
+        .await
+        .unwrap(),
+        (true, None)
+    );
+    let queue = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(queue.len(), 1);
+    assert_eq!(queue[0].id, refused.turn_id);
+    assert!(list_events(&store, &owner, session, 0, MAX_REPLAY_EVENTS)
+        .await
+        .unwrap()
+        .events
+        .is_empty());
+}

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -5913,7 +5913,14 @@ async fn a_replayed_external_message_records_once() {
     .unwrap();
     assert_eq!(
         replay,
-        crate::code::ExternalMessageRecord::Replay { turn_id: row.id }
+        crate::code::ExternalMessageRecord::Replay {
+            turn_id: row.id,
+            steer_requested: None,
+            expected_turn_id: None,
+            correlation_uuid: None,
+            admission: None,
+            queued_reason: None,
+        }
     );
     let queued = crate::db::code::list_queued_turns(&store, &owner, session_id)
         .await
@@ -5935,6 +5942,558 @@ async fn a_replayed_external_message_records_once() {
         second,
         crate::code::ExternalMessageRecord::Recorded(_)
     ));
+}
+
+/// A steering queue resolution is durable and replays reproduce the exact
+/// reason, so a retried delivery cannot invent a different outcome.
+#[tokio::test]
+async fn a_settled_steer_admission_replays_with_its_reason() {
+    use crate::code::{ExternalSteerAdmission, ExternalSteerQueuedReason};
+    use crate::db::code::{
+        record_external_message_with_steer, settle_external_steer_admission,
+        ExternalSteerAdmissionInput,
+    };
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session_id = seed_external_session(&store, &owner, "steer-replay").await;
+    let expected = TurnId::new();
+    let correlation = uuid::Uuid::new_v4();
+    let first = record_external_message_with_steer(
+        &store,
+        &owner,
+        session_id,
+        "EvSteer",
+        "1700000001.000100",
+        "redirect",
+        &crate::code::TurnActor::default(),
+        None,
+        ExternalSteerAdmissionInput {
+            request_steer: true,
+            expected_turn_id: Some(expected),
+            correlation_uuid: Some(correlation),
+        },
+    )
+    .await
+    .unwrap();
+    let crate::code::ExternalMessageRecord::Recorded(row) = first else {
+        panic!("first delivery must record");
+    };
+    assert!(settle_external_steer_admission(
+        &store,
+        &owner,
+        session_id,
+        "EvSteer",
+        expected,
+        ExternalSteerAdmission::Queued,
+        Some(ExternalSteerQueuedReason::SteerUnsupported),
+    )
+    .await
+    .unwrap());
+    let replay = record_external_message_with_steer(
+        &store,
+        &owner,
+        session_id,
+        "EvSteer",
+        "1700000001.000100",
+        "redirect",
+        &crate::code::TurnActor::default(),
+        None,
+        ExternalSteerAdmissionInput::default(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        replay,
+        crate::code::ExternalMessageRecord::Replay {
+            turn_id: row.id,
+            steer_requested: Some(true),
+            expected_turn_id: Some(expected),
+            correlation_uuid: Some(correlation),
+            admission: Some(ExternalSteerAdmission::Queued),
+            queued_reason: Some(ExternalSteerQueuedReason::SteerUnsupported),
+        }
+    );
+}
+
+/// A zero-row CAS under a concurrent settle must return true exactly when
+/// the winner wrote the identical resolution, reason included.
+#[tokio::test]
+async fn a_settle_race_validates_the_winner_instead_of_failing_ambiguously() {
+    use crate::code::{ExternalSteerAdmission, ExternalSteerQueuedReason};
+    use crate::db::code::{
+        record_external_message_with_steer, settle_external_steer_admission,
+        ExternalSteerAdmissionInput,
+    };
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session_id = seed_external_session(&store, &owner, "steer-race").await;
+    let expected = TurnId::new();
+    let correlation = uuid::Uuid::new_v4();
+    record_external_message_with_steer(
+        &store,
+        &owner,
+        session_id,
+        "EvRace",
+        "1700000001.000100",
+        "redirect",
+        &crate::code::TurnActor::default(),
+        None,
+        ExternalSteerAdmissionInput {
+            request_steer: true,
+            expected_turn_id: Some(expected),
+            correlation_uuid: Some(correlation),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(settle_external_steer_admission(
+        &store,
+        &owner,
+        session_id,
+        "EvRace",
+        expected,
+        ExternalSteerAdmission::Queued,
+        Some(ExternalSteerQueuedReason::StaleTurn),
+    )
+    .await
+    .unwrap());
+    // Winning row already holds the identical resolution, so the loser's
+    // zero-row CAS is a successful idempotent retry.
+    assert!(settle_external_steer_admission(
+        &store,
+        &owner,
+        session_id,
+        "EvRace",
+        expected,
+        ExternalSteerAdmission::Queued,
+        Some(ExternalSteerQueuedReason::StaleTurn),
+    )
+    .await
+    .unwrap());
+    // A different reason is not the same admission and must not be claimed.
+    assert!(!settle_external_steer_admission(
+        &store,
+        &owner,
+        session_id,
+        "EvRace",
+        expected,
+        ExternalSteerAdmission::Queued,
+        Some(ExternalSteerQueuedReason::Unacknowledged),
+    )
+    .await
+    .unwrap());
+    let replay = crate::db::code::external_steer_admission(&store, &owner, session_id, "EvRace")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        replay,
+        crate::code::ExternalMessageRecord::Replay {
+            admission: Some(ExternalSteerAdmission::Queued),
+            queued_reason: Some(ExternalSteerQueuedReason::StaleTurn),
+            ..
+        }
+    ));
+}
+
+async fn record_pending_steer(
+    store: &crate::db::DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event_id: &str,
+) -> (QueuedTurn, TurnId, uuid::Uuid) {
+    let expected = TurnId::new();
+    let correlation = uuid::Uuid::new_v4();
+    let record = crate::db::code::record_external_message_with_steer(
+        store,
+        owner,
+        session_id,
+        event_id,
+        "1700000001.000100",
+        "redirect",
+        &crate::code::TurnActor::default(),
+        None,
+        crate::db::code::ExternalSteerAdmissionInput {
+            request_steer: true,
+            expected_turn_id: Some(expected),
+            correlation_uuid: Some(correlation),
+        },
+    )
+    .await
+    .unwrap();
+    let crate::code::ExternalMessageRecord::Recorded(row) = record else {
+        panic!("first delivery must record");
+    };
+    (*row, expected, correlation)
+}
+
+#[tokio::test]
+async fn unresolved_steer_owns_its_queue_row_until_explicit_fallback() {
+    use crate::code::{ExternalSteerAdmission, ExternalSteerQueuedReason};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "steer-held").await;
+    let (row, expected, _) = record_pending_steer(&store, &owner, session, "EvHeld").await;
+    let tail = enqueue_queued_turn(&store, &owner, &queued_message(session, "later"))
+        .await
+        .unwrap();
+    assert_eq!(
+        list_queued_turns(&store, &owner, session)
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    assert!(queued_turn_head(&store, &owner, session)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(
+        !promote_queued_turn(&store, &owner, &row, &turn_for(&row, 1))
+            .await
+            .unwrap()
+    );
+    assert!(
+        !crate::db::code::promote_moved_queued_turn(&store, &owner, &row, &turn_for(&row, 1))
+            .await
+            .unwrap()
+    );
+    assert!(
+        update_queued_turn(&store, &owner, session, row.id, Some("different"), None)
+            .await
+            .is_err()
+    );
+    assert!(crate::db::code::settle_external_steer_admission(
+        &store,
+        &owner,
+        session,
+        "EvHeld",
+        expected,
+        ExternalSteerAdmission::Queued,
+        Some(ExternalSteerQueuedReason::SteerUnsupported),
+    )
+    .await
+    .unwrap());
+    let released = queued_turn_head(&store, &owner, session)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(released.id, row.id);
+    assert!(
+        promote_queued_turn(&store, &owner, &released, &turn_for(&released, 1))
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        queued_turn_head(&store, &owner, session)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        tail.id
+    );
+}
+
+#[tokio::test]
+async fn confirmed_steer_consumes_only_its_row_and_keeps_original_replay_metadata() {
+    use crate::code::{ExternalMessageRecord, ExternalSteerAdmission};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "steer-consumed").await;
+    let (row, expected, correlation) = record_pending_steer(&store, &owner, session, "EvAck").await;
+    let tail = enqueue_queued_turn(&store, &owner, &queued_message(session, "later"))
+        .await
+        .unwrap();
+    assert!(!crate::db::code::settle_external_steer_admission(
+        &store,
+        &owner,
+        session,
+        "EvAck",
+        TurnId::new(),
+        ExternalSteerAdmission::Steered,
+        None,
+    )
+    .await
+    .unwrap());
+    for _ in 0..2 {
+        assert!(crate::db::code::settle_external_steer_admission(
+            &store,
+            &owner,
+            session,
+            "EvAck",
+            expected,
+            ExternalSteerAdmission::Steered,
+            None,
+        )
+        .await
+        .unwrap());
+    }
+    let queue = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(queue.len(), 1);
+    assert_eq!(queue[0].id, tail.id);
+    assert!(
+        !promote_queued_turn(&store, &owner, &row, &turn_for(&row, 1))
+            .await
+            .unwrap()
+    );
+    let replay = crate::db::code::record_external_message_with_steer(
+        &store,
+        &owner,
+        session,
+        "EvAck",
+        "changed",
+        "changed",
+        &crate::code::TurnActor::default(),
+        None,
+        crate::db::code::ExternalSteerAdmissionInput {
+            request_steer: false,
+            expected_turn_id: Some(TurnId::new()),
+            correlation_uuid: Some(uuid::Uuid::new_v4()),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        replay,
+        ExternalMessageRecord::Replay {
+            turn_id: row.id,
+            steer_requested: Some(true),
+            expected_turn_id: Some(expected),
+            correlation_uuid: Some(correlation),
+            admission: Some(ExternalSteerAdmission::Steered),
+            queued_reason: None,
+        }
+    );
+}
+
+#[tokio::test]
+async fn steer_correlation_is_unique_per_session_and_scalar_lookup_is_scoped() {
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "steer-correlation").await;
+    let (_, expected, correlation) = record_pending_steer(&store, &owner, session, "EvFirst").await;
+    let duplicate = crate::db::code::record_external_message_with_steer(
+        &store,
+        &owner,
+        session,
+        "EvDifferent",
+        "1700000002.0",
+        "another",
+        &crate::code::TurnActor::default(),
+        None,
+        crate::db::code::ExternalSteerAdmissionInput {
+            request_steer: true,
+            expected_turn_id: Some(expected),
+            correlation_uuid: Some(correlation),
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(
+        duplicate,
+        crate::db::code::ExternalMessageIntakeError::Context {
+            kind: "steer_correlation_conflict",
+            ..
+        }
+    ));
+    assert_eq!(
+        list_queued_turns(&store, &owner, session)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        crate::db::code::external_event_key_by_correlation(&store, &owner, session, correlation)
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("EvFirst")
+    );
+    assert!(crate::db::code::external_event_key_by_correlation(
+        &store,
+        &OwnerId::new("other").unwrap(),
+        session,
+        correlation
+    )
+    .await
+    .unwrap()
+    .is_none());
+    let other = seed_external_session(&store, &owner, "steer-other-session").await;
+    crate::db::code::record_external_message_with_steer(
+        &store,
+        &owner,
+        other,
+        "EvOther",
+        "1700000002.0",
+        "another",
+        &crate::code::TurnActor::default(),
+        None,
+        crate::db::code::ExternalSteerAdmissionInput {
+            request_steer: true,
+            expected_turn_id: Some(expected),
+            correlation_uuid: Some(correlation),
+        },
+    )
+    .await
+    .unwrap();
+    // The database constraint also protects writers that bypass intake.
+    let updated = entities::code_external_event::Entity::update_many()
+        .col_expr(
+            entities::code_external_event::Column::SessionId,
+            sea_orm::sea_query::Expr::value(session.0),
+        )
+        .filter(entities::code_external_event::Column::SessionId.eq(other.0))
+        .exec(&store.conn)
+        .await;
+    assert!(
+        updated.is_err(),
+        "the unique index must reject a second correlation"
+    );
+}
+
+#[tokio::test]
+async fn steer_dispatch_claim_preserves_target_and_cannot_be_repeated() {
+    use crate::db::code::{claim_external_steer_target, external_steer_target_by_correlation};
+    let (dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "steer-target").await;
+    let (row, expected, correlation) =
+        record_pending_steer(&store, &owner, session, "EvTarget").await;
+    assert!(
+        external_steer_target_by_correlation(&store, &owner, session, correlation)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(!claim_external_steer_target(
+        &store,
+        &owner,
+        session,
+        "EvTarget",
+        TurnId::new(),
+        correlation,
+        "sb1",
+        2,
+        uuid::Uuid::new_v4()
+    )
+    .await
+    .unwrap());
+    assert!(claim_external_steer_target(
+        &store,
+        &owner,
+        session,
+        "EvTarget",
+        expected,
+        correlation,
+        "sb1",
+        2,
+        uuid::Uuid::new_v4()
+    )
+    .await
+    .unwrap());
+    assert!(!claim_external_steer_target(
+        &store,
+        &owner,
+        session,
+        "EvTarget",
+        expected,
+        correlation,
+        "sb1",
+        2,
+        uuid::Uuid::new_v4()
+    )
+    .await
+    .unwrap());
+    assert!(!claim_external_steer_target(
+        &store,
+        &owner,
+        session,
+        "EvTarget",
+        expected,
+        correlation,
+        "sb2",
+        3,
+        uuid::Uuid::new_v4()
+    )
+    .await
+    .unwrap());
+    // Reopen the database to prove that dispatch ownership survives a restart.
+    drop(store);
+    let url = format!("sqlite://{}?mode=rwc", dir.path().join("test.db").display());
+    let store = crate::db::DbStore::connect_test_sqlite(&url, 1)
+        .await
+        .unwrap();
+    assert!(!claim_external_steer_target(
+        &store,
+        &owner,
+        session,
+        "EvTarget",
+        expected,
+        correlation,
+        "sb1",
+        2,
+        uuid::Uuid::new_v4()
+    )
+    .await
+    .unwrap());
+    let target = external_steer_target_by_correlation(&store, &owner, session, correlation)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(target.event_id, "EvTarget");
+    assert_eq!(target.turn_id, row.id);
+    assert_eq!(target.expected_turn_id, expected);
+    assert_eq!(target.sandbox_id, "sb1");
+    assert_eq!(target.native_turn, 2);
+    assert!(queued_turn_head(&store, &owner, session)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn concurrent_steer_settlement_has_one_owner_and_matching_queue_state() {
+    use crate::code::{ExternalSteerAdmission, ExternalSteerQueuedReason};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "steer-settlement-race").await;
+    let (row, expected, _) = record_pending_steer(&store, &owner, session, "EvRaceAck").await;
+    let (ack, fallback) = tokio::join!(
+        crate::db::code::settle_external_steer_admission(
+            &store,
+            &owner,
+            session,
+            "EvRaceAck",
+            expected,
+            ExternalSteerAdmission::Steered,
+            None
+        ),
+        crate::db::code::settle_external_steer_admission(
+            &store,
+            &owner,
+            session,
+            "EvRaceAck",
+            expected,
+            ExternalSteerAdmission::Queued,
+            Some(ExternalSteerQueuedReason::StaleTurn)
+        ),
+    );
+    let ack = ack.unwrap();
+    let fallback = fallback.unwrap();
+    assert_ne!(ack, fallback);
+    let queue = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(queue.is_empty(), ack);
+    if fallback {
+        assert_eq!(
+            queued_turn_head(&store, &owner, session)
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            row.id
+        );
+    }
 }
 
 /// Out-of-order deliveries apply in channel order while still queued, and
@@ -6540,7 +7099,14 @@ async fn external_context_is_first_message_only_and_bound_to_its_grant() {
     .unwrap();
     assert_eq!(
         replay,
-        crate::code::ExternalMessageRecord::Replay { turn_id: row.id }
+        crate::code::ExternalMessageRecord::Replay {
+            turn_id: row.id,
+            steer_requested: None,
+            expected_turn_id: None,
+            correlation_uuid: None,
+            admission: None,
+            queued_reason: None,
+        }
     );
     let later = record_external_message_with_context(
         &store,

--- a/crates/tidebreak-harness/src/claude/parse.rs
+++ b/crates/tidebreak-harness/src/claude/parse.rs
@@ -344,6 +344,7 @@ impl ClaudeStreamParser {
                     if parent.is_none() && !text.is_empty() {
                         events.push(HarnessEvent::UserSteered {
                             text: bound(text, MAX_EVENT_TEXT_CHARS),
+                            correlation_uuid: None,
                         });
                     }
                 }

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -128,6 +128,7 @@ enum PendingWriteState {
 struct PendingSteer {
     expected_turn_id: String,
     text: String,
+    correlation_uuid: Option<uuid::Uuid>,
     reply: Option<oneshot::Sender<Result<(), HarnessError>>>,
     deadline: Option<Instant>,
     write_state: PendingWriteState,
@@ -401,7 +402,13 @@ impl CodexSession {
     /// write removes a queued request, while cancellation after that point
     /// leaves the stream reader responsible for the acknowledgement and
     /// `UserSteered` event.
-    async fn request_steer(&self, thread_id: String, text: String) -> Result<(), HarnessError> {
+    #[allow(clippy::too_many_arguments)]
+    async fn request_steer(
+        &self,
+        thread_id: String,
+        text: String,
+        correlation: Option<uuid::Uuid>,
+    ) -> Result<(), HarnessError> {
         let Some(stdin) = self.stdin.lock().expect("codex stdin").clone() else {
             return Err(HarnessError::SteeringRejected(
                 "the engine child has no stdin".into(),
@@ -416,7 +423,10 @@ impl CodexSession {
                     ControlTurn::Active(turn_id) => {
                         let expected_turn_id = turn_id.clone();
                         let rpc_id = self.next_rpc_id();
-                        let client_message_id = format!("tidebreak-steer-{rpc_id}");
+                        let correlation_uuid = correlation;
+                        let client_message_id = correlation_uuid
+                            .map(|uuid| format!("tidebreak-steer-{uuid}"))
+                            .unwrap_or_else(|| format!("tidebreak-steer-{rpc_id}"));
                         let message = steer_request(
                             rpc_id,
                             &thread_id,
@@ -434,6 +444,7 @@ impl CodexSession {
                             PendingSteer {
                                 expected_turn_id,
                                 text: text.clone(),
+                                correlation_uuid,
                                 reply: Some(tx),
                                 deadline: None,
                                 write_state: PendingWriteState::Queued,
@@ -476,9 +487,11 @@ impl CodexSession {
             message,
         );
         let result = rx.await.unwrap_or_else(|_| {
-            Err(HarnessError::SteeringRejected(
-                "the engine dropped the steering response".into(),
-            ))
+            Err(if correlation.is_some() {
+                HarnessError::Other("The engine dropped the steering acknowledgment.".into())
+            } else {
+                HarnessError::SteeringRejected("the engine dropped the steering response".into())
+            })
         });
         registration.disarm();
         result
@@ -493,8 +506,9 @@ impl CodexSession {
         };
         for (id, mut pending) in pending {
             if let Some(reply) = pending.reply.take() {
-                let _ = reply.send(Err(HarnessError::SteeringRejected(
-                    "the prior turn ended before steering was accepted".into(),
+                let _ = reply.send(Err(pending_steer_failure(
+                    &pending,
+                    "the prior turn ended before steering was accepted",
                 )));
             }
             self.parser
@@ -553,16 +567,19 @@ impl CodexSession {
                 .filter_map(|id| state.pending.remove(&id).map(|pending| (id, pending)))
                 .collect::<Vec<_>>();
             for pending in state.pending.values_mut() {
-                pending.accept_response = false;
+                pending.accept_response = pending.correlation_uuid.is_some();
+                pending
+                    .deadline
+                    .get_or_insert_with(|| Instant::now() + CONTROL_RPC_TIMEOUT);
                 if let Some(reply) = pending.reply.take() {
-                    let _ = reply.send(Err(HarnessError::SteeringRejected(detail.into())));
+                    let _ = reply.send(Err(pending_steer_failure(&pending, detail)));
                 }
             }
             (removed, state.interrupt.take())
         };
         for (id, mut pending) in removed {
             if let Some(reply) = pending.reply.take() {
-                let _ = reply.send(Err(HarnessError::SteeringRejected(detail.into())));
+                let _ = reply.send(Err(pending_steer_failure(&pending, detail)));
             }
             self.parser
                 .lock()
@@ -594,7 +611,7 @@ impl CodexSession {
         };
         for (id, mut pending) in pending {
             if let Some(reply) = pending.reply.take() {
-                let _ = reply.send(Err(HarnessError::SteeringRejected(detail.into())));
+                let _ = reply.send(Err(pending_steer_failure(&pending, detail)));
             }
             self.parser
                 .lock()
@@ -625,8 +642,9 @@ impl CodexSession {
 
     fn expire_control_requests(&self) {
         let now = Instant::now();
-        let expired = {
+        let forgotten = {
             let mut state = self.control_state.lock().expect("codex control state");
+            let active = matches!(state.turn, ControlTurn::Active(_) | ControlTurn::Starting);
             let ids = state
                 .pending
                 .iter()
@@ -637,16 +655,30 @@ impl CodexSession {
                         .then_some(*id)
                 })
                 .collect::<Vec<_>>();
-            ids.into_iter()
-                .filter_map(|id| state.pending.remove(&id).map(|pending| (id, pending)))
-                .collect::<Vec<_>>()
-        };
-        for (id, mut pending) in expired {
-            if let Some(reply) = pending.reply.take() {
-                let _ = reply.send(Err(HarnessError::SteeringRejected(
-                    "timed out waiting for the engine to accept steering".into(),
-                )));
+            let mut forgotten = Vec::new();
+            for id in ids {
+                let pending = state.pending.get_mut(&id).expect("pending request exists");
+                if let Some(reply) = pending.reply.take() {
+                    let _ = reply.send(Err(pending_steer_failure(
+                        pending,
+                        "timed out waiting for the engine to accept steering",
+                    )));
+                }
+                if active
+                    && pending.correlation_uuid.is_some()
+                    && pending.write_state != PendingWriteState::Queued
+                {
+                    // Keep the native correlation so a later ACK can settle the durable receipt.
+                    // The terminal boundary installs a bounded drain deadline.
+                    pending.deadline = None;
+                } else {
+                    state.pending.remove(&id);
+                    forgotten.push(id);
+                }
             }
+            forgotten
+        };
+        for id in forgotten {
             self.parser
                 .lock()
                 .expect("codex parser")
@@ -1236,7 +1268,10 @@ impl CodexSession {
                         if pending.accept_response && result.is_ok() {
                             self.spec
                                 .sink
-                                .emit(HarnessEvent::UserSteered { text: pending.text })
+                                .emit(HarnessEvent::UserSteered {
+                                    text: pending.text,
+                                    correlation_uuid: pending.correlation_uuid,
+                                })
                                 .await;
                         }
                         if let Some(reply) = pending.reply.take() {
@@ -1404,12 +1439,20 @@ impl HarnessSession for CodexSession {
     }
 
     async fn steer(&self, text: String) -> Result<(), HarnessError> {
+        self.steer_with_correlation(text, None).await
+    }
+
+    async fn steer_with_correlation(
+        &self,
+        text: String,
+        correlation_uuid: Option<uuid::Uuid>,
+    ) -> Result<(), HarnessError> {
         let Some(thread_id) = self.resume_ref.lock().expect("codex resume").clone() else {
             return Err(HarnessError::SteeringRejected(
                 "the engine session has no thread id".into(),
             ));
         };
-        self.request_steer(thread_id, text).await
+        self.request_steer(thread_id, text, correlation_uuid).await
     }
 
     async fn decide(
@@ -1596,12 +1639,10 @@ fn validate_steer_response(value: &Value, expected_turn_id: &str) -> Result<(), 
         .pointer("/result/turnId")
         .and_then(Value::as_str)
         .ok_or_else(|| {
-            HarnessError::SteeringRejected(
-                "the engine returned no turn id for the steering request".into(),
-            )
+            HarnessError::Other("the engine returned no turn id for the steering request".into())
         })?;
     if accepted_turn_id != expected_turn_id {
-        return Err(HarnessError::SteeringRejected(format!(
+        return Err(HarnessError::Other(format!(
             "the engine acknowledged turn {accepted_turn_id}, not active turn {expected_turn_id}"
         )));
     }
@@ -1721,7 +1762,7 @@ fn fail_control_write(
         .remove(&rpc_id);
     if let Some(mut pending) = pending {
         if let Some(reply) = pending.reply.take() {
-            let _ = reply.send(Err(HarnessError::SteeringRejected(detail)));
+            let _ = reply.send(Err(pending_steer_failure(&pending, &detail)));
         }
     }
     parser
@@ -1753,3 +1794,12 @@ where
 
 #[cfg(test)]
 mod tests;
+
+// A completed write with a lost acknowledgment does not prove native rejection.
+fn pending_steer_failure(pending: &PendingSteer, detail: &str) -> HarnessError {
+    if pending.correlation_uuid.is_some() && pending.write_state != PendingWriteState::Queued {
+        HarnessError::Other(detail.into())
+    } else {
+        HarnessError::SteeringRejected(detail.into())
+    }
+}

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -572,7 +572,7 @@ impl CodexSession {
                     .deadline
                     .get_or_insert_with(|| Instant::now() + CONTROL_RPC_TIMEOUT);
                 if let Some(reply) = pending.reply.take() {
-                    let _ = reply.send(Err(pending_steer_failure(&pending, detail)));
+                    let _ = reply.send(Err(pending_steer_failure(pending, detail)));
                 }
             }
             (removed, state.interrupt.take())

--- a/crates/tidebreak-harness/src/codex/session/tests.rs
+++ b/crates/tidebreak-harness/src/codex/session/tests.rs
@@ -591,6 +591,7 @@ fn register_pending(
         PendingSteer {
             expected_turn_id: "TURN-1".into(),
             text: "redirect".into(),
+            correlation_uuid: None,
             reply: Some(reply),
             deadline,
             write_state,
@@ -1083,7 +1084,7 @@ fn steer_response_must_acknowledge_the_expected_turn() {
     validate_steer_response(&json!({ "result": { "turnId": "TURN-1" } }), "TURN-1").unwrap();
     let mismatch = validate_steer_response(&json!({ "result": { "turnId": "TURN-2" } }), "TURN-1")
         .unwrap_err();
-    assert!(matches!(mismatch, HarnessError::SteeringRejected(_)));
+    assert!(matches!(mismatch, HarnessError::Other(_)));
     let rejected = validate_steer_response(
         &json!({ "error": { "message": "turn is no longer steerable" } }),
         "TURN-1",
@@ -1332,10 +1333,15 @@ async fn rejected_or_mismatched_ack_never_emits_user_steered() {
             Some(Instant::now() + CONTROL_RPC_TIMEOUT),
         );
         session.emit_parsed(&response.to_string()).await;
-        assert!(matches!(
-            receiver.await.unwrap(),
-            Err(HarnessError::SteeringRejected(_))
-        ));
+        let error = receiver.await.unwrap().unwrap_err();
+        if response.get("error").is_some() {
+            assert!(matches!(error, HarnessError::SteeringRejected(_)));
+        } else {
+            assert!(
+                matches!(error, HarnessError::Other(_)),
+                "a mismatched ACK does not prove rejection"
+            );
+        }
         assert!(!sink
             .events
             .lock()
@@ -1424,7 +1430,7 @@ async fn native_steer_uses_the_active_turn_id_and_waits_for_ack() {
         .expect("codex test events")
         .iter()
         .filter_map(|event| match event {
-            HarnessEvent::UserSteered { text } => Some(text.clone()),
+            HarnessEvent::UserSteered { text, .. } => Some(text.clone()),
             _ => None,
         })
         .collect();
@@ -2081,4 +2087,110 @@ fn apps_channel_mounts_an_http_server_with_the_bearer_in_the_environment() {
         "the adapter's token is the only source; settings cannot supply one"
     );
     validate_launch_plan(&plan).unwrap();
+}
+
+#[tokio::test]
+async fn correlated_steer_write_failure_only_releases_before_writing() {
+    for write_state in [
+        PendingWriteState::Queued,
+        PendingWriteState::Writing,
+        PendingWriteState::Written,
+    ] {
+        let session = unit_session(Arc::new(RecordingSink::default()));
+        let receiver = register_pending(&session, 7, write_state, None);
+        session
+            .control_state
+            .lock()
+            .unwrap()
+            .pending
+            .get_mut(&7)
+            .unwrap()
+            .correlation_uuid = Some(uuid::Uuid::new_v4());
+        fail_control_write(
+            &session.control_state,
+            &session.control_state_changed,
+            &session.parser,
+            7,
+            "write failed".into(),
+        );
+        let error = receiver.await.unwrap().unwrap_err();
+        if write_state == PendingWriteState::Queued {
+            assert!(matches!(error, HarnessError::SteeringRejected(_)));
+        } else {
+            assert!(
+                matches!(error, HarnessError::Other(_)),
+                "possible delivery must not release fallback: {error:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn correlated_steer_late_ack_survives_timeout() {
+    let sink = Arc::new(RecordingSink::default());
+    let session = unit_session(sink.clone());
+    let correlation = uuid::Uuid::new_v4();
+    let receiver = register_pending(
+        &session,
+        7,
+        PendingWriteState::Written,
+        Some(Instant::now()),
+    );
+    session
+        .control_state
+        .lock()
+        .unwrap()
+        .pending
+        .get_mut(&7)
+        .unwrap()
+        .correlation_uuid = Some(correlation);
+    session.expire_control_requests();
+    assert!(matches!(
+        receiver.await.unwrap(),
+        Err(HarnessError::Other(_))
+    ));
+    assert!(session
+        .control_state
+        .lock()
+        .unwrap()
+        .pending
+        .contains_key(&7));
+    session
+        .emit_parsed(r#"{"id":7,"result":{"turnId":"TURN-1"}}"#)
+        .await;
+    assert!(sink.events.lock().unwrap().iter().any(|event| matches!(event, HarnessEvent::UserSteered { correlation_uuid: Some(id), .. } if *id == correlation)));
+    assert!(session.control_state.lock().unwrap().pending.is_empty());
+}
+
+#[tokio::test]
+async fn correlated_steer_timeout_does_not_hold_terminal_drain_forever() {
+    let session = unit_session(Arc::new(RecordingSink::default()));
+    let receiver = register_pending(
+        &session,
+        7,
+        PendingWriteState::Written,
+        Some(Instant::now()),
+    );
+    session
+        .control_state
+        .lock()
+        .unwrap()
+        .pending
+        .get_mut(&7)
+        .unwrap()
+        .correlation_uuid = Some(uuid::Uuid::new_v4());
+    session.expire_control_requests();
+    assert!(matches!(
+        receiver.await.unwrap(),
+        Err(HarnessError::Other(_))
+    ));
+    session.close_control_turn_for_terminal("completed", false);
+    {
+        let mut state = session.control_state.lock().unwrap();
+        let pending = state.pending.get_mut(&7).unwrap();
+        assert!(pending.deadline.is_some());
+        pending.deadline = Some(Instant::now());
+    }
+    session.expire_control_requests();
+    assert!(!session.controls_pending());
 }

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -250,6 +250,10 @@ pub enum HarnessEvent {
     UserSteered {
         /// The steered text.
         text: String,
+        /// Optional caller correlation id, echoed from the admission so the
+        /// server can reconcile the durable queue row without resending text.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        correlation_uuid: Option<uuid::Uuid>,
     },
     /// The turn finished successfully.
     TurnCompleted {
@@ -1069,6 +1073,18 @@ pub trait HarnessSession: Send + Sync {
     async fn steer(&self, text: String) -> Result<(), HarnessError> {
         let _ = text;
         Err(HarnessError::SteeringUnsupported)
+    }
+
+    /// Require an adapter to acknowledge correlated steering explicitly.
+    async fn steer_with_correlation(
+        &self,
+        text: String,
+        correlation_uuid: Option<uuid::Uuid>,
+    ) -> Result<(), HarnessError> {
+        if correlation_uuid.is_some() {
+            return Err(HarnessError::SteeringUnsupported);
+        }
+        self.steer(text).await
     }
 
     /// Engine-native resume token, when the stream has reported one.

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -517,6 +517,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::external_messages),
         )
         .route(
+            "/external/code/sessions/{id}/messages/{event_id}/admission",
+            get(routes::code::external_steer_receipt),
+        )
+        .route(
             "/external/code/sessions/{id}/conversation-requests",
             get(routes::code::external_conversation_requests),
         )

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -572,7 +572,7 @@ pub async fn external_get_or_create(
         | ExternalSessionResolution::Existing(binding) => binding.session_id,
         ExternalSessionResolution::Ended { session_id } => *session_id,
         ExternalSessionResolution::GrantMismatch => {
-            return Err(ServerError::not_found("code session not found"))
+            return Err(ServerError::not_found("code session not found"));
         }
     };
     let actual = runtime
@@ -732,6 +732,17 @@ pub struct ExternalMessageBody {
     /// The binding whose channel opted in.
     #[serde(default)]
     pub context_binding_id: Option<tidebreak_core::CodeBindingId>,
+    /// Ask to steer into the active native turn. Old clients omit it and
+    /// keep the queue-default contract.
+    #[serde(default)]
+    pub steer: bool,
+    /// The native turn the instruction targets; required when steering.
+    #[serde(default)]
+    pub expected_turn_id: Option<tidebreak_core::TurnId>,
+    /// Caller correlation id; echoed in the admission response and carried
+    /// through the supervised sandbox.
+    #[serde(default)]
+    pub correlation_uuid: Option<uuid::Uuid>,
 }
 
 #[derive(serde::Deserialize)]
@@ -743,12 +754,28 @@ pub struct ExternalActor {
 
 #[derive(serde::Serialize)]
 pub struct ExternalMessageResponse {
-    /// `new_turn`, `queued`, or `dropped`.
+    /// `new_turn`, `queued`, `dropped`, or `steered`.
     pub outcome: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub turn_id: Option<tidebreak_core::TurnId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub queued: Option<QueuedTurn>,
+    /// Present exactly when the engine acknowledged steering.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub steered: Option<SteeredAdmission>,
+    /// Machine-readable reason when a queued answer is the honest substitute
+    /// for a steering the machine could not prove.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<&'static str>,
+}
+
+/// One acknowledged steering admission.
+#[derive(serde::Serialize)]
+pub struct SteeredAdmission {
+    /// The native turn that acknowledged the instruction.
+    pub expected_turn_id: tidebreak_core::TurnId,
+    /// Caller correlation id, echoed verbatim.
+    pub correlation_uuid: Option<uuid::Uuid>,
 }
 
 /// `POST /external/code/sessions/{id}/messages` — deliver one message.
@@ -818,6 +845,9 @@ pub async fn external_messages(
                     channel_kind: Some(grant.channel_kind.clone()),
                     external_identity,
                 },
+                steer: body.steer,
+                expected_turn_id: body.expected_turn_id,
+                correlation_uuid: body.correlation_uuid,
             },
         )
         .await?;
@@ -826,19 +856,101 @@ pub async fn external_messages(
             outcome: "new_turn",
             turn_id: Some(turn.id),
             queued: None,
+            steered: None,
+            reason: None,
         },
         ExternalMessageOutcome::Queued(row) => ExternalMessageResponse {
             outcome: "queued",
             turn_id: Some(row.id),
             queued: Some(QueuedTurn::from(*row)),
+            steered: None,
+            // Routine queue-default delivery stays quiet in the channel;
+            // this reason is protocol state, not a client message.
+            reason: None,
+        },
+        ExternalMessageOutcome::SteerQueued { turn_id, reason } => ExternalMessageResponse {
+            outcome: "queued",
+            turn_id: Some(turn_id),
+            queued: None,
+            steered: None,
+            reason: Some(reason.as_str()),
+        },
+        ExternalMessageOutcome::Steered {
+            turn_id,
+            expected_turn_id,
+            correlation_uuid,
+        } => ExternalMessageResponse {
+            outcome: "steered",
+            turn_id: Some(turn_id),
+            queued: None,
+            steered: Some(SteeredAdmission {
+                expected_turn_id,
+                correlation_uuid,
+            }),
+            reason: None,
         },
         ExternalMessageOutcome::Dropped => ExternalMessageResponse {
             outcome: "dropped",
             turn_id: None,
             queued: None,
+            steered: None,
+            reason: None,
         },
     };
     Ok(Json(response))
+}
+
+/// The durable result of one external steering request.
+#[derive(serde::Serialize)]
+pub struct ExternalSteerReceiptResponse {
+    pub outcome: &'static str,
+    pub turn_id: tidebreak_core::TurnId,
+    pub expected_turn_id: tidebreak_core::TurnId,
+    pub correlation_uuid: Option<uuid::Uuid>,
+    pub reason: Option<&'static str>,
+}
+
+/// Read admission without submitting another message or contacting the harness.
+pub async fn external_steer_receipt(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path((id, event_id)): Path<(SessionId, String)>,
+) -> Result<Json<ExternalSteerReceiptResponse>, ServerError> {
+    use tidebreak_core::code::ExternalSteerAdmission;
+    let runtime = require_bound(&state, &grant, id).await?;
+    let receipt = tidebreak_core::db::code::external_steer_admission(
+        &runtime.db,
+        &grant.owner,
+        id,
+        &event_id,
+    )
+    .await?;
+    let Some(tidebreak_core::ExternalMessageRecord::Replay {
+        turn_id,
+        steer_requested: Some(true),
+        expected_turn_id: Some(expected_turn_id),
+        correlation_uuid,
+        admission,
+        queued_reason,
+        ..
+    }) = receipt
+    else {
+        return Err(ServerError::not_found("steering admission not found"));
+    };
+    let (outcome, reason) = match admission {
+        Some(ExternalSteerAdmission::Steered) => ("steered", None),
+        Some(ExternalSteerAdmission::Queued) => {
+            ("queued", queued_reason.map(|reason| reason.as_str()))
+        }
+        None => ("pending", Some("unacknowledged")),
+    };
+    Ok(Json(ExternalSteerReceiptResponse {
+        outcome,
+        turn_id,
+        expected_turn_id,
+        correlation_uuid,
+        reason,
+    }))
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -68,7 +68,7 @@ pub(crate) use external::{
     external_approval, external_approval_decision, external_attach_binding, external_bindings,
     external_events, external_get_or_create, external_interrupt, external_messages,
     external_plan_decision, external_question_decision, external_reap, external_rotate,
-    external_session_access,
+    external_session_access, external_steer_receipt,
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -4976,3 +4976,120 @@ async fn repositoryless_slack_refuses_invalid_sandbox_defaults_without_machine_f
         assert!(fake.spawns.lock().unwrap().is_empty());
     }
 }
+
+#[tokio::test]
+async fn steering_receipt_reads_are_scoped_and_never_resend() {
+    let (router, fake, runtime, repo_id, _dir) = external_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let (_, foreign) = runtime
+        .mint_adapter_grant(&owner, "slack", "U2", "T1")
+        .await
+        .unwrap();
+    client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({"external_key":"T1/C1/receipt", "repo_id":repo_id}))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    let session_id = bound_session_id(&runtime, &owner, "T1/C1/receipt").await;
+    let target = tidebreak_core::TurnId::new();
+    let correlation = uuid::Uuid::new_v4();
+    tidebreak_core::db::code::record_external_message_with_steer(
+        &runtime.db,
+        &owner,
+        session_id,
+        "Ev-receipt",
+        "1.1",
+        "follow up",
+        &Default::default(),
+        None,
+        tidebreak_core::db::code::ExternalSteerAdmissionInput {
+            request_steer: true,
+            expected_turn_id: Some(target),
+            correlation_uuid: Some(correlation),
+        },
+    )
+    .await
+    .unwrap();
+    let url =
+        format!("http://{addr}/external/code/sessions/{session_id}/messages/Ev-receipt/admission");
+    assert_eq!(
+        client.get(&url).send().await.unwrap().status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(
+        client
+            .get(&url)
+            .bearer_auth(&foreign.token)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    let pending: serde_json::Value = client
+        .get(&url)
+        .bearer_auth(&pair.token)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(pending["outcome"], "pending");
+    assert_eq!(pending["expected_turn_id"], target.to_string());
+    assert_eq!(pending["correlation_uuid"], correlation.to_string());
+    assert_eq!(pending["reason"], "unacknowledged");
+    assert!(tidebreak_core::db::code::settle_external_steer_admission(
+        &runtime.db,
+        &owner,
+        session_id,
+        "Ev-receipt",
+        target,
+        tidebreak_core::code::ExternalSteerAdmission::Steered,
+        None
+    )
+    .await
+    .unwrap());
+    let settled: serde_json::Value = client
+        .get(&url)
+        .bearer_auth(&pair.token)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(settled["outcome"], "steered");
+    assert_eq!(settled["turn_id"], pending["turn_id"]);
+    assert!(settled["reason"].is_null());
+    assert!(fake.spawns.lock().unwrap().is_empty());
+    assert!(fake.sends.lock().unwrap().is_empty());
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "test revocation")
+        .await
+        .unwrap();
+    assert_eq!(
+        client
+            .get(&url)
+            .bearer_auth(&pair.token)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+}

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1838,10 +1838,12 @@ mod tests {
     #[tokio::test]
     async fn external_steering_rejects_missing_target_and_replays_original_receipt() {
         use tidebreak_core::code::ExternalSteerQueuedReason;
-        for (harness, compatible) in [
-            (HarnessKind::ClaudeCode, false),
-            (HarnessKind::Codex, false),
-            (HarnessKind::Codex, true),
+        for (harness, compatible, stale, oversized_frame) in [
+            (HarnessKind::ClaudeCode, false, false, false),
+            (HarnessKind::Codex, false, false, false),
+            (HarnessKind::Codex, true, false, false),
+            (HarnessKind::Codex, true, true, false),
+            (HarnessKind::Codex, true, false, true),
         ] {
             let dir = tempfile::tempdir().unwrap();
             let mut spawn_settings = settings();
@@ -1875,7 +1877,12 @@ mod tests {
             };
             let make_message =
                 |event: &str, steer, target, correlation| crate::code::runtime::ExternalMessage {
-                    text: "Read the thread.".into(),
+                    // Escaping exceeds the frame limit while the original text still fits.
+                    text: if oversized_frame && event == "steer" {
+                        "\"".repeat(20 * 1024)
+                    } else {
+                        "Read the thread.".into()
+                    },
                     event_id: event.into(),
                     channel_ts: "1.0".into(),
                     actor: tidebreak_core::TurnActor::default(),
@@ -1931,16 +1938,23 @@ mod tests {
                     .unwrap();
             }
             let correlation = uuid::Uuid::new_v4();
+            let expected_turn = if stale {
+                tidebreak_core::TurnId::new()
+            } else {
+                active.id
+            };
             let first_steer = runtime
                 .external_submit_message(
                     &owner,
                     grant.id,
                     binding.session_id,
-                    make_message("steer", true, Some(active.id), Some(correlation)),
+                    make_message("steer", true, Some(expected_turn), Some(correlation)),
                 )
                 .await
                 .unwrap();
-            let expected_reason = if compatible {
+            let expected_reason = if stale || oversized_frame {
+                ExternalSteerQueuedReason::StaleTurn
+            } else if compatible {
                 ExternalSteerQueuedReason::Unacknowledged
             } else {
                 ExternalSteerQueuedReason::SteerUnsupported
@@ -1950,7 +1964,29 @@ mod tests {
             };
             assert_eq!(reason, expected_reason);
             let sends = fake.sends.lock().unwrap().len();
-            assert_eq!(sends, usize::from(compatible));
+            assert_eq!(sends, usize::from(compatible && !stale && !oversized_frame));
+            let tail = runtime
+                .external_submit_message(
+                    &owner,
+                    grant.id,
+                    binding.session_id,
+                    make_message("later", false, None, None),
+                )
+                .await
+                .unwrap();
+            let ExternalMessageOutcome::Queued(tail) = tail else {
+                panic!("expected later message to queue: {tail:?}");
+            };
+            let rows = tidebreak_core::db::code::list_queued_turns(
+                &runtime.db,
+                &owner,
+                binding.session_id,
+            )
+            .await
+            .unwrap();
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].id, turn_id);
+            assert_eq!(rows[1].id, tail.id);
             let replay = runtime
                 .external_submit_message(
                     &owner,
@@ -1973,7 +2009,7 @@ mod tests {
                 sends,
                 "a replay must not dispatch again"
             );
-            if compatible {
+            if compatible && !stale && !oversized_frame {
                 let target = tidebreak_core::db::code::external_steer_target_by_correlation(
                     &runtime.db,
                     &owner,
@@ -1996,15 +2032,28 @@ mod tests {
                     "unknown delivery holds the queue"
                 );
             } else {
+                assert_eq!(
+                    tidebreak_core::db::code::queued_turn_head(
+                        &runtime.db,
+                        &owner,
+                        binding.session_id
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .id,
+                    turn_id,
+                    "proven fallback releases the original head before the later message"
+                );
                 // Once fallback promotes, its original admission receipt still replays.
                 fake.event_reads.lock().unwrap().push_back(SandboxEvents {
                     sandbox_id: "sb-1".into(),
                     state: SandboxState::Running,
-                    latest_event_seq: 2,
+                    latest_event_seq: 3,
                     events: vec![
-                        event(1, "turn_started", serde_json::json!({"turn":1})),
+                        event(2, "turn_started", serde_json::json!({"turn":1})),
                         event(
-                            2,
+                            3,
                             "turn_completed",
                             serde_json::json!({"turn":1,"exit_code":0}),
                         ),
@@ -2021,14 +2070,27 @@ mod tests {
                     .await
                     .unwrap();
                 runtime.promote_remote_queue_heads().await.unwrap();
-                assert!(tidebreak_core::db::code::list_queued_turns(
+                assert_eq!(
+                    tidebreak_core::db::code::get_open_turn(
+                        &runtime.db,
+                        &owner,
+                        binding.session_id,
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .id,
+                    turn_id
+                );
+                let remaining = tidebreak_core::db::code::list_queued_turns(
                     &runtime.db,
                     &owner,
-                    binding.session_id
+                    binding.session_id,
                 )
                 .await
-                .unwrap()
-                .is_empty());
+                .unwrap();
+                assert_eq!(remaining.len(), 1);
+                assert_eq!(remaining[0].id, tail.id);
                 let replay = runtime
                     .external_submit_message(
                         &owner,
@@ -2039,7 +2101,42 @@ mod tests {
                     .await
                     .unwrap();
                 assert!(
-                    matches!(replay, ExternalMessageOutcome::SteerQueued { turn_id: replayed, reason: ExternalSteerQueuedReason::SteerUnsupported } if replayed == turn_id)
+                    matches!(replay, ExternalMessageOutcome::SteerQueued { turn_id: replayed, reason } if replayed == turn_id && reason == expected_reason)
+                );
+                fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                    sandbox_id: "sb-1".into(),
+                    state: SandboxState::Running,
+                    latest_event_seq: 5,
+                    events: vec![
+                        event(4, "turn_started", serde_json::json!({"turn":2})),
+                        event(
+                            5,
+                            "turn_completed",
+                            serde_json::json!({"turn":2,"exit_code":0}),
+                        ),
+                    ],
+                });
+                session = runtime
+                    .get_session(&owner, binding.session_id)
+                    .await
+                    .unwrap();
+                remote
+                    .driver(&runtime.db, runtime.bus.as_ref())
+                    .pump(&mut session, 0)
+                    .await
+                    .unwrap();
+                runtime.promote_remote_queue_heads().await.unwrap();
+                assert_eq!(
+                    tidebreak_core::db::code::get_open_turn(
+                        &runtime.db,
+                        &owner,
+                        binding.session_id,
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .id,
+                    tail.id
                 );
             }
         }

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1798,6 +1798,9 @@ mod tests {
             channel_ts: "1700000001.000100".into(),
             actor: tidebreak_core::TurnActor::default(),
             context: None,
+            steer: false,
+            expected_turn_id: None,
+            correlation_uuid: None,
         };
         let first = runtime
             .external_submit_message(&owner, grant.id, binding.session_id, message())
@@ -1830,6 +1833,216 @@ mod tests {
         };
         assert_eq!(turn.id, replayed.id);
         assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn external_steering_rejects_missing_target_and_replays_original_receipt() {
+        use tidebreak_core::code::ExternalSteerQueuedReason;
+        for (harness, compatible) in [
+            (HarnessKind::ClaudeCode, false),
+            (HarnessKind::Codex, false),
+            (HarnessKind::Codex, true),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let mut spawn_settings = settings();
+            spawn_settings.engine = Some(harness);
+            spawn_settings.engines = Some(vec![harness]);
+            spawn_settings.embedded_engine_registration = true;
+            let (runtime, fake, owner, _) =
+                runtime_with_remote_settings(dir.path(), spawn_settings).await;
+            let (grant, _) = runtime
+                .mint_adapter_grant(&owner, "slack", "U1", "T1")
+                .await
+                .unwrap();
+            let (resolution, _) = runtime
+                .external_get_or_create(
+                    &owner,
+                    None,
+                    grant.id,
+                    "slack",
+                    "T1/C1/steer",
+                    None,
+                    None,
+                    harness,
+                    session_settings(),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
+                panic!("expected creation");
+            };
+            let make_message =
+                |event: &str, steer, target, correlation| crate::code::runtime::ExternalMessage {
+                    text: "Read the thread.".into(),
+                    event_id: event.into(),
+                    channel_ts: "1.0".into(),
+                    actor: tidebreak_core::TurnActor::default(),
+                    context: None,
+                    steer,
+                    expected_turn_id: target,
+                    correlation_uuid: correlation,
+                };
+            let invalid = runtime
+                .external_submit_message(
+                    &owner,
+                    grant.id,
+                    binding.session_id,
+                    make_message("invalid", true, None, None),
+                )
+                .await;
+            assert!(invalid.is_err());
+            assert!(tidebreak_core::db::code::list_queued_turns(
+                &runtime.db,
+                &owner,
+                binding.session_id
+            )
+            .await
+            .unwrap()
+            .is_empty());
+            assert!(fake.spawns.lock().unwrap().is_empty());
+            let first = runtime
+                .external_submit_message(
+                    &owner,
+                    grant.id,
+                    binding.session_id,
+                    make_message("first", false, None, None),
+                )
+                .await
+                .unwrap();
+            let ExternalMessageOutcome::NewTurn(active) = first else {
+                panic!("expected active turn: {first:?}");
+            };
+            if compatible {
+                fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                    sandbox_id: "sb-1".into(), state: SandboxState::Running, latest_event_seq: 1,
+                    events: vec![event(1, "supervisor_started", serde_json::json!({"agent":"tidebreak-supervised-agent", "steering_protocol":1,"runtime_id":uuid::Uuid::new_v4().to_string()}))],
+                });
+                let remote = runtime.remote_sessions().unwrap();
+                let mut session = runtime
+                    .get_session(&owner, binding.session_id)
+                    .await
+                    .unwrap();
+                remote
+                    .driver(&runtime.db, runtime.bus.as_ref())
+                    .pump(&mut session, 0)
+                    .await
+                    .unwrap();
+            }
+            let correlation = uuid::Uuid::new_v4();
+            let first_steer = runtime
+                .external_submit_message(
+                    &owner,
+                    grant.id,
+                    binding.session_id,
+                    make_message("steer", true, Some(active.id), Some(correlation)),
+                )
+                .await
+                .unwrap();
+            let expected_reason = if compatible {
+                ExternalSteerQueuedReason::Unacknowledged
+            } else {
+                ExternalSteerQueuedReason::SteerUnsupported
+            };
+            let ExternalMessageOutcome::SteerQueued { turn_id, reason } = first_steer else {
+                panic!("expected queued receipt: {first_steer:?}");
+            };
+            assert_eq!(reason, expected_reason);
+            let sends = fake.sends.lock().unwrap().len();
+            assert_eq!(sends, usize::from(compatible));
+            let replay = runtime
+                .external_submit_message(
+                    &owner,
+                    grant.id,
+                    binding.session_id,
+                    make_message(
+                        "steer",
+                        true,
+                        Some(tidebreak_core::TurnId::new()),
+                        Some(uuid::Uuid::new_v4()),
+                    ),
+                )
+                .await
+                .unwrap();
+            assert!(
+                matches!(replay, ExternalMessageOutcome::SteerQueued { turn_id: replayed, reason } if replayed == turn_id && reason == expected_reason)
+            );
+            assert_eq!(
+                fake.sends.lock().unwrap().len(),
+                sends,
+                "a replay must not dispatch again"
+            );
+            if compatible {
+                let target = tidebreak_core::db::code::external_steer_target_by_correlation(
+                    &runtime.db,
+                    &owner,
+                    binding.session_id,
+                    correlation,
+                )
+                .await
+                .unwrap()
+                .unwrap();
+                assert_eq!(target.expected_turn_id, active.id);
+                assert!(
+                    tidebreak_core::db::code::queued_turn_head(
+                        &runtime.db,
+                        &owner,
+                        binding.session_id
+                    )
+                    .await
+                    .unwrap()
+                    .is_none(),
+                    "unknown delivery holds the queue"
+                );
+            } else {
+                // Once fallback promotes, its original admission receipt still replays.
+                fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                    sandbox_id: "sb-1".into(),
+                    state: SandboxState::Running,
+                    latest_event_seq: 2,
+                    events: vec![
+                        event(1, "turn_started", serde_json::json!({"turn":1})),
+                        event(
+                            2,
+                            "turn_completed",
+                            serde_json::json!({"turn":1,"exit_code":0}),
+                        ),
+                    ],
+                });
+                let remote = runtime.remote_sessions().unwrap();
+                let mut session = runtime
+                    .get_session(&owner, binding.session_id)
+                    .await
+                    .unwrap();
+                remote
+                    .driver(&runtime.db, runtime.bus.as_ref())
+                    .pump(&mut session, 0)
+                    .await
+                    .unwrap();
+                runtime.promote_remote_queue_heads().await.unwrap();
+                assert!(tidebreak_core::db::code::list_queued_turns(
+                    &runtime.db,
+                    &owner,
+                    binding.session_id
+                )
+                .await
+                .unwrap()
+                .is_empty());
+                let replay = runtime
+                    .external_submit_message(
+                        &owner,
+                        grant.id,
+                        binding.session_id,
+                        make_message("steer", true, Some(active.id), Some(correlation)),
+                    )
+                    .await
+                    .unwrap();
+                assert!(
+                    matches!(replay, ExternalMessageOutcome::SteerQueued { turn_id: replayed, reason: ExternalSteerQueuedReason::SteerUnsupported } if replayed == turn_id)
+                );
+            }
+        }
     }
 
     #[tokio::test]
@@ -1886,6 +2099,9 @@ mod tests {
                 channel_ts: "1.0".into(),
                 actor: tidebreak_core::TurnActor::default(),
                 context: None,
+                steer: false,
+                expected_turn_id: None,
+                correlation_uuid: None,
             };
             let first = runtime
                 .external_submit_message(&owner, grant, binding.session_id, message("Ev1"))
@@ -2047,6 +2263,9 @@ mod tests {
                 channel_ts: "1.0".into(),
                 actor: tidebreak_core::TurnActor::default(),
                 context: None,
+                steer: false,
+                expected_turn_id: None,
+                correlation_uuid: None,
             };
             let lock = remote.promotion_lock(binding.session_id);
             let guard = lock.lock().await;
@@ -2177,6 +2396,9 @@ mod tests {
                     event_id: "Ev1".to_owned(),
                     channel_ts: "1700000001.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await
@@ -2204,6 +2426,9 @@ mod tests {
                     event_id: "Ev1".to_owned(),
                     channel_ts: "1700000001.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await
@@ -2227,6 +2452,9 @@ mod tests {
                     event_id: "Ev2".to_owned(),
                     channel_ts: "1700000002.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await
@@ -2245,6 +2473,9 @@ mod tests {
                     event_id: "Ev2".to_owned(),
                     channel_ts: "1700000002.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await
@@ -2268,6 +2499,9 @@ mod tests {
                     event_id: "Ev3".to_owned(),
                     channel_ts: "1700000003.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await;
@@ -2290,6 +2524,9 @@ mod tests {
                     event_id: "Ev4".to_owned(),
                     channel_ts: "1700000004.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await;
@@ -2340,6 +2577,9 @@ mod tests {
                     event_id: "Ev0".to_owned(),
                     channel_ts: "1700000000.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await
@@ -2355,6 +2595,9 @@ mod tests {
                     event_id: "EvB".to_owned(),
                     channel_ts: "1700000002.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await
@@ -2382,6 +2625,9 @@ mod tests {
                     event_id: "EvA".to_owned(),
                     channel_ts: "1700000001.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await
@@ -2457,6 +2703,9 @@ mod tests {
                     event_id: "EvB".to_owned(),
                     channel_ts: "1700000002.000100".to_owned(),
                     actor: tidebreak_core::TurnActor::default(),
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -76,7 +76,8 @@ use super::native_runtime::{NativeRuntime, NativeRuntimeScope};
 use super::recovery::{self, RecoveryAction};
 use super::session_worker::{
     attach_engine, spawn_session_worker, wake_queue, AttachmentStore, ExecutionSettingsSettlement,
-    PermissionModeSettlement, TriggerDeliveryClaim, WorkerCommand, WorkerError, WorkerHandle,
+    PermissionModeSettlement, SteerAdmission, TriggerDeliveryClaim, WorkerCommand, WorkerError,
+    WorkerHandle,
 };
 #[cfg(windows)]
 use super::worktree::repo_paths_equivalent;
@@ -151,6 +152,14 @@ pub struct ExternalMessage {
     pub actor: TurnActor,
     /// Bounded prior thread messages; accepted only with channel opt-in.
     pub context: Option<tidebreak_core::code::ExternalThreadContext>,
+    /// Whether this delivery asked to steer into the active native turn.
+    /// Old clients omit it and keep the queue-default contract.
+    pub steer: bool,
+    /// The native turn the instruction targets; required when `steer` is true.
+    pub expected_turn_id: Option<TurnId>,
+    /// Caller correlation id; echoed in the admission response and carried
+    /// into the supervised sandbox so an engine UUID maps back here.
+    pub correlation_uuid: Option<uuid::Uuid>,
 }
 
 /// Result of one external message delivery (`docs/slack-sessions.md`,
@@ -158,10 +167,28 @@ pub struct ExternalMessage {
 /// earned, derived from the row's current state.
 #[derive(Debug)]
 pub enum ExternalMessageOutcome {
+    /// A durable steering receipt remains queued or awaits acknowledgment.
+    SteerQueued {
+        turn_id: TurnId,
+        reason: tidebreak_core::code::ExternalSteerQueuedReason,
+    },
     /// The message became a running turn.
     NewTurn(Box<Turn>),
     /// The session was busy; the message sits as a durable queue row.
     Queued(Box<QueuedTurn>),
+    /// The engine acknowledged the instruction into the expected active
+    /// Tidebreak turn. The message row itself remains parked until that
+    /// turn settles and is then consumed without resending its text.
+    Steered {
+        /// The durable receipt/message id the admission owns; stable for
+        /// replay and distinct from the target turn.
+        turn_id: TurnId,
+        /// The active Tidebreak turn the engine acknowledged, matching the
+        /// caller's `expected_turn_id` exactly.
+        expected_turn_id: TurnId,
+        /// Caller correlation id, echoed verbatim.
+        correlation_uuid: Option<uuid::Uuid>,
+    },
     /// The row the first delivery caused was retracted before it could
     /// run; the replay has nothing to point at.
     Dropped,
@@ -823,7 +850,10 @@ impl CodeRuntime {
             return Ok(None);
         };
         if engine.is_in_process() {
-            return Err(ServerError::unprocessable_kind("sandbox_settings_unavailable", "this sandbox profile must select an external harness as its default; choose Internal explicitly to run on the machine"));
+            return Err(ServerError::unprocessable_kind(
+                "sandbox_settings_unavailable",
+                "this sandbox profile must select an external harness as its default; choose Internal explicitly to run on the machine",
+            ));
         }
         let session = Self::remote_session_value(
             owner,

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -446,7 +446,10 @@ impl CodeRuntime {
                     if mode > policy.ceiling {
                         return Err(ServerError::conflict_kind(
                             "permission_mode_above_ceiling",
-                            format!("This deployment allows channel sessions up to {}. To allow {mode}, raise TIDEBREAK_EXTERNAL_PERMISSION_CEILING.", policy.ceiling),
+                            format!(
+                                "This deployment allows channel sessions up to {}. To allow {mode}, raise TIDEBREAK_EXTERNAL_PERMISSION_CEILING.",
+                                policy.ceiling
+                            ),
                         ));
                     }
                     let session = self
@@ -1154,6 +1157,9 @@ impl CodeRuntime {
             channel_ts,
             actor,
             context,
+            steer,
+            expected_turn_id,
+            correlation_uuid,
         } = message;
         if !tidebreak_core::db::code::session_bound_to_grant(&self.db, owner, session_id, grant_id)
             .await?
@@ -1180,7 +1186,14 @@ impl CodeRuntime {
             }
             _ => {}
         }
-        let record = tidebreak_core::db::code::record_external_message_with_context(
+        // A sandbox admission needs a durable correlation id so its ack can
+        // settle without ambiguity; mint one when the caller did not supply it.
+        let correlation_uuid = if steer {
+            Some(correlation_uuid.unwrap_or_else(uuid::Uuid::new_v4))
+        } else {
+            correlation_uuid
+        };
+        let record = tidebreak_core::db::code::record_external_message_with_steer(
             &self.db,
             owner,
             session_id,
@@ -1189,6 +1202,11 @@ impl CodeRuntime {
             &text,
             &actor,
             context.as_ref(),
+            tidebreak_core::db::code::ExternalSteerAdmissionInput {
+                request_steer: steer,
+                expected_turn_id,
+                correlation_uuid,
+            },
         )
         .await
         .map_err(|error| match error {
@@ -1197,10 +1215,69 @@ impl CodeRuntime {
             }
             tidebreak_core::db::code::ExternalMessageIntakeError::Store(error) => error.into(),
         })?;
+        use tidebreak_core::code::{ExternalSteerAdmission, ExternalSteerQueuedReason};
         let (turn_id, fresh) = match &record {
             tidebreak_core::ExternalMessageRecord::Recorded(row) => (row.id, true),
-            tidebreak_core::ExternalMessageRecord::Replay { turn_id } => (*turn_id, false),
+            tidebreak_core::ExternalMessageRecord::Replay { turn_id, .. } => (*turn_id, false),
         };
+        // The first delivery owns the receipt metadata. A replay never steers again.
+        if let tidebreak_core::ExternalMessageRecord::Replay {
+            steer_requested: Some(true),
+            expected_turn_id: Some(target),
+            correlation_uuid: stored_correlation,
+            admission,
+            queued_reason,
+            ..
+        } = &record
+        {
+            return Ok(if *admission == Some(ExternalSteerAdmission::Steered) {
+                ExternalMessageOutcome::Steered {
+                    turn_id,
+                    expected_turn_id: *target,
+                    correlation_uuid: *stored_correlation,
+                }
+            } else {
+                ExternalMessageOutcome::SteerQueued {
+                    turn_id,
+                    reason: queued_reason.unwrap_or(ExternalSteerQueuedReason::Unacknowledged),
+                }
+            });
+        }
+        if steer && fresh {
+            let target = expected_turn_id.expect("steering target validated before recording");
+            if session.execution_location == ExecutionLocation::Sandbox {
+                return self
+                    .steer_remote_external(
+                        owner,
+                        &session,
+                        &event_id,
+                        &text,
+                        target,
+                        turn_id,
+                        correlation_uuid
+                            .expect("steering correlation is assigned before recording"),
+                    )
+                    .await;
+            }
+            let reason = self
+                .steer_external(
+                    owner,
+                    session_id,
+                    event_id.clone(),
+                    text,
+                    target,
+                    correlation_uuid,
+                )
+                .await?;
+            return Ok(match reason {
+                Some(reason) => ExternalMessageOutcome::SteerQueued { turn_id, reason },
+                None => ExternalMessageOutcome::Steered {
+                    turn_id,
+                    expected_turn_id: target,
+                    correlation_uuid,
+                },
+            });
+        }
         if fresh {
             // Best effort: a refusal leaves the row queued for the sweep.
             let session = self.get_session(owner, session_id).await?;
@@ -1224,6 +1301,132 @@ impl CodeRuntime {
         }
         // The row the first delivery caused was retracted before it ran.
         Ok(ExternalMessageOutcome::Dropped)
+    }
+
+    /// Dispatch to one durable sandbox target. Native acknowledgment settles the receipt.
+    #[allow(clippy::too_many_arguments)]
+    async fn steer_remote_external(
+        &self,
+        owner: &OwnerId,
+        session: &Session,
+        event_id: &str,
+        text: &str,
+        expected_turn_id: tidebreak_core::TurnId,
+        turn_id: tidebreak_core::TurnId,
+        correlation_uuid: uuid::Uuid,
+    ) -> Result<ExternalMessageOutcome, ServerError> {
+        use tidebreak_core::code::supervisor_tools::{encode_steer_frame, SupervisorSteerFrame};
+        use tidebreak_core::code::ExternalSteerQueuedReason;
+        let queued = |reason| ExternalMessageOutcome::SteerQueued { turn_id, reason };
+        if !supports_sandbox_steer(session.harness_kind) {
+            self.settle_external_queued(
+                owner,
+                session.id,
+                event_id,
+                expected_turn_id,
+                ExternalSteerQueuedReason::SteerUnsupported,
+            )
+            .await?;
+            return Ok(queued(ExternalSteerQueuedReason::SteerUnsupported));
+        }
+        let open = tidebreak_core::db::code::get_open_turn(&self.db, owner, session.id).await?;
+        let Some(open) = open.filter(|turn| turn.id == expected_turn_id) else {
+            self.settle_external_queued(
+                owner,
+                session.id,
+                event_id,
+                expected_turn_id,
+                ExternalSteerQueuedReason::StaleTurn,
+            )
+            .await?;
+            return Ok(queued(ExternalSteerQueuedReason::StaleTurn));
+        };
+        let Some(remote) = self.remote_sessions() else {
+            self.settle_external_queued(
+                owner,
+                session.id,
+                event_id,
+                expected_turn_id,
+                ExternalSteerQueuedReason::SteerUnsupported,
+            )
+            .await?;
+            return Ok(queued(ExternalSteerQueuedReason::SteerUnsupported));
+        };
+        let Some(runtime_id) = remote
+            .driver(&self.db, self.bus.as_ref())
+            .steering_runtime(owner, session.id)
+            .await?
+        else {
+            self.settle_external_queued(
+                owner,
+                session.id,
+                event_id,
+                expected_turn_id,
+                ExternalSteerQueuedReason::SteerUnsupported,
+            )
+            .await?;
+            return Ok(queued(ExternalSteerQueuedReason::SteerUnsupported));
+        };
+        let incarnation =
+            tidebreak_core::db::code::latest_incarnation(&self.db, owner, session.id).await?;
+        let Some(incarnation) = incarnation else {
+            self.settle_external_queued(
+                owner,
+                session.id,
+                event_id,
+                expected_turn_id,
+                ExternalSteerQueuedReason::StaleTurn,
+            )
+            .await?;
+            return Ok(queued(ExternalSteerQueuedReason::StaleTurn));
+        };
+        let target = incarnation
+            .sandbox_id
+            .as_deref()
+            .zip(native_steer_turn(open.ordinal, incarnation.starting_turn).ok());
+        let Some((sandbox_id, native_turn)) = target else {
+            self.settle_external_queued(
+                owner,
+                session.id,
+                event_id,
+                expected_turn_id,
+                ExternalSteerQueuedReason::StaleTurn,
+            )
+            .await?;
+            return Ok(queued(ExternalSteerQueuedReason::StaleTurn));
+        };
+        let claimed = tidebreak_core::db::code::claim_external_steer_target(
+            &self.db,
+            owner,
+            session.id,
+            event_id,
+            expected_turn_id,
+            correlation_uuid,
+            sandbox_id,
+            native_turn,
+            runtime_id,
+        )
+        .await?;
+        if claimed {
+            // A network error cannot prove that the inbox rejected this instruction.
+            // Preserve the receipt until durable native admission evidence arrives.
+            let _ = remote
+                .driver(&self.db, self.bus.as_ref())
+                .send_steer_frame(
+                    owner,
+                    session.id,
+                    encode_steer_frame(&SupervisorSteerFrame {
+                        expected_turn_id: expected_turn_id.to_string(),
+                        sandbox_id: sandbox_id.to_owned(),
+                        runtime_id: runtime_id.to_string(),
+                        native_turn,
+                        correlation_uuid: correlation_uuid.to_string(),
+                        body: text.to_owned(),
+                    }),
+                )
+                .await;
+        }
+        Ok(queued(ExternalSteerQueuedReason::Unacknowledged))
     }
 
     pub(super) async fn interrupt_remote(&self, session: &Session) -> Result<(), ServerError> {
@@ -1308,5 +1511,38 @@ impl CodeRuntime {
             )
             .await;
         }
+    }
+}
+
+/// Whether a sandbox harness has a verified acknowledged mid-turn steering
+/// channel. Codex's `turn/steer` is verified; Claude reports Unknown and
+/// must never be claimed steered on a stdin write.
+fn supports_sandbox_steer(harness: tidebreak_core::HarnessKind) -> bool {
+    matches!(harness, tidebreak_core::HarnessKind::Codex)
+}
+
+fn native_steer_turn(ordinal: i64, starting_turn: i32) -> Result<u32, ServerError> {
+    ordinal
+        .checked_sub(i64::from(starting_turn))
+        .and_then(|offset| offset.checked_add(1))
+        .filter(|turn| *turn > 0)
+        .and_then(|turn| u32::try_from(turn).ok())
+        .ok_or_else(|| {
+            ServerError::conflict_kind(
+                "stale_turn",
+                "The turn does not belong to this sandbox incarnation.",
+            )
+        })
+}
+
+#[cfg(test)]
+mod steer_target_tests {
+    use super::native_steer_turn;
+    #[test]
+    fn maps_session_ordinals_into_each_incarnation() {
+        assert_eq!(native_steer_turn(1, 1).unwrap(), 1);
+        assert_eq!(native_steer_turn(4, 4).unwrap(), 1);
+        assert_eq!(native_steer_turn(5, 4).unwrap(), 2);
+        assert!(native_steer_turn(3, 4).is_err());
     }
 }

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -1410,7 +1410,7 @@ impl CodeRuntime {
         if claimed {
             // A network error cannot prove that the inbox rejected this instruction.
             // Preserve the receipt until durable native admission evidence arrives.
-            let _ = remote
+            let dispatch = remote
                 .driver(&self.db, self.bus.as_ref())
                 .send_steer_frame(
                     owner,
@@ -1425,6 +1425,20 @@ impl CodeRuntime {
                     }),
                 )
                 .await;
+            if matches!(
+                dispatch,
+                Err(crate::code::remote::driver::SteerDispatchError::NotSent(_))
+            ) {
+                self.settle_external_queued(
+                    owner,
+                    session.id,
+                    event_id,
+                    expected_turn_id,
+                    ExternalSteerQueuedReason::StaleTurn,
+                )
+                .await?;
+                return Ok(queued(ExternalSteerQueuedReason::StaleTurn));
+            }
         }
         Ok(queued(ExternalSteerQueuedReason::Unacknowledged))
     }

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -601,10 +601,11 @@ impl CodeRuntime {
         expected_turn_id: TurnId,
         message: String,
     ) -> Result<(), ServerError> {
-        self.steer_inner(owner, id, expected_turn_id, message, None)
+        self.steer_inner(owner, id, expected_turn_id, message, None, None)
             .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn steer_inner(
         &self,
         owner: &OwnerId,
@@ -612,6 +613,7 @@ impl CodeRuntime {
         expected_turn_id: TurnId,
         message: String,
         trigger_delivery: Option<TriggerDeliveryClaim>,
+        admission: Option<SteerAdmission>,
     ) -> Result<(), ServerError> {
         if let Some(claim) = trigger_delivery {
             if tidebreak_core::db::code::trigger_delivery_accepted(
@@ -685,6 +687,7 @@ impl CodeRuntime {
                 .send(WorkerCommand::Steer {
                     expected_turn_id,
                     message,
+                    admission,
                     reply,
                 })
                 .await
@@ -732,6 +735,7 @@ impl CodeRuntime {
                 delivery_id,
                 lease_token,
             }),
+            None,
         )
         .await
     }
@@ -787,5 +791,132 @@ impl CodeRuntime {
                 other => ServerError::conflict_kind("session_not_reaped", other.to_string()),
             })?;
         self.attach_and_spawn_worker(session).await
+    }
+}
+
+impl CodeRuntime {
+    /// Ask the local worker to settle an external steering receipt before replying.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn steer_external(
+        &self,
+        owner: &OwnerId,
+        session_id: SessionId,
+        event_id: String,
+        text: String,
+        expected_turn_id: TurnId,
+        correlation_uuid: Option<uuid::Uuid>,
+    ) -> Result<Option<tidebreak_core::code::ExternalSteerQueuedReason>, ServerError> {
+        use tidebreak_core::code::ExternalSteerQueuedReason;
+        let session = self.get_session(owner, session_id).await?;
+        let adapter = self.adapter(session.harness_kind)?;
+        let probe = self.probe(adapter.as_ref()).await;
+        let reason = if adapter.capabilities(&probe).mid_turn_steering != CapLevel::Supported {
+            Some(ExternalSteerQueuedReason::SteerUnsupported)
+        } else if get_open_turn(&self.db, owner, session_id)
+            .await?
+            .is_none_or(|turn| turn.id != expected_turn_id)
+        {
+            Some(ExternalSteerQueuedReason::StaleTurn)
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            self.settle_external_queued(owner, session_id, &event_id, expected_turn_id, reason)
+                .await?;
+            return Ok(Some(reason));
+        }
+        let handle = match self.require_worker(session_id) {
+            Ok(handle) => handle,
+            Err(_) => {
+                self.settle_external_queued(
+                    owner,
+                    session_id,
+                    &event_id,
+                    expected_turn_id,
+                    ExternalSteerQueuedReason::StaleTurn,
+                )
+                .await?;
+                return Ok(Some(ExternalSteerQueuedReason::StaleTurn));
+            }
+        };
+        if handle.spawn_epoch != session.spawn_epoch {
+            self.settle_external_queued(
+                owner,
+                session_id,
+                &event_id,
+                expected_turn_id,
+                ExternalSteerQueuedReason::StaleTurn,
+            )
+            .await?;
+            return Ok(Some(ExternalSteerQueuedReason::StaleTurn));
+        }
+        let (reply, rx) = oneshot::channel();
+        if handle
+            .commands
+            .send(WorkerCommand::Steer {
+                expected_turn_id,
+                message: text,
+                admission: Some(SteerAdmission {
+                    spawn_epoch: session.spawn_epoch,
+                    db: self.db.clone(),
+                    owner: owner.clone(),
+                    session_id,
+                    event_id: event_id.clone(),
+                    expected_turn_id,
+                    correlation_uuid,
+                }),
+                reply,
+            })
+            .await
+            .is_err()
+        {
+            self.settle_external_queued(
+                owner,
+                session_id,
+                &event_id,
+                expected_turn_id,
+                ExternalSteerQueuedReason::StaleTurn,
+            )
+            .await?;
+            return Ok(Some(ExternalSteerQueuedReason::StaleTurn));
+        }
+        Ok(match rx.await {
+            Ok(Ok(())) => None,
+            Ok(Err(WorkerError::NoActiveTurn(_) | WorkerError::StaleTurn(_))) => {
+                Some(ExternalSteerQueuedReason::StaleTurn)
+            }
+            Ok(Err(WorkerError::SteeringUnavailable(_) | WorkerError::SteeringRejected(_))) => {
+                Some(ExternalSteerQueuedReason::SteerUnsupported)
+            }
+            // A lost reply or timeout cannot prove refusal. Retain the held receipt.
+            _ => Some(ExternalSteerQueuedReason::Unacknowledged),
+        })
+    }
+
+    pub(super) async fn settle_external_queued(
+        &self,
+        owner: &OwnerId,
+        session_id: SessionId,
+        event_id: &str,
+        expected_turn_id: TurnId,
+        reason: tidebreak_core::code::ExternalSteerQueuedReason,
+    ) -> Result<(), ServerError> {
+        let settled = tidebreak_core::db::code::settle_external_steer_admission(
+            &self.db,
+            owner,
+            session_id,
+            event_id,
+            expected_turn_id,
+            tidebreak_core::code::ExternalSteerAdmission::Queued,
+            Some(reason),
+        )
+        .await?;
+        if !settled {
+            return Err(ServerError::conflict_kind(
+                "steer_settlement_conflict",
+                "The steering receipt already has a different outcome.",
+            ));
+        }
+        Ok(())
     }
 }

--- a/crates/tidebreak-server/src/code/session_tools.rs
+++ b/crates/tidebreak-server/src/code/session_tools.rs
@@ -161,16 +161,36 @@ fn text<'a>(args: &'a Value, key: &str, max: usize) -> Result<&'a str, ServerErr
 impl Tool for SessionTool {
     fn spec(&self) -> ToolSpec {
         let (description, properties, required) = match self.name {
-            "code_repos" => ("List repositories available to this conversation's personal or bot identity. Choose repositories from the task; the conversation does not need a default repository.", json!({}), json!([])),
-            "code_session_create" => ("Start independent work in a repository and return its child session. Use a different request_key for each task and reuse it on retries. You may start children in different repositories. Read their results with code_wait before answering. The configured GitHub identity controls repository access across every channel; no channel repository approval is needed.", json!({
-                "repository":{"type":"string","description":"GitHub owner/name"},
-                "task":{"type":"string","maxLength":16000},
-                "request_key":{"type":"string","maxLength":128,"description":"Stable key for this task, reused on retries."},
-                "harness":{"type":"string","description":"Optional installed harness; defaults to claude_code."}
-            }), json!(["repository","task","request_key"])),
-            "code_run_turn" => ("Send a follow-up to one of this conversation's child sessions. Use a stable request_key to prevent duplicate turns on retry.", json!({"session_id":{"type":"string"},"text":{"type":"string","maxLength":16000},"request_key":{"type":"string","maxLength":128}}), json!(["session_id","text","request_key"])),
-            "code_wait" => ("Read child results, waiting up to 20 seconds while they run. Results remain in requested order. If waiting is true, call again after other useful work. A child awaiting approval includes its pending cards.", json!({"session_ids":{"type":"array","minItems":1,"maxItems":8,"items":{"type":"string"}}}), json!(["session_ids"])),
-            _ => ("List this conversation's child sessions, including their repositories and status.", json!({}), json!([])),
+            "code_repos" => (
+                "List repositories available to this conversation's personal or bot identity. Choose repositories from the task; the conversation does not need a default repository.",
+                json!({}),
+                json!([]),
+            ),
+            "code_session_create" => (
+                "Start independent work in a repository and return its child session. Use a different request_key for each task and reuse it on retries. You may start children in different repositories. Read their results with code_wait before answering. The configured GitHub identity controls repository access across every channel; no channel repository approval is needed.",
+                json!({
+                    "repository":{"type":"string","description":"GitHub owner/name"},
+                    "task":{"type":"string","maxLength":16000},
+                    "request_key":{"type":"string","maxLength":128,"description":"Stable key for this task, reused on retries."},
+                    "harness":{"type":"string","description":"Optional installed harness; defaults to claude_code."}
+                }),
+                json!(["repository", "task", "request_key"]),
+            ),
+            "code_run_turn" => (
+                "Send a follow-up to one of this conversation's child sessions. Use a stable request_key to prevent duplicate turns on retry.",
+                json!({"session_id":{"type":"string"},"text":{"type":"string","maxLength":16000},"request_key":{"type":"string","maxLength":128}}),
+                json!(["session_id", "text", "request_key"]),
+            ),
+            "code_wait" => (
+                "Read child results, waiting up to 20 seconds while they run. Results remain in requested order. If waiting is true, call again after other useful work. A child awaiting approval includes its pending cards.",
+                json!({"session_ids":{"type":"array","minItems":1,"maxItems":8,"items":{"type":"string"}}}),
+                json!(["session_ids"]),
+            ),
+            _ => (
+                "List this conversation's child sessions, including their repositories and status.",
+                json!({}),
+                json!([]),
+            ),
         };
         ToolSpec {
             name: self.name.into(),
@@ -368,7 +388,10 @@ impl SessionTool {
                 .count()
                 >= 8
         {
-            return Err(ServerError::conflict_kind("child_session_limit", "A conversation can start at most 16 children and run at most 8 at once. Wait for running children before starting more."));
+            return Err(ServerError::conflict_kind(
+                "child_session_limit",
+                "A conversation can start at most 16 children and run at most 8 at once. Wait for running children before starting more.",
+            ));
         }
         if let Some(lender) = &auth.lender {
             // Refuse a missing person connection rather than silently moving
@@ -483,7 +506,7 @@ impl SessionTool {
                     return Err(ServerError::conflict_kind(
                         "child_unavailable",
                         "This child session ended or belongs to another connection.",
-                    ))
+                    ));
                 }
             };
             runtime.get_session(&auth.parent.owner, id).await?
@@ -586,6 +609,9 @@ async fn send(
                     channel_ts: chrono::Utc::now().timestamp_micros().to_string(),
                     actor,
                     context: None,
+                    steer: false,
+                    expected_turn_id: None,
+                    correlation_uuid: None,
                 },
             )
             .await?;

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -79,9 +79,29 @@ pub(crate) enum WorkerCommand {
     Steer {
         expected_turn_id: TurnId,
         message: String,
+        /// Durable external admission to settle, when this steer came from
+        /// the Slack messages endpoint.
+        admission: Option<SteerAdmission>,
         reply: oneshot::Sender<Result<(), WorkerError>>,
     },
     Shutdown,
+}
+
+/// One durable external steering admission the worker owes a settlement for.
+#[derive(Clone)]
+pub(crate) struct SteerAdmission {
+    pub db: Arc<DbStore>,
+    /// Owner of the external event row.
+    pub owner: OwnerId,
+    /// Session the event row belongs to.
+    pub session_id: SessionId,
+    pub spawn_epoch: i64,
+    /// Channel event id, the idempotency key of the admission.
+    pub event_id: String,
+    /// The active Tidebreak turn the instruction targets.
+    pub expected_turn_id: TurnId,
+    /// Caller correlation id.
+    pub correlation_uuid: Option<uuid::Uuid>,
 }
 
 /// The durable outcome that releases a worker after native mode acceptance.
@@ -545,7 +565,7 @@ impl LiveSink {
                     return Err(WorkerError::Failed(format!(
                         "session {} has no open turn for approval {approval_id}",
                         self.session_id
-                    )))
+                    )));
                 }
                 Err(err) => return Err(WorkerError::Failed(err.to_string())),
             },
@@ -691,6 +711,37 @@ impl HarnessEventSink for LiveSink {
             return;
         }
         let turn_id = *self.turn_id.lock().unwrap();
+        if let HarnessEvent::UserSteered {
+            correlation_uuid: Some(correlation_uuid),
+            ..
+        } = &event
+        {
+            let Some(expected_turn_id) = turn_id else {
+                return;
+            };
+            match tidebreak_core::db::code::settle_machine_external_steer_ack(
+                &self.db,
+                &self.owner,
+                self.session_id,
+                self.spawn_epoch,
+                expected_turn_id,
+                *correlation_uuid,
+            )
+            .await
+            {
+                Ok(true) => {}
+                Ok(false) => return,
+                Err(error) => {
+                    warn!(
+                        session = %self.session_id,
+                        %correlation_uuid,
+                        %error,
+                        "could not persist a correlated machine steering acknowledgment"
+                    );
+                    return;
+                }
+            }
+        }
         let Some(session_event) = map_event(event, turn_id) else {
             return;
         };
@@ -1792,9 +1843,11 @@ async fn apply_control(
         WorkerCommand::Steer {
             expected_turn_id,
             message,
+            admission,
             reply,
         } => {
-            let result = match active_turn_id {
+            let admission = admission.as_ref();
+            let mut result = match active_turn_id {
                 None => Err(WorkerError::NoActiveTurn(
                     "there is no active turn to steer; the message was not queued".into(),
                 )),
@@ -1805,7 +1858,7 @@ async fn apply_control(
                 )),
                 Some(_) => match tokio::time::timeout(
                     STEER_CONTROL_TIMEOUT,
-                    engine.steer(message),
+                    engine.steer_with_correlation(message, admission.and_then(|a| a.correlation_uuid)),
                 )
                 .await
                 {
@@ -1819,12 +1872,64 @@ async fn apply_control(
                         }
                         other => WorkerError::Failed(other.to_string()),
                     }),
-                    Err(_) => Err(WorkerError::SteeringRejected(
-                        "the engine did not acknowledge steering before the control timeout; the message was not queued"
-                            .into(),
-                    )),
+                    Err(_) => {
+                        let detail = "the engine did not acknowledge steering before the control timeout".to_owned();
+                        Err(if admission.is_some() {
+                            WorkerError::Failed(detail)
+                        } else {
+                            WorkerError::SteeringRejected(detail)
+                        })
+                    },
                 },
             };
+            if let Some(admission) = admission {
+                use tidebreak_core::code::{ExternalSteerAdmission, ExternalSteerQueuedReason};
+                let settlement = match &result {
+                    Ok(()) => Some((ExternalSteerAdmission::Steered, None)),
+                    Err(WorkerError::NoActiveTurn(_) | WorkerError::StaleTurn(_)) => Some((
+                        ExternalSteerAdmission::Queued,
+                        Some(ExternalSteerQueuedReason::StaleTurn),
+                    )),
+                    Err(WorkerError::SteeringUnavailable(_) | WorkerError::SteeringRejected(_)) => {
+                        Some((
+                            ExternalSteerAdmission::Queued,
+                            Some(ExternalSteerQueuedReason::SteerUnsupported),
+                        ))
+                    }
+                    _ => None,
+                };
+                if let Some((outcome, reason)) = settlement {
+                    let settled = if let Some(correlation_uuid) = admission.correlation_uuid {
+                        tidebreak_core::db::code::settle_machine_external_steer_admission(
+                            &admission.db,
+                            &admission.owner,
+                            admission.session_id,
+                            admission.spawn_epoch,
+                            admission.expected_turn_id,
+                            correlation_uuid,
+                            outcome,
+                            reason,
+                        )
+                        .await
+                    } else {
+                        Ok(false)
+                    };
+                    match settled {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            warn!(
+                                session = %admission.session_id,
+                                event_id = %admission.event_id,
+                                "dropping a steering settlement from a mismatched worker, turn, or outcome"
+                            );
+                            result = Err(WorkerError::Failed(
+                                "The steering receipt no longer matches this worker, turn, or outcome.".into(),
+                            ));
+                        }
+                        Err(error) => result = Err(WorkerError::Failed(error.to_string())),
+                    }
+                }
+            }
             let _ = reply.send(result);
             ControlFlow::Continue
         }
@@ -2604,7 +2709,7 @@ async fn drive_turn_inner(
                 WorktreeWait::Shutdown => {
                     return Err(WorkerError::Conflict(
                         "the session worker is shutting down".into(),
-                    ))
+                    ));
                 }
             }
         }
@@ -4148,7 +4253,7 @@ fn map_event(event: HarnessEvent, turn_id: Option<TurnId>) -> Option<Event> {
             decision: decision.into(),
             actor: None,
         },
-        HarnessEvent::UserSteered { text } => Event::UserSteered {
+        HarnessEvent::UserSteered { text, .. } => Event::UserSteered {
             text,
             message_id: None,
         },

--- a/crates/tidebreak-server/src/code/session_worker/tests.rs
+++ b/crates/tidebreak-server/src/code/session_worker/tests.rs
@@ -2062,3 +2062,735 @@ async fn an_update_quiesce_refuses_new_turns_until_resumed() {
         1
     );
 }
+
+#[derive(Clone, Copy)]
+enum SteerControlAnswer {
+    Ack,
+    Unsupported,
+    Rejected,
+    Unknown,
+    Timeout,
+}
+
+/// A native control channel whose acknowledgment can be held independently
+/// of the worker reply and database commit.
+struct SteerControlHarness {
+    answer: SteerControlAnswer,
+    entered: Notify,
+    acknowledge: Notify,
+    acknowledged: Notify,
+    requests: std::sync::Mutex<Vec<(String, Option<uuid::Uuid>)>>,
+    events: std::sync::Mutex<Vec<HarnessEvent>>,
+}
+
+impl SteerControlHarness {
+    fn new(answer: SteerControlAnswer) -> Self {
+        Self {
+            answer,
+            entered: Notify::new(),
+            acknowledge: Notify::new(),
+            acknowledged: Notify::new(),
+            requests: std::sync::Mutex::new(Vec::new()),
+            events: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl HarnessSession for SteerControlHarness {
+    async fn run_turn(&self, _: TurnInput) -> Result<TurnOutcome, HarnessError> {
+        panic!("a steering control must not start another native turn");
+    }
+
+    async fn decide(&self, _: HarnessApprovalRef, _: ApprovalDecision) -> Result<(), HarnessError> {
+        panic!("a steering control must not decide an approval");
+    }
+
+    async fn interrupt(&self) -> Result<(), HarnessError> {
+        panic!("a steering control must not interrupt the native turn");
+    }
+
+    async fn steer_with_correlation(
+        &self,
+        text: String,
+        correlation_uuid: Option<uuid::Uuid>,
+    ) -> Result<(), HarnessError> {
+        self.requests
+            .lock()
+            .unwrap()
+            .push((text.clone(), correlation_uuid));
+        self.entered.notify_one();
+        match self.answer {
+            SteerControlAnswer::Ack => {
+                self.acknowledge.notified().await;
+                self.events.lock().unwrap().push(HarnessEvent::UserSteered {
+                    text,
+                    correlation_uuid,
+                });
+                self.acknowledged.notify_one();
+                Ok(())
+            }
+            SteerControlAnswer::Unsupported => Err(HarnessError::SteeringUnsupported),
+            SteerControlAnswer::Rejected => Err(HarnessError::SteeringRejected(
+                "native turn rejected the request".into(),
+            )),
+            SteerControlAnswer::Unknown => Err(HarnessError::Other(
+                "the request was written but its acknowledgment was lost".into(),
+            )),
+            SteerControlAnswer::Timeout => std::future::pending().await,
+        }
+    }
+
+    fn resume_ref(&self) -> Option<String> {
+        None
+    }
+    fn unrecognized_events(&self) -> u64 {
+        0
+    }
+    async fn shutdown(self: Box<Self>) -> Result<(), HarnessError> {
+        Ok(())
+    }
+}
+
+async fn pending_worker_steer(
+    db: &Arc<DbStore>,
+    session_id: SessionId,
+) -> (SteerAdmission, QueuedTurn) {
+    let expected_turn_id = TurnId::new();
+    let correlation_uuid = Some(uuid::Uuid::new_v4());
+    let owner = OwnerId::local();
+    let record = tidebreak_core::db::code::record_external_message_with_steer(
+        db,
+        &owner,
+        session_id,
+        "EvWorkerSteer",
+        "1700000001.000100",
+        "use the corrected fixture",
+        &tidebreak_core::TurnActor::default(),
+        None,
+        tidebreak_core::db::code::ExternalSteerAdmissionInput {
+            request_steer: true,
+            expected_turn_id: Some(expected_turn_id),
+            correlation_uuid,
+        },
+    )
+    .await
+    .unwrap();
+    let tidebreak_core::ExternalMessageRecord::Recorded(row) = record else {
+        panic!("first worker steer must create its receipt");
+    };
+    (
+        SteerAdmission {
+            db: Arc::clone(db),
+            owner,
+            session_id,
+            spawn_epoch: 1,
+            event_id: "EvWorkerSteer".into(),
+            expected_turn_id,
+            correlation_uuid,
+        },
+        *row,
+    )
+}
+
+async fn worker_steer_receipt(admission: &SteerAdmission) -> tidebreak_core::ExternalMessageRecord {
+    tidebreak_core::db::code::external_steer_admission(
+        &admission.db,
+        &admission.owner,
+        admission.session_id,
+        &admission.event_id,
+    )
+    .await
+    .unwrap()
+    .unwrap()
+}
+
+#[tokio::test]
+async fn durable_steer_ack_commits_before_the_worker_replies() {
+    use sea_orm::{ConnectionTrait, TransactionTrait};
+    use tidebreak_core::code::{ExternalMessageRecord, ExternalSteerAdmission};
+    let (directory, db, _, session_id) = seeded_session(HarnessKind::Codex, None).await;
+    let (admission, row) = pending_worker_steer(&db, session_id).await;
+    insert_running_steer_target(&db, &admission).await;
+    let engine = Arc::new(SteerControlHarness::new(SteerControlAnswer::Ack));
+    // Hold SQLite's writer lock so the native ACK cannot immediately become
+    // a durable receipt. A premature worker reply is observable in this gap.
+    let writer = sea_orm::Database::connect(format!(
+        "sqlite://{}?mode=rwc",
+        directory.path().join("t.db").display()
+    ))
+    .await
+    .unwrap();
+    let transaction = writer.begin().await.unwrap();
+    transaction
+        .execute_unprepared(
+            "UPDATE session SET unrecognized_event_count = unrecognized_event_count",
+        )
+        .await
+        .unwrap();
+    let (reply, mut response) = oneshot::channel();
+    let worker = {
+        let engine = Arc::clone(&engine);
+        let admission = admission.clone();
+        tokio::spawn(async move {
+            apply_control(
+                engine.as_ref(),
+                WorkerCommand::Steer {
+                    expected_turn_id: admission.expected_turn_id,
+                    message: row.message,
+                    admission: Some(admission.clone()),
+                    reply,
+                },
+                Some(admission.expected_turn_id),
+                None,
+            )
+            .await;
+        })
+    };
+    engine.entered.notified().await;
+    assert!(matches!(
+        worker_steer_receipt(&admission).await,
+        ExternalMessageRecord::Replay {
+            admission: None,
+            ..
+        }
+    ));
+    assert!(matches!(
+        response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+    engine.acknowledge.notify_one();
+    engine.acknowledged.notified().await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut response)
+            .await
+            .is_err(),
+        "native ACK alone must not complete the worker reply before persistence"
+    );
+    transaction.rollback().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), response)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    worker.await.unwrap();
+    assert!(matches!(
+        worker_steer_receipt(&admission).await,
+        ExternalMessageRecord::Replay {
+            admission: Some(ExternalSteerAdmission::Steered),
+            ..
+        }
+    ));
+    assert!(
+        tidebreak_core::db::code::list_queued_turns(&db, &admission.owner, session_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        engine.requests.lock().unwrap().as_slice(),
+        &[(
+            "use the corrected fixture".into(),
+            admission.correlation_uuid
+        )]
+    );
+    assert_eq!(engine.events.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn durable_steer_ack_survives_a_dropped_worker_reply() {
+    use tidebreak_core::code::{ExternalMessageRecord, ExternalSteerAdmission};
+    let (directory, db, _, session_id) = seeded_session(HarnessKind::Codex, None).await;
+    let (admission, row) = pending_worker_steer(&db, session_id).await;
+    insert_running_steer_target(&db, &admission).await;
+    let engine = SteerControlHarness::new(SteerControlAnswer::Ack);
+    engine.acknowledge.notify_one();
+    let (reply, response) = oneshot::channel();
+    drop(response);
+    apply_control(
+        &engine,
+        WorkerCommand::Steer {
+            expected_turn_id: admission.expected_turn_id,
+            message: row.message,
+            admission: Some(admission.clone()),
+            reply,
+        },
+        Some(admission.expected_turn_id),
+        None,
+    )
+    .await;
+    assert_eq!(engine.events.lock().unwrap().len(), 1);
+    // A reconnecting HTTP delivery reads the stored admission, even when its
+    // original request no longer waits for the worker's response.
+    let reopened = DbStore::connect(&format!(
+        "sqlite://{}?mode=rwc",
+        directory.path().join("t.db").display()
+    ))
+    .await
+    .unwrap();
+    let replay = tidebreak_core::db::code::record_external_message_with_steer(
+        &reopened,
+        &admission.owner,
+        session_id,
+        &admission.event_id,
+        "1700000001.000100",
+        "use the corrected fixture",
+        &tidebreak_core::TurnActor::default(),
+        None,
+        tidebreak_core::db::code::ExternalSteerAdmissionInput::default(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        replay,
+        ExternalMessageRecord::Replay {
+            turn_id: row.id,
+            steer_requested: Some(true),
+            expected_turn_id: Some(admission.expected_turn_id),
+            correlation_uuid: admission.correlation_uuid,
+            admission: Some(ExternalSteerAdmission::Steered),
+            queued_reason: None,
+        }
+    );
+    assert!(
+        tidebreak_core::db::code::list_queued_turns(&reopened, &admission.owner, session_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn durable_steer_only_proven_rejection_releases_the_queue() {
+    use tidebreak_core::code::{
+        ExternalMessageRecord, ExternalSteerAdmission, ExternalSteerQueuedReason,
+    };
+    for (answer, released) in [
+        (SteerControlAnswer::Unsupported, true),
+        (SteerControlAnswer::Rejected, true),
+        (SteerControlAnswer::Unknown, false),
+        (SteerControlAnswer::Timeout, false),
+    ] {
+        let (_directory, db, _, session_id) = seeded_session(HarnessKind::Codex, None).await;
+        let (admission, row) = pending_worker_steer(&db, session_id).await;
+        let engine = SteerControlHarness::new(answer);
+        let (reply, response) = oneshot::channel();
+        apply_control(
+            &engine,
+            WorkerCommand::Steer {
+                expected_turn_id: admission.expected_turn_id,
+                message: row.message,
+                admission: Some(admission.clone()),
+                reply,
+            },
+            Some(admission.expected_turn_id),
+            None,
+        )
+        .await;
+        let error = response.await.unwrap().unwrap_err();
+        if released {
+            assert!(matches!(
+                error,
+                WorkerError::SteeringUnavailable(_) | WorkerError::SteeringRejected(_)
+            ));
+            assert!(matches!(
+                worker_steer_receipt(&admission).await,
+                ExternalMessageRecord::Replay {
+                    admission: Some(ExternalSteerAdmission::Queued),
+                    queued_reason: Some(ExternalSteerQueuedReason::SteerUnsupported),
+                    ..
+                }
+            ));
+        } else {
+            assert!(matches!(error, WorkerError::Failed(_)));
+            assert!(matches!(
+                worker_steer_receipt(&admission).await,
+                ExternalMessageRecord::Replay {
+                    admission: None,
+                    queued_reason: None,
+                    ..
+                }
+            ));
+        }
+        assert_eq!(
+            queued_turn_head(&db, &admission.owner, session_id)
+                .await
+                .unwrap()
+                .is_some(),
+            released
+        );
+        assert_eq!(
+            tidebreak_core::db::code::list_queued_turns(&db, &admission.owner, session_id)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(engine.events.lock().unwrap().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn durable_steer_stale_target_falls_back_without_native_delivery() {
+    use tidebreak_core::code::{
+        ExternalMessageRecord, ExternalSteerAdmission, ExternalSteerQueuedReason,
+    };
+    let (_directory, db, _, session_id) = seeded_session(HarnessKind::Codex, None).await;
+    let (admission, row) = pending_worker_steer(&db, session_id).await;
+    let engine = SteerControlHarness::new(SteerControlAnswer::Ack);
+    let (reply, response) = oneshot::channel();
+    apply_control(
+        &engine,
+        WorkerCommand::Steer {
+            expected_turn_id: admission.expected_turn_id,
+            message: row.message,
+            admission: Some(admission.clone()),
+            reply,
+        },
+        Some(TurnId::new()),
+        None,
+    )
+    .await;
+    assert!(matches!(
+        response.await.unwrap(),
+        Err(WorkerError::StaleTurn(_))
+    ));
+    assert!(engine.requests.lock().unwrap().is_empty());
+    assert!(matches!(
+        worker_steer_receipt(&admission).await,
+        ExternalMessageRecord::Replay {
+            admission: Some(ExternalSteerAdmission::Queued),
+            queued_reason: Some(ExternalSteerQueuedReason::StaleTurn),
+            ..
+        }
+    ));
+    assert_eq!(
+        queued_turn_head(&db, &admission.owner, session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        row.id
+    );
+}
+
+async fn insert_running_steer_target(db: &DbStore, admission: &SteerAdmission) -> Turn {
+    let turn = Turn {
+        actor: None,
+        id: admission.expected_turn_id,
+        session_id: admission.session_id,
+        ordinal: 1,
+        status: TurnStatus::Running,
+        model: None,
+        fast_mode: false,
+        user_input: "original work".into(),
+        user_input_blob_id: None,
+        attachments: Vec::new(),
+        checkpoint_ref: None,
+        diffstat: None,
+        usage: None,
+        narrative: None,
+        rewrite: None,
+        started_at: Utc::now(),
+        ended_at: None,
+        park_ref: None,
+        park_wait: None,
+    };
+    insert_turn(db, &admission.owner, &turn).await.unwrap();
+    turn
+}
+
+#[tokio::test]
+async fn durable_steer_late_stream_ack_consumes_the_original_queue_row() {
+    use tidebreak_core::code::{ExternalMessageRecord, ExternalSteerAdmission};
+    let (_directory, db, sink, session_id) = seeded_sink().await;
+    let (admission, row) = pending_worker_steer(&db, session_id).await;
+    insert_running_steer_target(&db, &admission).await;
+    sink.set_turn(admission.expected_turn_id);
+    let (reply, response) = oneshot::channel();
+    apply_control(
+        &SteerControlHarness::new(SteerControlAnswer::Timeout),
+        WorkerCommand::Steer {
+            expected_turn_id: admission.expected_turn_id,
+            message: row.message.clone(),
+            admission: Some(admission.clone()),
+            reply,
+        },
+        Some(admission.expected_turn_id),
+        None,
+    )
+    .await;
+    assert!(matches!(
+        response.await.unwrap(),
+        Err(WorkerError::Failed(_))
+    ));
+    assert!(matches!(
+        worker_steer_receipt(&admission).await,
+        ExternalMessageRecord::Replay {
+            admission: None,
+            ..
+        }
+    ));
+
+    sink.emit(HarnessEvent::UserSteered {
+        text: row.message.clone(),
+        correlation_uuid: admission.correlation_uuid,
+    })
+    .await;
+    assert!(matches!(
+        worker_steer_receipt(&admission).await,
+        ExternalMessageRecord::Replay {
+            admission: Some(ExternalSteerAdmission::Steered),
+            ..
+        }
+    ));
+    assert!(
+        tidebreak_core::db::code::list_queued_turns(&db, &admission.owner, session_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    let events = list_events(&db, &admission.owner, session_id, 0, MAX_REPLAY_EVENTS)
+        .await
+        .unwrap()
+        .events;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|item| matches!(&item.event,
+        Event::UserSteered { text, .. } if text == &row.message))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn durable_steer_stream_ack_rejects_stale_or_foreign_targets() {
+    use tidebreak_core::code::{
+        ExternalMessageRecord, ExternalSteerAdmission, ExternalSteerQueuedReason,
+    };
+    for invalid in [
+        "epoch",
+        "turn",
+        "terminal",
+        "location",
+        "remote_claim",
+        "correlation",
+        "owner",
+        "session",
+        "queued",
+    ] {
+        let location = if invalid == "location" {
+            tidebreak_core::ExecutionLocation::Sandbox
+        } else {
+            tidebreak_core::ExecutionLocation::Machine
+        };
+        let (_directory, db, mut sink, session_id) = seeded_sink_at(location).await;
+        let (admission, row) = pending_worker_steer(&db, session_id).await;
+        let mut turn = insert_running_steer_target(&db, &admission).await;
+        sink.set_turn(admission.expected_turn_id);
+        let mut correlation_uuid = admission.correlation_uuid;
+        match invalid {
+            "epoch" => {
+                tidebreak_core::db::code::bump_spawn_epoch(&db, session_id, None)
+                    .await
+                    .unwrap();
+            }
+            "turn" => {
+                turn.id = TurnId::new();
+                turn.ordinal = 2;
+                insert_turn(&db, &admission.owner, &turn).await.unwrap();
+                sink.set_turn(turn.id);
+            }
+            "terminal" => {
+                turn.status = TurnStatus::Completed;
+                turn.ended_at = Some(Utc::now());
+                tidebreak_core::db::code::save_turn(&db, &admission.owner, &turn)
+                    .await
+                    .unwrap();
+            }
+            "remote_claim" => assert!(tidebreak_core::db::code::claim_external_steer_target(
+                &db,
+                &admission.owner,
+                session_id,
+                &admission.event_id,
+                admission.expected_turn_id,
+                correlation_uuid.unwrap(),
+                "remote-sandbox",
+                2,
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .unwrap()),
+            "correlation" => correlation_uuid = Some(uuid::Uuid::new_v4()),
+            "owner" => {
+                Arc::get_mut(&mut sink).unwrap().owner = OwnerId::new("foreign-owner").unwrap()
+            }
+            "session" => Arc::get_mut(&mut sink).unwrap().session_id = SessionId::new(),
+            "queued" => assert!(tidebreak_core::db::code::settle_external_steer_admission(
+                &db,
+                &admission.owner,
+                session_id,
+                &admission.event_id,
+                admission.expected_turn_id,
+                ExternalSteerAdmission::Queued,
+                Some(ExternalSteerQueuedReason::SteerUnsupported),
+            )
+            .await
+            .unwrap()),
+            "location" => {}
+            _ => unreachable!(),
+        }
+        sink.emit(HarnessEvent::UserSteered {
+            text: row.message,
+            correlation_uuid,
+        })
+        .await;
+        let expected = (invalid == "queued").then_some(ExternalSteerAdmission::Queued);
+        assert!(
+            matches!(worker_steer_receipt(&admission).await,
+            ExternalMessageRecord::Replay { admission, .. } if admission == expected),
+            "{invalid}"
+        );
+        assert_eq!(
+            tidebreak_core::db::code::list_queued_turns(&db, &admission.owner, session_id)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "{invalid}"
+        );
+        let events = list_events(&db, &admission.owner, session_id, 0, MAX_REPLAY_EVENTS)
+            .await
+            .unwrap()
+            .events;
+        assert!(
+            !events
+                .iter()
+                .any(|item| matches!(item.event, Event::UserSteered { .. })),
+            "{invalid}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn durable_steer_stream_ack_waits_for_receipt_commit_before_publishing() {
+    use sea_orm::{ConnectionTrait, TransactionTrait};
+    let (directory, db, sink, session_id) = seeded_sink().await;
+    let (admission, row) = pending_worker_steer(&db, session_id).await;
+    insert_running_steer_target(&db, &admission).await;
+    sink.set_turn(admission.expected_turn_id);
+    let writer = sea_orm::Database::connect(format!(
+        "sqlite://{}?mode=rwc",
+        directory.path().join("t.db").display(),
+    ))
+    .await
+    .unwrap();
+    let transaction = writer.begin().await.unwrap();
+    transaction
+        .execute_unprepared(
+            "UPDATE session SET unrecognized_event_count = unrecognized_event_count",
+        )
+        .await
+        .unwrap();
+    let (mut live, _) = sink.bus.attach(session_id);
+    let mut emitting = tokio::spawn(async move {
+        sink.emit(HarnessEvent::UserSteered {
+            text: row.message,
+            correlation_uuid: admission.correlation_uuid,
+        })
+        .await;
+    });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut emitting)
+            .await
+            .is_err()
+    );
+    assert!(matches!(
+        live.try_recv(),
+        Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+    ));
+    transaction.rollback().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), emitting)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        tidebreak_core::db::code::list_queued_turns(&db, &OwnerId::local(), session_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    let events = list_events(&db, &OwnerId::local(), session_id, 0, MAX_REPLAY_EVENTS)
+        .await
+        .unwrap()
+        .events;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|item| matches!(item.event, Event::UserSteered { .. }))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn durable_steer_native_ack_after_handoff_cannot_settle_the_receipt() {
+    use tidebreak_core::code::ExternalMessageRecord;
+    let (_directory, db, _, session_id) = seeded_session(HarnessKind::Codex, None).await;
+    let (admission, row) = pending_worker_steer(&db, session_id).await;
+    insert_running_steer_target(&db, &admission).await;
+    let engine = Arc::new(SteerControlHarness::new(SteerControlAnswer::Ack));
+    let (reply, response) = oneshot::channel();
+    let control = {
+        let engine = Arc::clone(&engine);
+        let admission = admission.clone();
+        tokio::spawn(async move {
+            apply_control(
+                engine.as_ref(),
+                WorkerCommand::Steer {
+                    expected_turn_id: admission.expected_turn_id,
+                    message: row.message,
+                    admission: Some(admission.clone()),
+                    reply,
+                },
+                Some(admission.expected_turn_id),
+                None,
+            )
+            .await;
+        })
+    };
+    engine.entered.notified().await;
+    tidebreak_core::db::code::bump_spawn_epoch(&db, session_id, None)
+        .await
+        .unwrap();
+    engine.acknowledge.notify_one();
+    assert!(matches!(
+        response.await.unwrap(),
+        Err(WorkerError::Failed(_))
+    ));
+    control.await.unwrap();
+    assert_eq!(
+        engine.events.lock().unwrap().len(),
+        1,
+        "native ACK was delivered"
+    );
+    assert!(matches!(
+        worker_steer_receipt(&admission).await,
+        ExternalMessageRecord::Replay {
+            admission: None,
+            ..
+        }
+    ));
+    assert_eq!(
+        tidebreak_core::db::code::list_queued_turns(&db, &admission.owner, session_id)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(queued_turn_head(&db, &admission.owner, session_id)
+        .await
+        .unwrap()
+        .is_none());
+}

--- a/crates/tidebreak-server/src/obo_gateway/external/tests.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external/tests.rs
@@ -357,6 +357,9 @@ async fn sandbox_admission_requires_durable_external_consent_before_accepting_wo
                 event_id: "Ev1".into(),
                 channel_ts: "1.0".into(),
                 actor: tidebreak_core::TurnActor::default(),
+                steer: false,
+                expected_turn_id: None,
+                correlation_uuid: None,
                 context: None,
             },
         )
@@ -457,6 +460,9 @@ async fn sandbox_admission_requires_durable_external_consent_before_accepting_wo
                 event_id: "EvBeforeRevocation".into(),
                 channel_ts: "1.0".into(),
                 actor: tidebreak_core::TurnActor::default(),
+                steer: false,
+                expected_turn_id: None,
+                correlation_uuid: None,
                 context: None,
             },
         )

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -834,7 +834,12 @@ impl HarnessSession for ScriptedSession {
         if let Some(detail) = &self.steering_rejection {
             return Err(HarnessError::SteeringRejected(detail.clone()));
         }
-        self.sink.emit(HarnessEvent::UserSteered { text }).await;
+        self.sink
+            .emit(HarnessEvent::UserSteered {
+                text,
+                correlation_uuid: None,
+            })
+            .await;
         Ok(())
     }
 

--- a/crates/tidebreak-supervised-agent/src/drive.rs
+++ b/crates/tidebreak-supervised-agent/src/drive.rs
@@ -14,7 +14,7 @@
 //!   that cannot reach its supervisor for ten minutes is not supervised and
 //!   must not pretend to be.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -28,7 +28,9 @@ use crate::wip::{self, CheckpointPoint, WipContext};
 use crate::wire::{EmbeddedEngineRegistration, SupervisorMessage, SupervisorPoll};
 use crate::{EXIT_CONTROL_FATAL, EXIT_ENGINE_FAILED};
 use tidebreak_core::code::supervisor_tools::is_result_frame;
-use tidebreak_core::code::supervisor_tools::{decode_steer_frame, is_steer_frame};
+use tidebreak_core::code::supervisor_tools::{
+    decode_steer_frame, is_steer_frame, SupervisorSteerFrame,
+};
 
 /// Consecutive retryable poll failures before the agent gives up.
 ///
@@ -104,6 +106,8 @@ pub struct Driver<E> {
     sandbox_id: Option<String>,
     /// A fresh process identity fences inbox redelivery after a pod restart.
     runtime_id: uuid::Uuid,
+    /// Original targets whose native acceptance is still unknown in this turn.
+    pending_steers: HashMap<uuid::Uuid, (i64, SupervisorSteerFrame)>,
 }
 
 enum SteerFrameStep {
@@ -144,6 +148,7 @@ impl<E: Engine> Driver<E> {
             embedded_engine: None,
             sandbox_id: inputs.sandbox_id.clone(),
             runtime_id: uuid::Uuid::new_v4(),
+            pending_steers: HashMap::new(),
         }
     }
 
@@ -345,6 +350,7 @@ impl<E: Engine> Driver<E> {
         }
 
         let end = loop {
+            self.drain_steer_acks(handle.as_mut());
             let step = tokio::select! {
                 end = handle.wait() => TurnStep::End(end),
                 () = tokio::time::sleep(self.poll_interval) => TurnStep::Tick,
@@ -364,6 +370,10 @@ impl<E: Engine> Driver<E> {
             }
         };
 
+        // The native stream can acknowledge steering while its terminal result arrives.
+        // Flush that evidence before reporting completion, then forget unresolved targets.
+        self.drain_steer_acks(handle.as_mut());
+        self.pending_steers.clear();
         let record = handle.assistant_record();
         match end {
             TurnEnd::Interrupted => {
@@ -478,6 +488,35 @@ impl<E: Engine> Driver<E> {
         None
     }
 
+    fn emit_steer_ack(&mut self, seq: i64, frame: &SupervisorSteerFrame) {
+        self.outbox.push(
+            "steer_ack",
+            serde_json::json!({
+                "seq": seq,
+                "expected_turn_id": frame.expected_turn_id,
+                "sandbox_id": frame.sandbox_id,
+                "runtime_id": frame.runtime_id,
+                "native_turn": frame.native_turn,
+                "correlation_uuid": frame.correlation_uuid,
+            }),
+        );
+    }
+
+    /// Resolve only acknowledgments for validated requests from this runtime turn.
+    fn drain_steer_acks(&mut self, handle: &mut dyn TurnHandle) {
+        for correlation in handle.drain_steer_acks() {
+            let Some((seq, frame)) = self.pending_steers.remove(&correlation) else {
+                continue;
+            };
+            if frame.native_turn == self.turn
+                && self.sandbox_id.as_deref() == Some(frame.sandbox_id.as_str())
+                && uuid::Uuid::parse_str(&frame.runtime_id).ok() == Some(self.runtime_id)
+            {
+                self.emit_steer_ack(seq, &frame);
+            }
+        }
+    }
+
     /// Delivers exactly one framed steering admission.
     async fn steer_frame(
         &mut self,
@@ -526,25 +565,26 @@ impl<E: Engine> Driver<E> {
             );
             return SteerFrameStep::Continue;
         }
+        let correlation_uuid = correlation_uuid.expect("a validated frame has a correlation");
+        if self.pending_steers.contains_key(&correlation_uuid) {
+            // A transport replay cannot replace or resend the first admitted instruction.
+            let message = self.inbox.pop_front().expect("front was just observed");
+            self.delivered_through = Some(message.seq);
+            self.advance_acknowledged_frames();
+            return SteerFrameStep::Continue;
+        }
+        self.pending_steers
+            .insert(correlation_uuid, (message.seq, frame.clone()));
         match handle
-            .steer_with_correlation(frame.body.clone(), correlation_uuid)
+            .steer_with_correlation(frame.body.clone(), Some(correlation_uuid))
             .await
         {
             SteerOutcome::Delivered => {
+                self.pending_steers.remove(&correlation_uuid);
                 let message = self.inbox.pop_front().expect("front was just observed");
                 self.delivered_through = Some(message.seq);
                 self.advance_acknowledged_frames();
-                self.outbox.push(
-                    "steer_ack",
-                    serde_json::json!({
-                        "seq": message.seq,
-                        "expected_turn_id": frame.expected_turn_id,
-                    "sandbox_id": frame.sandbox_id,
-                    "runtime_id": frame.runtime_id,
-                    "native_turn": frame.native_turn,
-                        "correlation_uuid": frame.correlation_uuid,
-                    }),
-                );
+                self.emit_steer_ack(message.seq, &frame);
                 SteerFrameStep::Continue
             }
             SteerOutcome::Unacknowledged => {
@@ -565,6 +605,7 @@ impl<E: Engine> Driver<E> {
                 SteerFrameStep::Continue
             }
             SteerOutcome::Refused => {
+                self.pending_steers.remove(&correlation_uuid);
                 // The engine refused; consume the frame so it can never run as
                 // an ordinary text turn beside the server's durable row. The
                 // server owns queue fallback through the original queue id.
@@ -586,6 +627,7 @@ impl<E: Engine> Driver<E> {
                 SteerFrameStep::Continue
             }
             SteerOutcome::Ended(end) => {
+                self.pending_steers.remove(&correlation_uuid);
                 let message = self.inbox.pop_front().expect("front was just observed");
                 self.delivered_through = Some(message.seq);
                 self.advance_acknowledged_frames();
@@ -977,6 +1019,8 @@ mod tests {
         refuse_steer: AtomicBool,
         correlated_outcome: Mutex<Option<SteerOutcome>>,
         correlated_calls: AtomicUsize,
+        steer_acks: Mutex<Vec<uuid::Uuid>>,
+        steer_acks_on_end: Mutex<Vec<uuid::Uuid>>,
         ends: tokio::sync::Mutex<mpsc::UnboundedReceiver<TurnEnd>>,
         end_sender: mpsc::UnboundedSender<TurnEnd>,
         records: Mutex<VecDeque<Option<AssistantRecord>>>,
@@ -997,6 +1041,8 @@ mod tests {
                     refuse_steer: AtomicBool::new(false),
                     correlated_outcome: Mutex::new(None),
                     correlated_calls: AtomicUsize::new(0),
+                    steer_acks: Mutex::new(Vec::new()),
+                    steer_acks_on_end: Mutex::new(Vec::new()),
                     ends: tokio::sync::Mutex::new(ends),
                     end_sender,
                     records: Mutex::new(VecDeque::new()),
@@ -1026,9 +1072,12 @@ mod tests {
     impl TurnHandle for MockTurnHandle {
         async fn wait(&mut self) -> TurnEnd {
             let mut ends = self.state.ends.lock().await;
-            ends.recv().await.unwrap_or(TurnEnd::Fatal {
+            let ended = ends.recv().await.unwrap_or(TurnEnd::Fatal {
                 message: "the scripted engine hung up".to_owned(),
-            })
+            });
+            let acks = std::mem::take(&mut *self.state.steer_acks_on_end.lock().unwrap());
+            self.state.steer_acks.lock().unwrap().extend(acks);
+            ended
         }
 
         async fn steer(&mut self, body: String) -> SteerOutcome {
@@ -1066,6 +1115,10 @@ mod tests {
 
         async fn interrupt(&mut self) {
             self.state.end_sender.send(TurnEnd::Interrupted).unwrap();
+        }
+
+        fn drain_steer_acks(&mut self) -> Vec<uuid::Uuid> {
+            std::mem::take(&mut *self.state.steer_acks.lock().unwrap())
         }
 
         fn assistant_record(&mut self) -> Option<AssistantRecord> {
@@ -1209,6 +1262,172 @@ mod tests {
             assert_eq!(events[0].payload["sandbox_id"], frame.sandbox_id);
             assert_eq!(events[0].payload["native_turn"], frame.native_turn);
             assert_eq!(events[0].payload["runtime_id"], frame.runtime_id);
+        }
+    }
+
+    #[tokio::test]
+    async fn delayed_steering_ack_preserves_target_and_ignores_duplicate_or_unknown_ids() {
+        let engine = MockEngine::new();
+        *engine.state.correlated_outcome.lock().unwrap() = Some(SteerOutcome::Unacknowledged);
+        let mut driver = driver(engine.clone(), "http://unused", &inputs("turn", None));
+        driver.sandbox_id = Some("018f0000-0000-7000-8000-000000000000".into());
+        let message = steering_message(1, 1, driver.runtime_id);
+        let frame = decode_steer_frame(&message.body).unwrap();
+        let correlation = frame.correlation_uuid.parse::<uuid::Uuid>().unwrap();
+        let mut handle = MockTurnHandle {
+            state: Arc::clone(&engine.state),
+        };
+        driver.inbox.push_back(message.clone());
+        assert!(driver.steer_pending(&mut handle).await.is_none());
+        assert_eq!(driver.outbox.take_batch()[0].kind, "steer_unacknowledged");
+        assert_eq!(driver.pending_steers.len(), 1);
+
+        // A duplicate transport delivery must not replace the original target or text.
+        let mut replay_frame = frame.clone();
+        replay_frame.expected_turn_id = uuid::Uuid::new_v4().to_string();
+        replay_frame.body = "changed replay".into();
+        let mut replay = message;
+        replay.seq = 2;
+        replay.body = tidebreak_core::code::supervisor_tools::encode_steer_frame(&replay_frame);
+        driver.inbox.push_back(replay);
+        assert!(driver.steer_pending(&mut handle).await.is_none());
+        assert_eq!(engine.state.correlated_calls.load(Ordering::SeqCst), 1);
+        engine.state.steer_acks.lock().unwrap().extend([
+            uuid::Uuid::new_v4(),
+            correlation,
+            correlation,
+        ]);
+        driver.drain_steer_acks(&mut handle);
+        let events = driver.outbox.take_batch();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "steer_ack");
+        assert_eq!(events[0].payload["seq"], 1);
+        assert_eq!(
+            events[0].payload["expected_turn_id"],
+            frame.expected_turn_id
+        );
+        assert_eq!(
+            events[0].payload["correlation_uuid"],
+            frame.correlation_uuid
+        );
+        assert_eq!(events[0].payload["sandbox_id"], frame.sandbox_id);
+        assert_eq!(events[0].payload["runtime_id"], frame.runtime_id);
+        assert_eq!(events[0].payload["native_turn"], frame.native_turn);
+        assert!(driver.pending_steers.is_empty());
+        engine.state.steer_acks.lock().unwrap().push(correlation);
+        driver.drain_steer_acks(&mut handle);
+        assert!(driver.outbox.take_batch().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delayed_acks_cannot_settle_stale_or_already_resolved_frames() {
+        for outcome in [SteerOutcome::Delivered, SteerOutcome::Refused] {
+            let engine = MockEngine::new();
+            *engine.state.correlated_outcome.lock().unwrap() = Some(outcome);
+            let mut driver = driver(engine.clone(), "http://unused", &inputs("turn", None));
+            driver.sandbox_id = Some("018f0000-0000-7000-8000-000000000000".into());
+            let message = steering_message(1, 1, driver.runtime_id);
+            let correlation = decode_steer_frame(&message.body)
+                .unwrap()
+                .correlation_uuid
+                .parse::<uuid::Uuid>()
+                .unwrap();
+            let stale = steering_message(2, 99, driver.runtime_id);
+            let stale_correlation = decode_steer_frame(&stale.body)
+                .unwrap()
+                .correlation_uuid
+                .parse::<uuid::Uuid>()
+                .unwrap();
+            let mut handle = MockTurnHandle {
+                state: Arc::clone(&engine.state),
+            };
+            driver.inbox.extend([message, stale]);
+            assert!(driver.steer_pending(&mut handle).await.is_none());
+            driver.outbox.take_batch();
+            assert!(driver.pending_steers.is_empty());
+            engine
+                .state
+                .steer_acks
+                .lock()
+                .unwrap()
+                .extend([correlation, stale_correlation]);
+            driver.drain_steer_acks(&mut handle);
+            assert!(driver.outbox.take_batch().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn running_ticks_flush_late_acks_and_terminal_drain_precedes_completion() {
+        for at_terminal in [false, true] {
+            let (state, url) = start_supervisor().await;
+            let engine = MockEngine::new();
+            *engine.state.correlated_outcome.lock().unwrap() = Some(SteerOutcome::Unacknowledged);
+            let mut driver = driver(engine.clone(), &url, &inputs("turn", None));
+            driver.sandbox_id = Some("018f0000-0000-7000-8000-000000000000".into());
+            let message = steering_message(1, 1, driver.runtime_id);
+            let correlation = decode_steer_frame(&message.body)
+                .unwrap()
+                .correlation_uuid
+                .parse::<uuid::Uuid>()
+                .unwrap();
+            // This second request never acknowledges; turn completion must not invent one.
+            driver
+                .inbox
+                .extend([message, steering_message(2, 1, driver.runtime_id)]);
+            let run = tokio::spawn(async move {
+                driver
+                    .run_turn(TurnRequest {
+                        turn: 1,
+                        source: TurnSource::SpawnTask,
+                        input: "work".into(),
+                    })
+                    .await
+                    .unwrap();
+                driver
+            });
+            wait_for(&state, |supervisor| {
+                supervisor
+                    .events
+                    .iter()
+                    .filter(|(kind, _)| kind == "steer_unacknowledged")
+                    .count()
+                    == 2
+            })
+            .await;
+            if at_terminal {
+                engine
+                    .state
+                    .steer_acks_on_end
+                    .lock()
+                    .unwrap()
+                    .push(correlation);
+            } else {
+                engine.state.steer_acks.lock().unwrap().push(correlation);
+                wait_for(&state, |supervisor| {
+                    supervisor
+                        .events
+                        .iter()
+                        .any(|(kind, _)| kind == "steer_ack")
+                })
+                .await;
+            }
+            engine.finish(TurnEnd::Completed { success: true });
+            let driver = run.await.unwrap();
+            assert!(driver.pending_steers.is_empty());
+            let kinds = event_kinds(&state);
+            assert_eq!(
+                kinds
+                    .iter()
+                    .filter(|kind| kind.as_str() == "steer_ack")
+                    .count(),
+                1
+            );
+            let ack_position = kinds.iter().position(|kind| kind == "steer_ack").unwrap();
+            let completed_position = kinds
+                .iter()
+                .position(|kind| kind == "turn_completed")
+                .unwrap();
+            assert!(ack_position < completed_position);
         }
     }
 

--- a/crates/tidebreak-supervised-agent/src/drive.rs
+++ b/crates/tidebreak-supervised-agent/src/drive.rs
@@ -28,6 +28,7 @@ use crate::wip::{self, CheckpointPoint, WipContext};
 use crate::wire::{EmbeddedEngineRegistration, SupervisorMessage, SupervisorPoll};
 use crate::{EXIT_CONTROL_FATAL, EXIT_ENGINE_FAILED};
 use tidebreak_core::code::supervisor_tools::is_result_frame;
+use tidebreak_core::code::supervisor_tools::{decode_steer_frame, is_steer_frame};
 
 /// Consecutive retryable poll failures before the agent gives up.
 ///
@@ -98,6 +99,16 @@ pub struct Driver<E> {
     /// The installed engine to register on every poll, when the environment
     /// admitted an identity for this run.
     embedded_engine: Option<EmbeddedEngineRegistration>,
+    /// Sandbox identifier the environment assigned this incarnation; a
+    /// steering frame from any other sandbox is stale and never applied.
+    sandbox_id: Option<String>,
+    /// A fresh process identity fences inbox redelivery after a pod restart.
+    runtime_id: uuid::Uuid,
+}
+
+enum SteerFrameStep {
+    Continue,
+    End(TurnEnd),
 }
 
 impl<E: Engine> Driver<E> {
@@ -131,6 +142,8 @@ impl<E: Engine> Driver<E> {
             push_denied: inputs.forge_push_denied,
             wip: None,
             embedded_engine: None,
+            sandbox_id: inputs.sandbox_id.clone(),
+            runtime_id: uuid::Uuid::new_v4(),
         }
     }
 
@@ -199,6 +212,8 @@ impl<E: Engine> Driver<E> {
             serde_json::json!({
                 "harness": "custom",
                 "agent": "tidebreak-supervised-agent",
+                "steering_protocol": 1,
+                "runtime_id": self.runtime_id.to_string(),
             }),
         );
         if self.push_denied && !self.research {
@@ -236,8 +251,37 @@ impl<E: Engine> Driver<E> {
         self.max_turns.is_none_or(|max| turn <= max)
     }
 
+    /// An idle frame may be a replay whose native acknowledgment was lost.
+    /// Consume its transport entry without releasing the server's queue row.
+    fn consume_idle_steer_frames(&mut self) {
+        for message in &self.inbox {
+            if self.processed_frames.contains(&message.seq) || !is_steer_frame(&message.body) {
+                continue;
+            }
+            let payload = match decode_steer_frame(&message.body) {
+                Some(frame) => serde_json::json!({
+                    "seq": message.seq,
+                    "expected_turn_id": frame.expected_turn_id,
+                    "sandbox_id": frame.sandbox_id,
+                    "runtime_id": frame.runtime_id,
+                    "native_turn": frame.native_turn,
+                    "correlation_uuid": frame.correlation_uuid,
+                    "reason": "turn_not_running",
+                }),
+                None => serde_json::json!({
+                    "seq": message.seq,
+                    "reason": "malformed_steer_frame",
+                }),
+            };
+            self.outbox.push("steer_unacknowledged", payload);
+            self.processed_frames.insert(message.seq);
+        }
+        self.advance_acknowledged_frames();
+    }
+
     /// Picks the next turn, or nothing.
-    fn decide(&self) -> NextAction {
+    fn decide(&mut self) -> NextAction {
+        self.consume_idle_steer_frames();
         if !self.budget_allows(self.turn) {
             // The budget is spent: park idle and keep polling, matching the
             // spawn contract. The endpoint decides what happens next.
@@ -254,7 +298,7 @@ impl<E: Engine> Driver<E> {
             .inbox
             .iter()
             .filter(|message| !self.processed_frames.contains(&message.seq))
-            .map(|message| message.body.as_str())
+            .map(|message| message.body.clone())
             .collect::<Vec<_>>();
         if !input.is_empty() {
             return NextAction::Run(TurnRequest {
@@ -408,9 +452,16 @@ impl<E: Engine> Driver<E> {
     /// Delivers pending inbox messages into a running turn, in order.
     async fn steer_pending(&mut self, handle: &mut dyn TurnHandle) -> Option<TurnEnd> {
         while let Some(message) = self.inbox.front() {
+            if is_steer_frame(&message.body) {
+                let message = message.clone();
+                match self.steer_frame(handle, &message).await {
+                    SteerFrameStep::Continue => {}
+                    SteerFrameStep::End(end) => return Some(end),
+                }
+                continue;
+            }
             if message.interrupt {
-                // The body is not delivered into this turn; it stays queued
-                // and opens the next one.
+                // Ordinary interrupt input opens the next turn.
                 handle.interrupt().await;
                 return None;
             }
@@ -420,11 +471,139 @@ impl<E: Engine> Driver<E> {
                     self.delivered_through = Some(message.seq);
                     self.advance_acknowledged_frames();
                 }
-                SteerOutcome::Refused => return None,
+                SteerOutcome::Refused | SteerOutcome::Unacknowledged => return None,
                 SteerOutcome::Ended(end) => return Some(end),
             }
         }
         None
+    }
+
+    /// Delivers exactly one framed steering admission.
+    async fn steer_frame(
+        &mut self,
+        handle: &mut dyn TurnHandle,
+        message: &SupervisorMessage,
+    ) -> SteerFrameStep {
+        let Some(frame) = decode_steer_frame(&message.body) else {
+            // A malformed reserved frame must not become engine text: dropping
+            // it is safer than letting an unvalidated payload steer the agent.
+            let message = self.inbox.pop_front().expect("front was just observed");
+            self.delivered_through = Some(message.seq);
+            self.advance_acknowledged_frames();
+            self.outbox.push(
+                "steer_refused",
+                serde_json::json!({
+                    "seq": message.seq,
+                    "reason": "malformed_steer_frame",
+                }),
+            );
+            return SteerFrameStep::Continue;
+        };
+        let correlation_uuid = uuid::Uuid::parse_str(&frame.correlation_uuid).ok();
+        let stale = self.sandbox_id.as_deref() != Some(frame.sandbox_id.as_str())
+            || uuid::Uuid::parse_str(&frame.runtime_id).ok() != Some(self.runtime_id)
+            || frame.native_turn != self.turn
+            || correlation_uuid.is_none()
+            || uuid::Uuid::parse_str(&frame.expected_turn_id).is_err();
+        if stale {
+            // Gateway retains the inbox across pod replacements. This frame
+            // may have reached its old turn before that pod lost its receipt.
+            // A stale target proves nothing about its original admission.
+            let message = self.inbox.pop_front().expect("front was just observed");
+            self.delivered_through = Some(message.seq);
+            self.advance_acknowledged_frames();
+            self.outbox.push(
+                "steer_unacknowledged",
+                serde_json::json!({
+                    "seq": message.seq,
+                    "expected_turn_id": frame.expected_turn_id,
+                    "sandbox_id": frame.sandbox_id,
+                    "runtime_id": frame.runtime_id,
+                    "native_turn": frame.native_turn,
+                    "correlation_uuid": frame.correlation_uuid,
+                    "reason": "stale_turn",
+                }),
+            );
+            return SteerFrameStep::Continue;
+        }
+        match handle
+            .steer_with_correlation(frame.body.clone(), correlation_uuid)
+            .await
+        {
+            SteerOutcome::Delivered => {
+                let message = self.inbox.pop_front().expect("front was just observed");
+                self.delivered_through = Some(message.seq);
+                self.advance_acknowledged_frames();
+                self.outbox.push(
+                    "steer_ack",
+                    serde_json::json!({
+                        "seq": message.seq,
+                        "expected_turn_id": frame.expected_turn_id,
+                    "sandbox_id": frame.sandbox_id,
+                    "runtime_id": frame.runtime_id,
+                    "native_turn": frame.native_turn,
+                        "correlation_uuid": frame.correlation_uuid,
+                    }),
+                );
+                SteerFrameStep::Continue
+            }
+            SteerOutcome::Unacknowledged => {
+                let message = self.inbox.pop_front().expect("front was just observed");
+                self.delivered_through = Some(message.seq);
+                self.advance_acknowledged_frames();
+                self.outbox.push(
+                    "steer_unacknowledged",
+                    serde_json::json!({
+                        "seq": message.seq,
+                        "expected_turn_id": frame.expected_turn_id,
+                        "sandbox_id": frame.sandbox_id,
+                    "runtime_id": frame.runtime_id,
+                        "native_turn": frame.native_turn,
+                        "correlation_uuid": frame.correlation_uuid,
+                    }),
+                );
+                SteerFrameStep::Continue
+            }
+            SteerOutcome::Refused => {
+                // The engine refused; consume the frame so it can never run as
+                // an ordinary text turn beside the server's durable row. The
+                // server owns queue fallback through the original queue id.
+                let message = self.inbox.pop_front().expect("front was just observed");
+                self.delivered_through = Some(message.seq);
+                self.advance_acknowledged_frames();
+                self.outbox.push(
+                    "steer_refused",
+                    serde_json::json!({
+                        "seq": message.seq,
+                        "expected_turn_id": frame.expected_turn_id,
+                    "sandbox_id": frame.sandbox_id,
+                    "runtime_id": frame.runtime_id,
+                    "native_turn": frame.native_turn,
+                        "correlation_uuid": frame.correlation_uuid,
+                        "reason": "engine_refused",
+                    }),
+                );
+                SteerFrameStep::Continue
+            }
+            SteerOutcome::Ended(end) => {
+                let message = self.inbox.pop_front().expect("front was just observed");
+                self.delivered_through = Some(message.seq);
+                self.advance_acknowledged_frames();
+                self.outbox.push(
+                    "steer_refused",
+                    serde_json::json!({
+                        "seq": message.seq,
+                        "expected_turn_id": frame.expected_turn_id,
+                    "sandbox_id": frame.sandbox_id,
+                    "runtime_id": frame.runtime_id,
+                    "native_turn": frame.native_turn,
+                        "correlation_uuid": frame.correlation_uuid,
+                        "reason": "turn_ended",
+                    }),
+                );
+                SteerFrameStep::End(end)
+            }
+        }
     }
 
     /// Posts one poll, classifies the outcome, and absorbs instructions.
@@ -672,7 +851,7 @@ impl<E: Engine> Driver<E> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
@@ -796,6 +975,8 @@ mod tests {
         turns: Mutex<Vec<TurnRequest>>,
         steers: Mutex<Vec<String>>,
         refuse_steer: AtomicBool,
+        correlated_outcome: Mutex<Option<SteerOutcome>>,
+        correlated_calls: AtomicUsize,
         ends: tokio::sync::Mutex<mpsc::UnboundedReceiver<TurnEnd>>,
         end_sender: mpsc::UnboundedSender<TurnEnd>,
         records: Mutex<VecDeque<Option<AssistantRecord>>>,
@@ -814,6 +995,8 @@ mod tests {
                     turns: Mutex::new(Vec::new()),
                     steers: Mutex::new(Vec::new()),
                     refuse_steer: AtomicBool::new(false),
+                    correlated_outcome: Mutex::new(None),
+                    correlated_calls: AtomicUsize::new(0),
                     ends: tokio::sync::Mutex::new(ends),
                     end_sender,
                     records: Mutex::new(VecDeque::new()),
@@ -867,6 +1050,20 @@ mod tests {
             SteerOutcome::Delivered
         }
 
+        async fn steer_with_correlation(
+            &mut self,
+            _body: String,
+            _correlation: Option<uuid::Uuid>,
+        ) -> SteerOutcome {
+            self.state.correlated_calls.fetch_add(1, Ordering::SeqCst);
+            self.state
+                .correlated_outcome
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap_or(SteerOutcome::Refused)
+        }
+
         async fn interrupt(&mut self) {
             self.state.end_sender.send(TurnEnd::Interrupted).unwrap();
         }
@@ -887,6 +1084,175 @@ mod tests {
                 state: Arc::clone(&self.state),
             }))
         }
+    }
+
+    fn steering_message(seq: i64, native_turn: u32, runtime_id: uuid::Uuid) -> SupervisorMessage {
+        SupervisorMessage {
+            seq,
+            body: tidebreak_core::code::supervisor_tools::encode_steer_frame(
+                &tidebreak_core::code::supervisor_tools::SupervisorSteerFrame {
+                    expected_turn_id: uuid::Uuid::new_v4().to_string(),
+                    sandbox_id: "018f0000-0000-7000-8000-000000000000".into(),
+                    native_turn,
+                    runtime_id: runtime_id.to_string(),
+                    correlation_uuid: uuid::Uuid::new_v4().to_string(),
+                    body: "change the approach".into(),
+                },
+            ),
+            interrupt: false,
+        }
+    }
+
+    #[test]
+    fn idle_redelivery_stays_unresolved_without_starting_a_turn() {
+        let mut driver = driver(MockEngine::new(), "http://unused", &inputs("turn", None));
+        driver.ran_spawn_task = true;
+        driver
+            .inbox
+            .push_back(steering_message(1, 1, driver.runtime_id));
+        let mut malformed = steering_message(2, 1, driver.runtime_id);
+        malformed.body = format!(
+            "{}invalid",
+            tidebreak_core::code::supervisor_tools::STEER_PREFIX
+        );
+        driver.inbox.push_back(malformed);
+        assert!(matches!(driver.decide(), NextAction::Wait));
+        assert!(driver.inbox.is_empty());
+        assert_eq!(driver.delivered_through, Some(2));
+        let events = driver.outbox.take_batch();
+        assert_eq!(events.len(), 2);
+        assert!(events
+            .iter()
+            .all(|event| event.kind == "steer_unacknowledged"));
+    }
+
+    #[test]
+    fn idle_steering_behind_ordinary_input_does_not_enter_next_turn() {
+        let mut driver = driver(MockEngine::new(), "http://unused", &inputs("turn", None));
+        driver.ran_spawn_task = true;
+        let mut ordinary = steering_message(1, 1, driver.runtime_id);
+        ordinary.body = "ordinary message".into();
+        driver
+            .inbox
+            .extend([ordinary, steering_message(2, 1, driver.runtime_id)]);
+        let NextAction::Run(request) = driver.decide() else {
+            panic!("ordinary input must run")
+        };
+        assert_eq!(request.input, "ordinary message");
+        assert_eq!(driver.delivered_through, None);
+        assert!(driver.processed_frames.contains(&2));
+    }
+
+    #[tokio::test]
+    async fn stale_and_refused_steering_never_reappears_as_input() {
+        let engine = MockEngine::new();
+        let mut driver = driver(engine.clone(), "http://unused", &inputs("turn", None));
+        driver.ran_spawn_task = true;
+        driver.sandbox_id = Some("018f0000-0000-7000-8000-000000000000".into());
+        let mut handle = MockTurnHandle {
+            state: Arc::clone(&engine.state),
+        };
+        driver
+            .inbox
+            .push_back(steering_message(1, 99, driver.runtime_id));
+        assert!(driver.steer_pending(&mut handle).await.is_none());
+        driver
+            .inbox
+            .push_back(steering_message(2, 1, driver.runtime_id));
+        // The mock has no correlated acknowledgment configured.
+        assert!(driver.steer_pending(&mut handle).await.is_none());
+        assert!(engine.state.steers.lock().unwrap().is_empty());
+        assert!(matches!(driver.decide(), NextAction::Wait));
+        assert_eq!(driver.delivered_through, Some(2));
+        let events = driver.outbox.take_batch();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, "steer_unacknowledged");
+        assert_eq!(events[1].kind, "steer_refused");
+        assert_eq!(events[1].payload["native_turn"], 1);
+        assert_eq!(
+            events[1].payload["sandbox_id"],
+            "018f0000-0000-7000-8000-000000000000"
+        );
+    }
+
+    #[tokio::test]
+    async fn only_confirmed_steering_emits_ack_and_unknown_delivery_is_not_replayed() {
+        for (outcome, event_kind) in [
+            (SteerOutcome::Delivered, "steer_ack"),
+            (SteerOutcome::Unacknowledged, "steer_unacknowledged"),
+        ] {
+            let engine = MockEngine::new();
+            *engine.state.correlated_outcome.lock().unwrap() = Some(outcome);
+            let mut driver = driver(engine.clone(), "http://unused", &inputs("turn", None));
+            driver.ran_spawn_task = true;
+            driver.sandbox_id = Some("018f0000-0000-7000-8000-000000000000".into());
+            let mut handle = MockTurnHandle {
+                state: Arc::clone(&engine.state),
+            };
+            let message = steering_message(1, 1, driver.runtime_id);
+            let frame = decode_steer_frame(&message.body).unwrap();
+            driver.inbox.push_back(message);
+            assert!(driver.steer_pending(&mut handle).await.is_none());
+            assert!(matches!(driver.decide(), NextAction::Wait));
+            assert_eq!(driver.delivered_through, Some(1));
+            let events = driver.outbox.take_batch();
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].kind, event_kind);
+            assert_eq!(
+                events[0].payload["correlation_uuid"],
+                frame.correlation_uuid
+            );
+            assert_eq!(
+                events[0].payload["expected_turn_id"],
+                frame.expected_turn_id
+            );
+            assert_eq!(events[0].payload["sandbox_id"], frame.sandbox_id);
+            assert_eq!(events[0].payload["native_turn"], frame.native_turn);
+            assert_eq!(events[0].payload["runtime_id"], frame.runtime_id);
+        }
+    }
+
+    #[tokio::test]
+    async fn redelivery_after_lost_ack_does_not_release_the_original_instruction() {
+        let engine = MockEngine::new();
+        *engine.state.correlated_outcome.lock().unwrap() = Some(SteerOutcome::Delivered);
+        let mut first = driver(engine.clone(), "http://unused", &inputs("turn", None));
+        first.sandbox_id = Some("018f0000-0000-7000-8000-000000000000".into());
+        let message = steering_message(1, 1, first.runtime_id);
+        let mut handle = MockTurnHandle {
+            state: Arc::clone(&engine.state),
+        };
+        first.inbox.push_back(message.clone());
+        assert!(first.steer_pending(&mut handle).await.is_none());
+        assert_eq!(first.outbox.take_batch()[0].kind, "steer_ack");
+        // The pod dies before posting that acknowledgment and transport cursor.
+        // Gateway has not observed turn_started either, so it restarts at the same turn.
+        drop(first);
+        let mut replacement = driver(engine.clone(), "http://unused", &inputs("turn", None));
+        replacement.sandbox_id = Some("018f0000-0000-7000-8000-000000000000".into());
+        assert_eq!(replacement.turn, 1);
+        assert_ne!(
+            replacement.runtime_id,
+            decode_steer_frame(&message.body)
+                .unwrap()
+                .runtime_id
+                .parse::<uuid::Uuid>()
+                .unwrap()
+        );
+        replacement.ran_spawn_task = true;
+        replacement.inbox.push_back(message);
+        assert!(replacement.steer_pending(&mut handle).await.is_none());
+        assert_eq!(
+            replacement.outbox.take_batch()[0].kind,
+            "steer_unacknowledged"
+        );
+        assert!(matches!(replacement.decide(), NextAction::Wait));
+        assert_eq!(replacement.delivered_through, Some(1));
+        assert_eq!(
+            engine.state.correlated_calls.load(Ordering::SeqCst),
+            1,
+            "a replacement process must not repeat native delivery"
+        );
     }
 
     fn inputs(mode: &str, max_turns: Option<&str>) -> Inputs {
@@ -1155,6 +1521,13 @@ mod tests {
         run.await.unwrap().unwrap();
         let kinds = event_kinds(&state);
         assert_eq!(kinds[0], "supervisor_started");
+        let started = event_payload(&state, "supervisor_started", 0);
+        assert_eq!(started["steering_protocol"], 1);
+        assert!(
+            !uuid::Uuid::parse_str(started["runtime_id"].as_str().unwrap())
+                .unwrap()
+                .is_nil()
+        );
         assert_eq!(kinds.last().map(String::as_str), Some("supervisor_stopped"));
         assert_eq!(
             event_payload(&state, "supervisor_stopped", 0)["reason"],

--- a/crates/tidebreak-supervised-agent/src/engine.rs
+++ b/crates/tidebreak-supervised-agent/src/engine.rs
@@ -62,6 +62,8 @@ pub enum SteerOutcome {
     Delivered,
     /// The engine accepts input only between turns.
     Refused,
+    /// Delivery may have reached the engine, but no acknowledgment arrived.
+    Unacknowledged,
     /// The turn ended before the message reached it.
     Ended(TurnEnd),
 }
@@ -79,9 +81,28 @@ pub trait TurnHandle: Send {
     /// Delivers a message into the running turn.
     ///
     /// Completion must win when it races delivery. Returning
-    /// [`SteerOutcome::Ended`] keeps the message unacknowledged so the next
-    /// turn receives it.
-    async fn steer(&mut self, body: String) -> SteerOutcome;
+    /// [`SteerOutcome::Ended`] keeps ordinary input queued for the next turn.
+    /// Reserved steering frames use the server's durable queue instead.
+    async fn steer(&mut self, body: String) -> SteerOutcome {
+        let _ = body;
+        SteerOutcome::Refused
+    }
+
+    /// Delivers a message with the caller's admission correlation id.
+    ///
+    /// The default refuses correlated delivery. An adapter must return
+    /// `Delivered` only after the harness acknowledges the same correlation.
+    async fn steer_with_correlation(
+        &mut self,
+        body: String,
+        correlation_uuid: Option<uuid::Uuid>,
+    ) -> SteerOutcome {
+        if correlation_uuid.is_some() {
+            SteerOutcome::Refused
+        } else {
+            self.steer(body).await
+        }
+    }
 
     /// Stops the turn. The next [`TurnHandle::wait`] reports how it ended —
     /// usually [`TurnEnd::Interrupted`], but a turn that finished first keeps

--- a/crates/tidebreak-supervised-agent/src/engine.rs
+++ b/crates/tidebreak-supervised-agent/src/engine.rs
@@ -104,6 +104,12 @@ pub trait TurnHandle: Send {
         }
     }
 
+    /// Drain native acknowledgments that arrive after a steering request returns.
+    /// Only correlated acceptance belongs here; a write or timeout proves nothing.
+    fn drain_steer_acks(&mut self) -> Vec<uuid::Uuid> {
+        Vec::new()
+    }
+
     /// Stops the turn. The next [`TurnHandle::wait`] reports how it ended —
     /// usually [`TurnEnd::Interrupted`], but a turn that finished first keeps
     /// its own outcome.

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -389,6 +389,7 @@ enum Terminal {
 struct TurnSink {
     last: Mutex<Option<Terminal>>,
     assistant: Mutex<AssistantBuffer>,
+    steer_acks: Mutex<Vec<uuid::Uuid>>,
 }
 
 #[derive(Default)]
@@ -402,6 +403,7 @@ impl TurnSink {
     fn clear(&self) {
         *self.last.lock().unwrap() = None;
         *self.assistant.lock().unwrap() = AssistantBuffer::default();
+        self.steer_acks.lock().unwrap().clear();
     }
 
     fn read(&self) -> Option<Terminal> {
@@ -463,6 +465,10 @@ impl HarnessEventSink for TurnSink {
             HarnessEvent::TurnInterrupted => {
                 *self.last.lock().unwrap() = Some(Terminal::Interrupted);
             }
+            HarnessEvent::UserSteered {
+                correlation_uuid: Some(correlation_uuid),
+                ..
+            } => self.steer_acks.lock().unwrap().push(correlation_uuid),
             HarnessEvent::AssistantMessage {
                 text,
                 parent_call_id: None,
@@ -595,6 +601,10 @@ impl TurnHandle for HarnessTurn {
         let _ = self.session.interrupt().await;
     }
 
+    fn drain_steer_acks(&mut self) -> Vec<uuid::Uuid> {
+        std::mem::take(&mut *self.sink.steer_acks.lock().unwrap())
+    }
+
     fn assistant_record(&mut self) -> Option<AssistantRecord> {
         self.sink.take_record()
     }
@@ -659,6 +669,20 @@ mod tests {
 
         async fn steer(&self, _text: String) -> Result<(), HarnessError> {
             Err(HarnessError::SteeringUnsupported)
+        }
+
+        async fn steer_with_correlation(
+            &self,
+            text: String,
+            correlation_uuid: Option<uuid::Uuid>,
+        ) -> Result<(), HarnessError> {
+            if correlation_uuid.is_some() {
+                Err(HarnessError::Other(
+                    "timed out waiting for native acknowledgment".into(),
+                ))
+            } else {
+                self.steer(text).await
+            }
         }
 
         fn resume_ref(&self) -> Option<String> {
@@ -1041,6 +1065,52 @@ mod tests {
             SteerOutcome::Ended(TurnEnd::Completed { success: true })
         );
         assert_eq!(turn.wait().await, TurnEnd::Completed { success: true });
+    }
+
+    #[tokio::test]
+    async fn a_timed_out_steer_can_drain_its_later_native_acknowledgment() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            events: vec![HarnessEvent::TurnInterrupted],
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: true,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("work")).await.unwrap();
+        let correlation = uuid::Uuid::new_v4();
+        assert_eq!(
+            turn.steer_with_correlation("guidance".into(), Some(correlation))
+                .await,
+            SteerOutcome::Unacknowledged
+        );
+        assert!(turn.drain_steer_acks().is_empty());
+        engine
+            .sink
+            .emit(HarnessEvent::UserSteered {
+                text: "uncorrelated".into(),
+                correlation_uuid: None,
+            })
+            .await;
+        assert!(turn.drain_steer_acks().is_empty());
+        engine
+            .sink
+            .emit(HarnessEvent::UserSteered {
+                text: "guidance".into(),
+                correlation_uuid: Some(correlation),
+            })
+            .await;
+        assert_eq!(turn.drain_steer_acks(), vec![correlation]);
+        assert!(turn.drain_steer_acks().is_empty());
+        engine
+            .sink
+            .emit(HarnessEvent::UserSteered {
+                text: "stale".into(),
+                correlation_uuid: Some(correlation),
+            })
+            .await;
+        engine.sink.clear();
+        assert!(turn.drain_steer_acks().is_empty());
+        turn.interrupt().await;
+        assert_eq!(turn.wait().await, TurnEnd::Interrupted);
     }
 
     #[tokio::test]

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -495,7 +495,7 @@ impl HarnessTurn {
             Err(error) => {
                 return TurnEnd::Fatal {
                     message: format!("the engine turn task failed: {error}"),
-                }
+                };
             }
             // Every launch or turn error is fatal here, `ResumeLost`
             // included: the engine's own session store is the only
@@ -504,7 +504,7 @@ impl HarnessTurn {
             Ok(Err(error)) => {
                 return TurnEnd::Fatal {
                     message: error.to_string(),
-                }
+                };
             }
             Ok(Ok(outcome)) => outcome,
         };
@@ -549,6 +549,14 @@ impl TurnHandle for HarnessTurn {
     }
 
     async fn steer(&mut self, body: String) -> SteerOutcome {
+        self.steer_with_correlation(body, None).await
+    }
+
+    async fn steer_with_correlation(
+        &mut self,
+        body: String,
+        correlation_uuid: Option<uuid::Uuid>,
+    ) -> SteerOutcome {
         if let Some(ended) = &self.ended {
             return SteerOutcome::Ended(ended.clone());
         }
@@ -556,20 +564,28 @@ impl TurnHandle for HarnessTurn {
         let joined = tokio::select! {
             biased;
             joined = &mut self.run => joined,
-            result = session.steer(body) => {
-                // Any refusal — an engine with no mid-turn channel, or one
-                // that rejected this steer — keeps the message queued for the
-                // next turn.
-                return if result.is_ok() {
-                    SteerOutcome::Delivered
-                } else {
-                    SteerOutcome::Refused
+            result = session.steer_with_correlation(body, correlation_uuid) => {
+                // Only an explicit refusal permits durable queue fallback.
+                // Other errors may follow a write whose acknowledgment was lost.
+                return match result {
+                    Ok(()) => SteerOutcome::Delivered,
+                    Err(HarnessError::SteeringUnsupported | HarnessError::SteeringRejected(_)) => {
+                        SteerOutcome::Refused
+                    }
+                    Err(_) if correlation_uuid.is_some() => SteerOutcome::Unacknowledged,
+                    Err(_) => SteerOutcome::Refused,
                 };
             }
         };
         let ended = self.conclude(joined);
         self.ended = Some(ended.clone());
-        SteerOutcome::Ended(ended)
+        if correlation_uuid.is_some() {
+            // The request may already be written when native completion wins.
+            // Keep its admission unresolved rather than replay its body.
+            SteerOutcome::Unacknowledged
+        } else {
+            SteerOutcome::Ended(ended)
+        }
     }
 
     async fn interrupt(&mut self) {
@@ -1023,6 +1039,24 @@ mod tests {
         assert_eq!(
             turn.steer("too late".to_owned()).await,
             SteerOutcome::Ended(TurnEnd::Completed { success: true })
+        );
+        assert_eq!(turn.wait().await, TurnEnd::Completed { success: true });
+    }
+
+    #[tokio::test]
+    async fn native_completion_during_correlated_delivery_does_not_prove_refusal() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            events: vec![completed_event()],
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let mut engine = engine_over(adapter, probe(true));
+        let mut turn = engine.start_turn(request("go")).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(
+            turn.steer_with_correlation("guidance".into(), Some(uuid::Uuid::new_v4()))
+                .await,
+            SteerOutcome::Unacknowledged,
         );
         assert_eq!(turn.wait().await, TurnEnd::Completed { success: true });
     }

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -827,12 +827,53 @@ access before admitting a repository, including a cached checkout.
 Decision [0094](decisions/0094-repository-optional-conversations-on-the-internal-engine.md)
 keeps the current list of work that remains for self-drive child sessions.
 
+## Explicit steering admission
+
+The messages endpoint accepts optional `steer`, `expected_turn_id`, and
+`correlation_uuid` fields. Existing clients keep queue-default behavior. To ask
+for mid-turn delivery, set `steer: true` and name the active Tidebreak turn in
+`expected_turn_id`. The server assigns a correlation UUID when you omit it.
+The native turn number stays an internal sandbox detail.
+
+To read a result without submitting again, call
+`GET /external/code/sessions/{id}/messages/{event_id}/admission` with the adapter
+token. The response returns `outcome` (`pending`, `steered`, or `queued`), the
+original `turn_id`, `expected_turn_id`, `correlation_uuid`, and `reason`. An
+unknown event or a session outside the grant returns 404.
+
+Each channel `event_id` owns one durable admission. A retry returns the first
+admission's target, correlation, and outcome. It never sends another steering
+request. Reusing a correlation UUID for a different event fails.
+
+An acknowledged native instruction returns `outcome: "steered"` with its
+original turn and correlation. Proven unsupported or stale requests return
+`outcome: "queued"` with `reason: "steer_unsupported"` or `"stale_turn"`; the
+original message can run at a later turn boundary. Successful steering consumes
+that original queue row atomically, so it cannot run a second time.
+
+`reason: "unacknowledged"` means that delivery has not been confirmed. It does
+not promise another execution. The admission remains held until native evidence
+settles it. A sandbox inbox receipt proves only transport storage. A completed
+write, timeout, idle sandbox, or restarted sandbox does not prove that the native
+engine rejected the instruction. Clients must not resend with a new event ID or
+show confirmed delivery from those signals.
+
+Codex supplies native acknowledgments. Harnesses without acknowledged steering
+fall back before dispatch. The sandbox must first advertise `steering_protocol: 1` in its
+`supervisor_started` event with a fresh `runtime_id` UUID for each process;
+older runtimes keep ordinary queue behavior. Sandbox acknowledgments must match
+the stored sandbox, runtime UUID, native turn, Tidebreak turn, and correlation.
+A replacement process cannot consume a frame addressed to its predecessor. A late local acknowledgment can
+settle the original receipt while its worker still owns the turn.
+
+Keep automatic adapter steering disabled until the adapter exposes pending
+admissions and their recovery controls. Native acceptance followed by process
+loss can remain unknown; transport idempotency cannot settle that case.
+
 ## Later
 
-- Steer as an upgrade to the messages endpoint (`steered` as a third
-  outcome), capability-gated per harness, honest rendering ("queued
-  behind the running turn" where mid-turn steer is unsupported) — gated
-  on the reply-during-run signal.
+- Automatic Slack steering, pending-admission recovery, and confirmed delivery
+  rendering, gated on the reply-during-run signal.
 - Slack Code channels as a session surface: one code channel per
   session, `AttentionState` feeding the native status.
 - Durable child wait/resume, the broader sandbox-child tools, and the thread/web tree,


### PR DESCRIPTION
Slack replies during an active turn need a durable result that survives retries without executing the same instruction twice. This adds optional steering admission to the external messages endpoint and a read-only receipt endpoint. Confirmed native delivery consumes the original queue row; proven unsupported or stale delivery retains ordinary queue fallback. Uncertain delivery stays pending.

The server validates the original turn, correlation, worker epoch, and sandbox/runtime identity. Sandbox dispatch requires an advertised protocol and a fresh process UUID. Late local and sandbox acknowledgments settle the original admission. Sandbox settlement preserves the original user text and message ID in the transcript in the same transaction, before advancing the event cursor. Replay does not dispatch or journal the instruction twice.

Validation: 89 focused tests across six crates passed on the initial implementation. Follow-up validation passes all 124 supervised-agent tests, four atomic transcript database tests, and four remote steering tests, including a crash before cursor advancement and duplicate acknowledgment replay. Scoped Clippy across the six affected packages, edition-2021 formatting, and diff checks pass.

This ships the optional protocol and receipt support. The companion Gateway adapter keeps automatic steering disabled by default, so ordinary Slack replies continue to queue. Explicit uncertain-delivery recovery, Claude acknowledged mid-turn steering, and live Slack acceptance remain follow-up requirements. Related to #3188 and brightwave-inc/model-gateway#1852; neither issue is closed by this PR.