### PR TITLE
improve(code): recover interrupted sessions automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,11 +619,16 @@ jobs:
           cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
+      - name: Set up self-contained Python for offline package tests
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12.11"
       - name: Verify native sandbox prerequisites
         run: |
           test -x /usr/bin/sandbox-exec
           /usr/bin/sandbox-exec -p '(version 1)(allow default)' /usr/bin/true
           /usr/bin/python3 -c 'import sys; print(sys.version)'
+          python3 -I -c 'import pathlib, pip, sys; assert pathlib.Path(pip.__file__).resolve().is_relative_to(pathlib.Path(sys.prefix).resolve()); print(sys.version, pip.__file__)'
       - name: Seatbelt local sandbox tests
         run: cargo test -p tidebreak-code-execution --locked --lib local::tests
       - name: Egress broker tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,6 +583,54 @@ jobs:
           -p tidebreak-desktop
           --locked
 
+  macos-sandbox:
+    name: macOS sandbox tests
+    needs: changes
+    # The execution crate depends on other workspace crates and the Cargo
+    # runner script, so every workspace change can affect native confinement.
+    if: ${{ needs.changes.outputs.workspace == 'true' }}
+    runs-on: macos-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      RUSTC_WRAPPER: sccache
+      # CI tests need no keychain identity or interactive signing setup.
+      TIDEBREAK_DEV_SIGNING_IDENTITY: ""
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - name: Set up compiler cache
+        uses: ./.github/actions/setup-sccache-s3
+        with:
+          access: ${{ github.event_name == 'pull_request' && 'read' || 'write' }}
+          remote-cache-enabled: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: macos-sandbox-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+      - name: Verify native sandbox prerequisites
+        run: |
+          test -x /usr/bin/sandbox-exec
+          /usr/bin/sandbox-exec -p '(version 1)(allow default)' /usr/bin/true
+          /usr/bin/python3 -c 'import sys; print(sys.version)'
+      - name: Seatbelt local sandbox tests
+        run: cargo test -p tidebreak-code-execution --locked --lib local::tests
+      - name: Egress broker tests
+        run: cargo test -p tidebreak-code-execution --locked --lib network::tests
+      - name: Seatbelt profile escaping tests
+        run: cargo test -p tidebreak-code-execution --locked --lib sbpl::tests
+
   windows-native:
     name: Windows native tests
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,7 +622,7 @@ jobs:
       - name: Set up self-contained Python for offline package tests
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.12.11"
+          python-version: "3.12.10"
       - name: Verify native sandbox prerequisites
         run: |
           test -x /usr/bin/sandbox-exec

--- a/crates/tidebreak-cli/src/code.rs
+++ b/crates/tidebreak-cli/src/code.rs
@@ -1328,7 +1328,6 @@ fn render_event(
         | Event::ApprovalResolved { .. }
         | Event::UserSteered { .. }
         | Event::CheckpointRecorded { .. }
-        | Event::AttentionChanged { .. }
         | _ => {}
     }
     dangling

--- a/crates/tidebreak-code-execution/src/lib.rs
+++ b/crates/tidebreak-code-execution/src/lib.rs
@@ -20,7 +20,8 @@ pub mod host_paths;
 pub mod host_tools;
 mod http;
 mod local;
-#[cfg(target_os = "macos")]
+// Only the macOS provider starts the broker, but every platform checks its policy.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod network;
 pub mod office_render;
 mod output;

--- a/crates/tidebreak-code-execution/src/local.rs
+++ b/crates/tidebreak-code-execution/src/local.rs
@@ -1757,14 +1757,23 @@ fn canonicalize_grant_directory(path: &Path) -> Result<PathBuf, ExecError> {
 #[cfg(target_os = "macos")]
 fn macos_developer_dir() -> Option<PathBuf> {
     let selected = fs::read_link("/var/select/developer_dir").ok()?;
+    canonical_developer_dir(
+        &selected,
+        &[
+            Path::new("/Applications/Xcode.app/Contents/Developer"),
+            Path::new("/Library/Developer/CommandLineTools"),
+        ],
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn canonical_developer_dir(selected: &Path, trusted_roots: &[&Path]) -> Option<PathBuf> {
     let selected = fs::canonicalize(selected).ok()?;
-    [
-        Path::new("/Applications/Xcode.app/Contents/Developer"),
-        Path::new("/Library/Developer/CommandLineTools"),
-    ]
-    .iter()
-    .any(|allowed| selected.starts_with(allowed))
-    .then_some(selected)
+    trusted_roots
+        .iter()
+        .filter_map(|allowed| fs::canonicalize(allowed).ok())
+        .any(|allowed| selected.starts_with(allowed))
+        .then_some(selected)
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/tidebreak-code-execution/src/local/tests.rs
+++ b/crates/tidebreak-code-execution/src/local/tests.rs
@@ -55,6 +55,34 @@ fn sandbox_path_denied_message_teaches_attach_or_connect_folder_recovery() {
 }
 
 #[cfg(target_os = "macos")]
+#[test]
+fn selected_developer_directory_resolves_trusted_xcode_aliases() {
+    let root = tempfile::tempdir().unwrap();
+    let versioned = root.path().join("Xcode_26.app/Contents/Developer");
+    let unrelated = root.path().join("Other.app/Contents/Developer");
+    fs::create_dir_all(&versioned).unwrap();
+    fs::create_dir_all(&unrelated).unwrap();
+    std::os::unix::fs::symlink(
+        root.path().join("Xcode_26.app"),
+        root.path().join("Xcode.app"),
+    )
+    .unwrap();
+    let trusted = root.path().join("Xcode.app/Contents/Developer");
+    assert_eq!(
+        canonical_developer_dir(&versioned, &[trusted.as_path()]),
+        Some(fs::canonicalize(&versioned).unwrap())
+    );
+    assert_eq!(
+        canonical_developer_dir(&unrelated, &[trusted.as_path()]),
+        None
+    );
+    assert_eq!(
+        canonical_developer_dir(&versioned, &[root.path().join("Missing.app").as_path()]),
+        None
+    );
+}
+
+#[cfg(target_os = "macos")]
 fn request(workspace: &str, execution: &str, script: &str) -> ExecRequest {
     ExecRequest::new(
         ExecutionId::parse(execution).unwrap(),

--- a/crates/tidebreak-code-execution/src/local/tests.rs
+++ b/crates/tidebreak-code-execution/src/local/tests.rs
@@ -294,9 +294,9 @@ async fn malformed_url_shaped_denied_path_is_normalized_after_successful_exit() 
     let denied_path = "/tmp/sentinel-malformed-url-denied-path-do-not-leak";
     let script = r#"path = "/" + "tmp" + "/sentinel-malformed-url-denied-path-do-not-leak"
 try:
-open(path).read()
+    open(path).read()
 except PermissionError as error:
-print("Operation not permitted: https://" + error.filename)"#;
+    print("Operation not permitted: https://" + error.filename)"#;
     let request = ExecRequest::new(
         ExecutionId::parse("call-malformed-url-denied-path").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
@@ -326,19 +326,19 @@ async fn escaped_denied_paths_are_normalized_across_output_channels() {
             r#"import sys
 path = "/" + "tmp" + "/sentinel-escaped-slash-denied-path-do-not-leak"
 try:
-open(path).read()
+    open(path).read()
 except PermissionError as error:
-print("Operation not permitted")
-print(error.filename.replace("/", "\\/"), file=sys.stderr)"#,
+    print("Operation not permitted")
+    print(error.filename.replace("/", "\\/"), file=sys.stderr)"#,
             "sentinel-escaped-slash-denied-path-do-not-leak",
         ),
         (
             "call-unicode-slash-denied-path",
             r#"path = "/" + "tmp" + "/sentinel-unicode-slash-denied-path-do-not-leak"
 try:
-open(path).read()
+    open(path).read()
 except PermissionError as error:
-print("Operation not permitted: " + error.filename.replace("/", "\\u002F"))"#,
+    print("Operation not permitted: " + error.filename.replace("/", "\\u002F"))"#,
             "sentinel-unicode-slash-denied-path-do-not-leak",
         ),
     ];
@@ -378,9 +378,9 @@ async fn file_url_denied_path_is_normalized_after_successful_exit() {
     let script = r#"import sys
 path = "/" + "tmp" + "/sentinel-file-url-denied-path-do-not-leak"
 try:
-open(path).read()
+    open(path).read()
 except PermissionError as error:
-print("Operation not permitted: file://" + error.filename, file=sys.stderr)"#;
+    print("Operation not permitted: file://" + error.filename, file=sys.stderr)"#;
     let request = ExecRequest::new(
         ExecutionId::parse("call-file-url-denied-path").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
@@ -1407,14 +1407,14 @@ files = {
 record = "tidebreakproof-1.0.0.dist-info/RECORD"
 rows = []
 with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as archive:
-for name, data in files.items():
-    archive.writestr(name, data)
-    digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
-    rows.append((name, f"sha256={digest}", str(len(data))))
-rows.append((record, "", ""))
-out = io.StringIO()
-csv.writer(out, lineterminator="\n").writerows(rows)
-archive.writestr(record, out.getvalue())
+    for name, data in files.items():
+        archive.writestr(name, data)
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        rows.append((name, f"sha256={digest}", str(len(data))))
+    rows.append((record, "", ""))
+    out = io.StringIO()
+    csv.writer(out, lineterminator="\n").writerows(rows)
+    archive.writestr(record, out.getvalue())
 "#;
 
     let Some(runtime) =

--- a/crates/tidebreak-code-execution/src/local/tests.rs
+++ b/crates/tidebreak-code-execution/src/local/tests.rs
@@ -104,6 +104,26 @@ fn fixture(timeout: Duration) -> (tempfile::TempDir, LocalExecutionProvider, Str
 }
 
 #[cfg(target_os = "macos")]
+async fn python_fixture(
+    timeout: Duration,
+) -> (tempfile::TempDir, LocalExecutionProvider, String, String) {
+    let runtime = crate::package_cache::SharedPackageCache::python_runtime(Path::new("python3"))
+        .await
+        .expect("Python sandbox tests require a supported python3 runtime on PATH");
+    let (root, provider, workspace) = fixture(timeout);
+    let provider = provider.with_python_runtime(
+        Some(runtime.prefix().to_owned()),
+        runtime.read_only_paths().to_vec(),
+    );
+    (
+        root,
+        provider,
+        workspace,
+        runtime.executable().to_str().unwrap().to_owned(),
+    )
+}
+
+#[cfg(target_os = "macos")]
 #[tokio::test]
 async fn direct_host_path_denial_is_actionable_and_distinct_from_workspace_enoent() {
     let (root, provider, workspace) = fixture(Duration::from_secs(3));
@@ -197,7 +217,7 @@ async fn failed_shell_access_to_denied_host_path_gets_the_stable_result_code() {
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn dynamically_constructed_host_path_denial_does_not_leak_process_diagnostics() {
-    let (root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let connected = root
         .path()
         .join("sentinel-dynamic-connected-folder-do-not-leak");
@@ -206,7 +226,7 @@ async fn dynamically_constructed_host_path_denial_does_not_leak_process_diagnost
     let request = ExecRequest::new(
         ExecutionId::parse("call-dynamic-python-denied-path").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
-        "/usr/bin/python3",
+        python.as_str(),
         vec![
             "-c".into(),
             "open('/' + 'tmp' + '/sentinel-dynamic-denied-path-do-not-leak').read()".into(),
@@ -268,13 +288,13 @@ async fn redirected_shell_path_denial_does_not_leak_through_stdout() {
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn caught_python_path_denial_does_not_leak_through_stdout() {
-    let (_root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (_root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let denied_path = "/tmp/sentinel-caught-python-denied-path-do-not-leak";
     let script = "try:\n    open('/' + 'tmp' + '/sentinel-caught-python-denied-path-do-not-leak').read()\nexcept PermissionError as error:\n    print(error)\n    raise SystemExit(19)";
     let request = ExecRequest::new(
         ExecutionId::parse("call-caught-python-denied-path").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
-        "/usr/bin/python3",
+        python.as_str(),
         vec!["-c".into(), script.into()],
         ".",
     )
@@ -293,13 +313,13 @@ async fn caught_python_path_denial_does_not_leak_through_stdout() {
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn caught_python_path_denial_does_not_leak_after_successful_exit() {
-    let (_root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (_root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let denied_path = "/tmp/sentinel-caught-success-denied-path-do-not-leak";
     let script = "path = '/' + 'tmp' + '/sentinel-caught-success-denied-path-do-not-leak'\ntry:\n    open(path).read()\nexcept PermissionError:\n    print(f'Operation not permitted: x{path}')";
     let request = ExecRequest::new(
         ExecutionId::parse("call-caught-success-python-denied-path").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
-        "/usr/bin/python3",
+        python.as_str(),
         vec!["-c".into(), script.into()],
         ".",
     )
@@ -318,7 +338,7 @@ async fn caught_python_path_denial_does_not_leak_after_successful_exit() {
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn malformed_url_shaped_denied_path_is_normalized_after_successful_exit() {
-    let (_root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (_root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let denied_path = "/tmp/sentinel-malformed-url-denied-path-do-not-leak";
     let script = r#"path = "/" + "tmp" + "/sentinel-malformed-url-denied-path-do-not-leak"
 try:
@@ -328,7 +348,7 @@ except PermissionError as error:
     let request = ExecRequest::new(
         ExecutionId::parse("call-malformed-url-denied-path").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
-        "/usr/bin/python3",
+        python.as_str(),
         vec!["-c".into(), script.into()],
         ".",
     )
@@ -347,7 +367,7 @@ except PermissionError as error:
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn escaped_denied_paths_are_normalized_across_output_channels() {
-    let (_root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (_root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let cases = [
         (
             "call-escaped-slash-denied-path",
@@ -375,7 +395,7 @@ except PermissionError as error:
         let request = ExecRequest::new(
             ExecutionId::parse(execution_id).unwrap(),
             ExecutionWorkspaceId::parse(&workspace).unwrap(),
-            "/usr/bin/python3",
+            python.as_str(),
             vec!["-c".into(), script.into()],
             ".",
         )
@@ -401,7 +421,7 @@ except PermissionError as error:
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn file_url_denied_path_is_normalized_after_successful_exit() {
-    let (_root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (_root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let denied_path = "/tmp/sentinel-file-url-denied-path-do-not-leak";
     let script = r#"import sys
 path = "/" + "tmp" + "/sentinel-file-url-denied-path-do-not-leak"
@@ -412,7 +432,7 @@ except PermissionError as error:
     let request = ExecRequest::new(
         ExecutionId::parse("call-file-url-denied-path").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
-        "/usr/bin/python3",
+        python.as_str(),
         vec!["-c".into(), script.into()],
         ".",
     )
@@ -431,13 +451,13 @@ except PermissionError as error:
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn prefixed_denied_path_across_output_channels_is_normalized_on_failure() {
-    let (_root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (_root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let denied_path = "/tmp/sentinel-cross-channel-denied-path-do-not-leak";
     let script = "import sys\npath = '/' + 'tmp' + '/sentinel-cross-channel-denied-path-do-not-leak'\ntry:\n    open(path).read()\nexcept PermissionError:\n    print('Operation not permitted')\n    print(f'x{path}', file=sys.stderr)\n    raise SystemExit(29)";
     let request = ExecRequest::new(
         ExecutionId::parse("call-cross-channel-python-denied-path").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
-        "/usr/bin/python3",
+        python.as_str(),
         vec!["-c".into(), script.into()],
         ".",
     )
@@ -546,7 +566,7 @@ async fn permission_denial_phrase_without_a_denied_path_is_preserved() {
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn successful_output_with_allowed_path_and_url_diagnostics_is_preserved() {
-    let (root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let allowed_path = fs::canonicalize(root.path().join(&workspace))
         .unwrap()
         .join("allowed.txt");
@@ -559,7 +579,7 @@ print("Operation not permitted: '" + path.replace("/", "\\u002f") + "'", file=sy
     let request = ExecRequest::new(
         ExecutionId::parse("call-successful-allowed-path-diagnostic").unwrap(),
         ExecutionWorkspaceId::parse(&workspace).unwrap(),
-        "/usr/bin/python3",
+        python.as_str(),
         vec!["-c".into(), script.into()],
         ".",
     )
@@ -654,7 +674,7 @@ async fn resolved_workspace_paths_keep_enoent_and_symlink_escapes_are_denied() {
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn local_sandbox_confines_writes_and_network_and_caches_exact_retry() {
-    let (root, provider, workspace) = fixture(Duration::from_secs(3));
+    let (root, provider, workspace, python) = python_fixture(Duration::from_secs(3)).await;
     let outside = root.path().join("outside");
     let script = format!(
         "printf ok > result; \
@@ -691,21 +711,8 @@ async fn local_sandbox_confines_writes_and_network_and_caches_exact_retry() {
 
     for (execution, command) in [
         ("call-python-path", "python3"),
-        ("call-python-system-path", "/usr/bin/python3"),
+        ("call-python-selected-path", python.as_str()),
     ] {
-        // The sandbox can only be as healthy as the host interpreter: on
-        // macOS installs with a broken Xcode python shim, python cannot
-        // run outside any sandbox either, so asserting here would fail on
-        // an environment defect while proving nothing about confinement.
-        let host_python_works = std::process::Command::new(command)
-            .args(["-c", "print(6 * 7)"])
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false);
-        if !host_python_works {
-            eprintln!("skipping {command}: host interpreter unusable in this environment");
-            continue;
-        }
         let python = ExecRequest::new(
             ExecutionId::parse(execution).unwrap(),
             ExecutionWorkspaceId::parse("chat-1").unwrap(),
@@ -715,15 +722,6 @@ async fn local_sandbox_confines_writes_and_network_and_caches_exact_retry() {
         )
         .unwrap();
         let python = provider.execute(python).await.unwrap();
-        // macOS ships /usr/bin/python3 as an Xcode shim that stats Xcode's
-        // frameworks before running; under the sandbox (or with a broken
-        // Xcode install) the shim dies before python exists. That failure
-        // is an environment defect, not a confinement finding — skip it
-        // loudly instead of failing the suite.
-        if python.exit_code != Some(0) && python.stderr.contains("unable to locate xcodebuild") {
-            eprintln!("skipping {command}: Xcode python shim cannot start on this host");
-            continue;
-        }
         assert_eq!(
             python.exit_code,
             Some(0),
@@ -732,6 +730,22 @@ async fn local_sandbox_confines_writes_and_network_and_caches_exact_retry() {
         );
         assert_eq!(python.stdout.trim(), "42");
     }
+    let shell_python = ExecRequest::new(
+        ExecutionId::parse("call-python-shell-path").unwrap(),
+        ExecutionWorkspaceId::parse(&workspace).unwrap(),
+        "/bin/sh",
+        vec!["-c".into(), "python3 -c 'print(6 * 7)'".into()],
+        ".",
+    )
+    .unwrap();
+    let shell_python = provider.execute(shell_python).await.unwrap();
+    assert_eq!(
+        shell_python.exit_code,
+        Some(0),
+        "shell Python stderr: {}",
+        shell_python.stderr
+    );
+    assert_eq!(shell_python.stdout.trim(), "42");
 }
 
 /// The production regression this pins: a sandboxed interpreter writing

--- a/crates/tidebreak-code-execution/src/sbpl.rs
+++ b/crates/tidebreak-code-execution/src/sbpl.rs
@@ -69,3 +69,73 @@ fn checked(path: &Path) -> Result<&str, UnsafeSandboxPath> {
 pub fn escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_quotes_and_backslashes_without_changing_other_characters() {
+        for (input, expected) in [
+            ("", ""),
+            ("/tmp/a folder/資料", "/tmp/a folder/資料"),
+            (r#"/tmp/a"b\c"#, r#"/tmp/a\"b\\c"#),
+            (r#"\""#, r#"\\\""#),
+            (r#"\\"#, r#"\\\\"#),
+        ] {
+            assert_eq!(escape(input), expected, "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn path_clauses_keep_injected_profile_rules_inside_the_string() {
+        let path = r#"/tmp/") (allow default) ;\"#;
+        let expected_literal = r#"(literal "/tmp/\") (allow default) ;\\")"#;
+        let expected_subpath = r#"(subpath "/tmp/\") (allow default) ;\\")"#;
+        assert_eq!(literal_str(path), expected_literal);
+        assert_eq!(subpath_str(path), expected_subpath);
+        assert_eq!(literal(Path::new(path)).unwrap(), expected_literal);
+        assert_eq!(subpath(Path::new(path)).unwrap(), expected_subpath);
+    }
+
+    #[test]
+    fn resolved_paths_reject_control_characters() {
+        // C0, DEL, and C1 controls include newlines and NUL. Escaping quotes
+        // must never admit a path that the profile parser interprets differently.
+        for control in (0..=0x1f).chain(0x7f..=0x9f) {
+            let path = format!("/tmp/before{}after", char::from_u32(control).unwrap());
+            for result in [literal(Path::new(&path)), subpath(Path::new(&path))] {
+                assert_eq!(result, Err(UnsafeSandboxPath::ControlCharacters));
+            }
+        }
+    }
+
+    #[test]
+    fn resolved_paths_preserve_unicode_and_spaces() {
+        let path = Path::new("/tmp/a folder/資料");
+        assert_eq!(literal(path).unwrap(), r#"(literal "/tmp/a folder/資料")"#);
+        assert_eq!(subpath(path).unwrap(), r#"(subpath "/tmp/a folder/資料")"#);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolved_paths_reject_non_utf8_bytes() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let path = Path::new(OsStr::from_bytes(b"/tmp/\xff"));
+        assert_eq!(literal(path), Err(UnsafeSandboxPath::NotUtf8));
+        assert_eq!(subpath(path), Err(UnsafeSandboxPath::NotUtf8));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolved_paths_reject_unpaired_utf16_surrogates() {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+
+        let path = OsString::from_wide(&[b'C' as u16, b':' as u16, b'\\' as u16, 0xd800]);
+        assert_eq!(literal(Path::new(&path)), Err(UnsafeSandboxPath::NotUtf8));
+        assert_eq!(subpath(Path::new(&path)), Err(UnsafeSandboxPath::NotUtf8));
+    }
+}

--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -373,7 +373,7 @@ fn state_token<'a>(
 
 /// A follow-up cannot authorize another budget after a spend stop. A failed
 /// checkout without a saved checkpoint cannot silently restart from the base.
-fn recovery_block(row: &CodeSessionIncarnation) -> Option<(&'static str, &'static str)> {
+pub fn recovery_block(row: &CodeSessionIncarnation) -> Option<(&'static str, &'static str)> {
     row.sandbox_id.as_ref()?;
     match row.stop_reason.as_deref() {
         Some("ceiling_exceeded" | "spend_ceiling_exceeded") => Some((

--- a/crates/tidebreak-core/fixtures/code-journal-events.json
+++ b/crates/tidebreak-core/fixtures/code-journal-events.json
@@ -122,16 +122,6 @@
     "remediation": "Reconnect this session from Slack."
   },
   {
-    "type": "attention_changed",
-    "state": {
-      "type": "fenced",
-      "reason": {
-        "type": "orphan_alive"
-      }
-    },
-    "source": "lifecycle"
-  },
-  {
     "type": "turn_refused",
     "usage": {
       "input_tokens": 12,

--- a/crates/tidebreak-core/src/chat_journal.rs
+++ b/crates/tidebreak-core/src/chat_journal.rs
@@ -12,7 +12,7 @@
 //! This is the aliasing the decision's amendment permits — one route family
 //! over one set of entities — and nothing else maps one side's entities into
 //! the other's shapes. Rows only an external engine writes (`SessionStarted`,
-//! `FileChanged`, `AttentionChanged`, …) have no chat reading and project to
+//! `FileChanged`, …) have no chat reading and project to
 //! nothing.
 
 use crate::code::{
@@ -300,7 +300,6 @@ pub fn chat_event(event: Event) -> Result<Option<AgentEvent>> {
         }
         | Event::CheckpointRecorded { .. }
         | Event::HarnessNotice { .. }
-        | Event::AttentionChanged { .. }
         | Event::CredentialRefused { .. } => return Ok(None),
     }))
 }

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -8,7 +8,6 @@
 //! the structured facts the chat surface replays (the alias layer the
 //! decision's amendment permits), and external adapters never produce them.
 
-use crate::attention::{AttentionSource, AttentionState};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -773,13 +772,6 @@ pub enum Event {
         /// Bounded remedy sentence for the person.
         remediation: String,
     },
-    /// Server-computed attention changed.
-    AttentionChanged {
-        /// New state.
-        state: AttentionState,
-        /// Who or what set it.
-        source: AttentionSource,
-    },
     /// The provider stream was preempted; clients discard the assistant and
     /// tool deltas streamed since the last stable boundary. Internal engine.
     StreamInterrupted,
@@ -835,7 +827,6 @@ pub struct SequencedEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::attention::FenceReason;
     use crate::code::HarnessKind;
     use uuid::Uuid;
 
@@ -984,15 +975,14 @@ mod tests {
             Event::TurnInterrupted { .. } => 14,
             Event::CheckpointRecorded { .. } => 15,
             Event::HarnessNotice { .. } => 16,
-            Event::AttentionChanged { .. } => 17,
-            Event::TurnRefused { .. } => 18,
-            Event::StreamInterrupted => 19,
-            Event::ToolArgsDelta { .. } => 20,
-            Event::TaskPlanUpdated { .. } => 21,
-            Event::ContextTruncated { .. } => 22,
-            Event::CompactionStarted => 23,
-            Event::CompactionFinished { .. } => 24,
-            Event::CredentialRefused { .. } => 25,
+            Event::TurnRefused { .. } => 17,
+            Event::StreamInterrupted => 18,
+            Event::ToolArgsDelta { .. } => 19,
+            Event::TaskPlanUpdated { .. } => 20,
+            Event::ContextTruncated { .. } => 21,
+            Event::CompactionStarted => 22,
+            Event::CompactionFinished { .. } => 23,
+            Event::CredentialRefused { .. } => 24,
         }
     }
 
@@ -1108,12 +1098,6 @@ mod tests {
                 reason: CredentialRefusalReason::ConnectionEnded,
                 message: "this external connection has no live gateway delegation".into(),
                 remediation: "Reconnect this session from Slack.".into(),
-            },
-            Event::AttentionChanged {
-                state: AttentionState::Fenced {
-                    reason: FenceReason::OrphanAlive,
-                },
-                source: AttentionSource::Lifecycle,
             },
             // The internal engine's rows. Their optional fields are pinned
             // on the chat journal fixture, which round-trips through these

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.dom.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Attention } from "../api/types";
 import { AttentionBadge } from "./AttentionBadge";
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
 });
 
 const cases: Array<{ attention: Attention; label: string; type: string }> = [
@@ -29,14 +30,6 @@ const cases: Array<{ attention: Attention; label: string; type: string }> = [
     },
     label: "Stalled",
     type: "stalled",
-  },
-  {
-    attention: {
-      state: { type: "fenced", reason: { type: "orphan_alive" } },
-      source: "lifecycle",
-    },
-    label: "Fenced",
-    type: "fenced",
   },
   {
     attention: { state: { type: "done_unreviewed" }, source: "lifecycle" },
@@ -115,4 +108,26 @@ describe("AttentionBadge", () => {
       "needs_you",
     );
   });
+});
+
+it("shows recovery after a brief delay without a warning mark", () => {
+  vi.useFakeTimers();
+  const { container } = render(
+    <AttentionBadge
+      attention={{
+        state: { type: "fenced", reason: { type: "orphan_alive" } },
+        source: "lifecycle",
+      }}
+      compact
+    />,
+  );
+  expect(container).toBeEmptyDOMElement();
+  act(() => vi.advanceTimersByTime(1500));
+  expect(screen.getByLabelText("Reconnecting…")).toHaveAttribute(
+    "data-attention",
+    "fenced",
+  );
+  expect(
+    container.querySelector("[data-loader-variant='comet']"),
+  ).not.toBeNull();
 });

--- a/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/AttentionBadge.tsx
@@ -1,5 +1,7 @@
-import { Ban, CircleAlert, CircleCheck, Clock, Pin } from "lucide-react";
+import { recoveryAttention } from "./sessionRecovery";
+import { CircleAlert, CircleCheck, Clock, Pin } from "lucide-react";
 
+import { useRecoveryDelay } from "./useRecoveryDelay";
 import { Loader } from "@/components/motion/loader";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -15,7 +17,7 @@ import {
 /**
  * Status affordance for a server-computed attention state.
  *
- * NeedsYou is strongest. Stalled and Fenced are distinct warnings.
+ * NeedsYou requests an action. Recovery stays quiet during brief disconnects.
  * DoneUnreviewed is a quiet mark.
  *
  * Working is a comet loader but not a pill. Compact surfaces use a distinct
@@ -46,7 +48,11 @@ export function AttentionBadge({
   compact?: boolean;
   className?: string;
 }) {
-  if (!attention) return null;
+  if (attention?.state.type === "fenced")
+    attention = recoveryAttention("fenced", attention, attention.state.reason);
+  const recovering = attention?.state.type === "fenced";
+  const showRecovery = useRecoveryDelay(recovering);
+  if (!attention || (recovering && !showRecovery)) return null;
   if (attention.state.type === "idle") return null;
   if (attention.state.type === "working" && !compact) return null;
   const label = attentionLabel(attention);
@@ -100,7 +106,14 @@ function CompactAttentionMark({
     case "stalled":
       return <Clock className={className} aria-hidden="true" />;
     case "fenced":
-      return <Ban className={className} aria-hidden="true" />;
+      return (
+        <Loader
+          variant="comet"
+          size={12}
+          className="text-muted-foreground"
+          decorative
+        />
+      );
     case "done_unreviewed":
       return <CircleCheck className={className} aria-hidden="true" />;
     case "idle":

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionPage.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionPage.test.tsx
@@ -123,45 +123,41 @@ it("updates workspace-less recovery from the digest without reloading its snapsh
     "true",
   );
   act(() =>
-    useCodeUpdatesStore
-      .getState()
-      .apply({
-        type: "digest",
-        digest: {
-          workspace: null,
-          session: session.id,
-          kind: "interactive",
-          lifecycle: "fenced",
-          fence_reason: { type: "probe_ambiguous", detail: "Recovery stopped" },
-          attention: {
-            state: {
-              type: "needs_you",
-              prompt: "Inspect the previous process.",
-              source: "lifecycle",
-            },
+    useCodeUpdatesStore.getState().apply({
+      type: "digest",
+      digest: {
+        workspace: null,
+        session: session.id,
+        kind: "interactive",
+        lifecycle: "fenced",
+        fence_reason: { type: "probe_ambiguous", detail: "Recovery stopped" },
+        attention: {
+          state: {
+            type: "needs_you",
+            prompt: "Inspect the previous process.",
             source: "lifecycle",
           },
-          title: "Conversation",
-          turn_count: 1,
+          source: "lifecycle",
         },
-      }),
+        title: "Conversation",
+        turn_count: 1,
+      },
+    }),
   );
   expect(screen.getByText("Inspect the previous process.")).toBeInTheDocument();
   act(() =>
-    useCodeUpdatesStore
-      .getState()
-      .apply({
-        type: "digest",
-        digest: {
-          workspace: null,
-          session: session.id,
-          kind: "interactive",
-          lifecycle: "idle",
-          attention: { state: { type: "idle" }, source: "lifecycle" },
-          title: "Conversation",
-          turn_count: 1,
-        },
-      }),
+    useCodeUpdatesStore.getState().apply({
+      type: "digest",
+      digest: {
+        workspace: null,
+        session: session.id,
+        kind: "interactive",
+        lifecycle: "idle",
+        attention: { state: { type: "idle" }, source: "lifecycle" },
+        title: "Conversation",
+        turn_count: 1,
+      },
+    }),
   );
   expect(screen.getByTestId("session-pane")).toHaveAttribute(
     "data-disabled",

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionPage.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionPage.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CodeSessionPage } from "./CodeSessionPage";
+import { CodeSessionPage, CodeSessionContent } from "./CodeSessionPage";
+import { useCodeUpdatesStore } from "./CodeUpdatesStore";
 import { codeSession } from "@/stories/fixtures";
 
 const mocks = vi.hoisted(() => {
@@ -22,13 +23,22 @@ vi.mock("./SessionLifecycleIndicator", () => ({
   SessionLifecycleIndicator: () => null,
 }));
 vi.mock("./workspace/CodeSessionPane", () => ({
-  CodeSessionPane: ({ session }: { session: { id: string } }) => (
-    <div>Session {session.id}</div>
+  CodeSessionPane: ({
+    session,
+    disabled,
+  }: {
+    session: { id: string };
+    disabled: boolean;
+  }) => (
+    <div data-testid="session-pane" data-disabled={disabled}>
+      Session {session.id}
+    </div>
   ),
 }));
 
 afterEach(cleanup);
 beforeEach(() => {
+  useCodeUpdatesStore.getState().resetLive();
   mocks.get.mockReset();
   mocks.navigate.mockReset();
 });
@@ -89,4 +99,87 @@ describe("durable session links", () => {
     expect(mocks.navigate).not.toHaveBeenCalled();
     expect(screen.getByText("Session second")).toBeTruthy();
   });
+});
+
+it("updates workspace-less recovery from the digest without reloading its snapshot", () => {
+  const session = {
+    ...codeSession,
+    workspace_id: null,
+    lifecycle: "fenced" as const,
+    fence_reason: { type: "orphan_alive" as const },
+  };
+  const { rerender } = render(
+    <CodeSessionContent
+      session={session}
+      error={null}
+      client={mocks.client as never}
+      models={[]}
+      defaultModelKey={null}
+      onRetry={() => {}}
+    />,
+  );
+  expect(screen.getByTestId("session-pane")).toHaveAttribute(
+    "data-disabled",
+    "true",
+  );
+  act(() =>
+    useCodeUpdatesStore
+      .getState()
+      .apply({
+        type: "digest",
+        digest: {
+          workspace: null,
+          session: session.id,
+          kind: "interactive",
+          lifecycle: "fenced",
+          fence_reason: { type: "probe_ambiguous", detail: "Recovery stopped" },
+          attention: {
+            state: {
+              type: "needs_you",
+              prompt: "Inspect the previous process.",
+              source: "lifecycle",
+            },
+            source: "lifecycle",
+          },
+          title: "Conversation",
+          turn_count: 1,
+        },
+      }),
+  );
+  expect(screen.getByText("Inspect the previous process.")).toBeInTheDocument();
+  act(() =>
+    useCodeUpdatesStore
+      .getState()
+      .apply({
+        type: "digest",
+        digest: {
+          workspace: null,
+          session: session.id,
+          kind: "interactive",
+          lifecycle: "idle",
+          attention: { state: { type: "idle" }, source: "lifecycle" },
+          title: "Conversation",
+          turn_count: 1,
+        },
+      }),
+  );
+  expect(screen.getByTestId("session-pane")).toHaveAttribute(
+    "data-disabled",
+    "false",
+  );
+  expect(screen.queryByText("Inspect the previous process.")).toBeNull();
+  rerender(
+    <CodeSessionContent
+      session={session}
+      error={null}
+      client={mocks.client as never}
+      models={[]}
+      defaultModelKey={null}
+      onRetry={() => {}}
+    />,
+  );
+  expect(screen.getByTestId("session-pane")).toHaveAttribute(
+    "data-disabled",
+    "false",
+  );
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionPage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionPage.tsx
@@ -1,3 +1,7 @@
+import { toast } from "sonner";
+import { useSessionDigest } from "./CodeUpdatesStore";
+import { SessionRecoveryNotice } from "./SessionRecoveryNotice";
+import { sessionRecoveryState } from "./sessionRecovery";
 import { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useApp } from "@/AppContext";
@@ -68,6 +72,7 @@ function CodeSessionRouteBody({ sessionId }: { sessionId: string }) {
         models={models}
         defaultModelKey={defaultModelKey}
         onRetry={() => setAttempt((value) => value + 1)}
+        onRecovered={setSession}
       />
     </RouteFrame>
   );
@@ -82,6 +87,7 @@ export function CodeSessionContent({
   models,
   defaultModelKey,
   onRetry,
+  onRecovered,
 }: {
   title?: string;
   session: CodeSessionSnapshot | null;
@@ -90,14 +96,31 @@ export function CodeSessionContent({
   models: ModelInfo[];
   defaultModelKey: string | null;
   onRetry: () => void;
+  onRecovered?: (session: CodeSessionSnapshot) => void;
 }) {
+  const digest = useSessionDigest(undefined, session?.id ?? null);
+  const recovery = sessionRecoveryState(session, digest);
+  const [retrying, setRetrying] = useState(false);
+  async function retryRecovery() {
+    if (!session || retrying) return;
+    setRetrying(true);
+    try {
+      const recovered = await client.reapCodeSession(session.id);
+      onRecovered?.(recovered);
+    } catch (error) {
+      toast.error(friendlyErrorMessage(error, "Could not recover the session"));
+    } finally {
+      setRetrying(false);
+    }
+  }
   return (
     <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
       <div className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-4">
         <h1 className="min-w-0 flex-1 truncate text-sm font-medium">{title}</h1>
         {session && (
           <SessionLifecycleIndicator
-            lifecycle={session.lifecycle}
+            lifecycle={recovery.lifecycle ?? session.lifecycle}
+            attention={recovery.attention}
             harness={session.harness_kind}
             unrecognizedEventCount={session.unrecognized_event_count}
           />
@@ -116,14 +139,25 @@ export function CodeSessionContent({
           </Button>
         </div>
       ) : session ? (
-        <CodeSessionPane
-          key={session.id}
-          session={session}
-          client={client}
-          catalogModels={models}
-          defaultModelKey={defaultModelKey}
-          disabled={false}
-        />
+        <>
+          <SessionRecoveryNotice
+            showProgress={false}
+            lifecycle={recovery.lifecycle}
+            attention={recovery.attention}
+            reason={recovery.reason}
+            retrying={retrying}
+            allowRetry={session.access !== "view"}
+            onRetry={() => void retryRecovery()}
+          />
+          <CodeSessionPane
+            key={session.id}
+            session={session}
+            client={client}
+            catalogModels={models}
+            defaultModelKey={defaultModelKey}
+            disabled={recovery.blocksTurn}
+          />
+        </>
       ) : (
         <div
           role="status"

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.test.ts
@@ -2192,23 +2192,6 @@ describe("unattributed terminals", () => {
   });
 });
 
-describe("attention_changed", () => {
-  it("reduces into state.attention and does not add a transcript item", () => {
-    const { state } = play([
-      {
-        type: "attention_changed",
-        state: { type: "stalled", idle_secs: 90 },
-        source: "heuristic",
-      },
-    ]);
-    expect(state.attention).toEqual({
-      state: { type: "stalled", idle_secs: 90 },
-      source: "heuristic",
-    });
-    expect(state.items).toEqual([]);
-  });
-});
-
 describe("user item createdAt", () => {
   it("carries the turn's started_at on accept and hydrate", () => {
     const accepted = applyAcceptedTurn(

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -1,6 +1,5 @@
 import type { ApprovalDecisionKind, TurnActor } from "../generated/wire";
 import type {
-  Attention,
   CodeApprovalState,
   CodeSessionLifecycle,
   CodeTurnSnapshot,
@@ -192,11 +191,6 @@ export type CodeSessionState = {
    * after assistant rows exist.
    */
   storedRewrites: Record<string, string>;
-  /**
-   * Latest `attention_changed` from the journal. Not a transcript item — the
-   * header badge reads this so a stall or a need-you does not grow the log.
-   */
-  attention: Attention | null;
 };
 
 export type CodeSessionEffect =
@@ -251,7 +245,6 @@ export function initialCodeSessionState(): CodeSessionState {
     lifecycle: null,
     contentRevision: 0,
     storedRewrites: {},
-    attention: null,
   };
 }
 
@@ -1124,16 +1117,6 @@ export function reduceCodeSessionEvent(
             turnId: attributedTurnId,
             text: event.text,
           }),
-        },
-        effects,
-      };
-    }
-
-    case "attention_changed": {
-      return {
-        state: {
-          ...state,
-          attention: { state: event.state, source: event.source },
         },
         effects,
       };

--- a/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeUpdatesStore.ts
@@ -437,6 +437,7 @@ export function noticeToAction(
           : {}),
         lifecycle: notice.lifecycle,
         attention: notice.attention,
+        ...(notice.fence_reason ? { fence_reason: notice.fence_reason } : {}),
         title: notice.title,
         turn_count: notice.turn_count,
         ...(notice.trigger_target_at !== undefined

--- a/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeWorkspacePage.tsx
@@ -68,6 +68,8 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { RouteFrame } from "@/RouteFrame";
+import { sessionRecoveryState } from "./sessionRecovery";
+import { SessionRecoveryNotice } from "./SessionRecoveryNotice";
 import { SessionLifecycleIndicator } from "./SessionLifecycleIndicator";
 import { SessionPermissionIndicator } from "./SessionPermissionIndicator";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -95,7 +97,6 @@ import { canOpenInExternalEditor } from "./codeWorktreeHost";
 import { cn, friendlyErrorMessage } from "@/lib/utils";
 import { codeClientGeneration } from "./CodeClientGeneration";
 import { findEditorPanel, offersSplitDrop } from "./editorDrag";
-import { fenceReasonText } from "./labels";
 import { forkTranscriptFile } from "./fork";
 import { isPutAway, sessionActivityLabel } from "./workspaceCards";
 import { toast } from "sonner";
@@ -130,7 +131,7 @@ const TerminalPane = lazy(async () => {
 });
 
 /**
- * One workspace: header, transcript, composer, and the fence/reap path.
+ * One workspace: header, transcript, composer, and automatic recovery.
  *
  * The session store lives in the registry so two views of the same session
  * share one socket. This page is the only mounted session view in the
@@ -316,7 +317,8 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     error,
     retry,
     startSession,
-    reap,
+    retryRecovery,
+    retryingRecovery,
     selectConversation,
     newConversation,
     forkConversation,
@@ -398,8 +400,10 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
     splitFocused,
   } = useEditorTabs({ layout, setLayout: setWorkspaceLayout });
 
-  const fenced =
-    session?.lifecycle === "fenced" || session?.fence_reason !== undefined;
+  const { lifecycle, attention, reason, blocksTurn } = sessionRecoveryState(
+    session,
+    digest,
+  );
   const doctorHarnesses = catalog.doctor?.harnesses ?? [];
   const title = digest?.title ?? workspace?.title;
   const repoName = repo?.display_name;
@@ -657,19 +661,15 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
             // so `.message-view` can grow and the composer stays at the bottom,
             // including on an empty transcript.
             <div className="chat-pane" hidden={!visible || !showingChat}>
-              {fenced && session?.fence_reason && (
-                <div className="notice-surface notice-warning mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm">
-                  <p>{fenceReasonText(session.fence_reason)}</p>
-                  <Button
-                    type="button"
-                    size="sm"
-                    className="self-start"
-                    onClick={() => void reap()}
-                  >
-                    Reap
-                  </Button>
-                </div>
-              )}
+              <SessionRecoveryNotice
+                showProgress={false}
+                allowRetry={session?.access !== "view"}
+                lifecycle={lifecycle}
+                attention={attention}
+                reason={reason}
+                retrying={retryingRecovery}
+                onRetry={() => void retryRecovery()}
+              />
               {workspace?.status === "setup_failed" && (
                 <SetupFailedBanner
                   output={workspace.setup_error}
@@ -740,7 +740,7 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
                   client={client}
                   catalogModels={models}
                   defaultModelKey={defaultModelKey}
-                  disabled={fenced || workspace?.status !== "active"}
+                  disabled={blocksTurn || workspace?.status !== "active"}
                   onOpenTurnDiff={openTurnDiff}
                   onForkFromTurn={
                     session.kind === "interactive"
@@ -963,13 +963,12 @@ function CodeWorkspaceBody({ workspaceId }: { workspaceId: string }) {
           session && !workspaceStartup ? (
             <>
               <SessionAttentionBadge
-                sessionId={session.id}
-                client={client}
-                fallback={digest?.attention ?? session.attention}
+                attention={digest?.attention ?? session.attention}
               />
               <PendingApprovalBadge sessionId={session.id} client={client} />
               <SessionLifecycleIndicator
                 lifecycle={digest?.lifecycle ?? session.lifecycle}
+                attention={attention}
                 harness={session.harness_kind}
                 version={session.harness_version}
                 unrecognizedEventCount={session.unrecognized_event_count}

--- a/crates/tidebreak-desktop/ui/src/code/SessionLifecycleIndicator.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionLifecycleIndicator.tsx
@@ -1,10 +1,11 @@
+import { useRecoveryDelay } from "./useRecoveryDelay";
 import { CircleAlert } from "lucide-react";
 
 import { Loader } from "@/components/motion/loader";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
-import type { CodeSessionSnapshot } from "../api/types";
+import type { Attention, CodeSessionSnapshot } from "../api/types";
 import { FOCUS_RING } from "./interactive";
 import { LIFECYCLE_LABELS, sessionLifecycleTooltip } from "./labels";
 import { STATUS_MARK } from "./statusTone";
@@ -23,13 +24,18 @@ export function SessionLifecycleIndicator({
   version,
   unrecognizedEventCount,
   runningLabel,
+  attention,
 }: {
   lifecycle: CodeSessionSnapshot["lifecycle"];
   harness: CodeSessionSnapshot["harness_kind"];
   version?: string;
   unrecognizedEventCount: number;
   runningLabel?: string;
+  attention?: Attention;
 }) {
+  const recovering =
+    lifecycle === "fenced" && attention?.state.type === "fenced";
+  const showRecovery = useRecoveryDelay(recovering);
   const tooltip = sessionLifecycleTooltip({
     lifecycle,
     harness,
@@ -38,13 +44,22 @@ export function SessionLifecycleIndicator({
     runningLabel,
   });
   const label =
-    lifecycle === "running" && runningLabel
-      ? runningLabel
-      : LIFECYCLE_LABELS[lifecycle];
+    lifecycle === "fenced" && attention?.state.type === "needs_you"
+      ? "Needs you"
+      : lifecycle === "running" && runningLabel
+        ? runningLabel
+        : LIFECYCLE_LABELS[lifecycle];
   const unrecognizedLabel = `${unrecognizedEventCount} unrecognized engine ${unrecognizedEventCount === 1 ? "event" : "events"} recorded in this session`;
 
+  if (recovering && !showRecovery) return null;
   return (
-    <WithTooltip label={tooltip}>
+    <WithTooltip
+      label={
+        attention?.state.type === "needs_you" && lifecycle === "fenced"
+          ? attention.state.prompt
+          : tooltip
+      }
+    >
       {/*
        * The tooltip carries the engine version and the dropped-event warning,
        * and neither is anywhere else on the page. A span cannot be tabbed to,
@@ -57,7 +72,7 @@ export function SessionLifecycleIndicator({
           FOCUS_RING,
         )}
       >
-        {lifecycle === "running" && (
+        {(lifecycle === "running" || recovering) && (
           <Loader variant="comet" size={12} className="text-live" decorative />
         )}
         <span>{label}</span>

--- a/crates/tidebreak-desktop/ui/src/code/SessionRecoveryNotice.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionRecoveryNotice.dom.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { Attention, FenceReason } from "../api/types";
+import { SessionLifecycleIndicator } from "./SessionLifecycleIndicator";
+import { SessionRecoveryNotice } from "./SessionRecoveryNotice";
+import { RECOVERY_NOTICE_DELAY_MS } from "./useRecoveryDelay";
+
+const recovering: Attention = {
+  state: { type: "fenced", reason: { type: "orphan_alive" } },
+  source: "lifecycle",
+};
+const blocked: Attention = {
+  state: {
+    type: "needs_you",
+    prompt: "The engine did not stop. Retry recovery.",
+    source: "lifecycle",
+  },
+  source: "lifecycle",
+};
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+it("keeps brief recovery quiet and cancels its timer after success", () => {
+  vi.useFakeTimers();
+  const { container, rerender } = render(
+    <SessionRecoveryNotice
+      lifecycle="fenced"
+      attention={recovering}
+      onRetry={vi.fn()}
+    />,
+  );
+  act(() => vi.advanceTimersByTime(RECOVERY_NOTICE_DELAY_MS - 1));
+  expect(container).toBeEmptyDOMElement();
+  rerender(
+    <SessionRecoveryNotice
+      lifecycle="idle"
+      attention={{ state: { type: "idle" }, source: "lifecycle" }}
+      onRetry={vi.fn()}
+    />,
+  );
+  act(() => vi.advanceTimersByTime(RECOVERY_NOTICE_DELAY_MS));
+  expect(container).toBeEmptyDOMElement();
+});
+
+it("shows delayed progress, then a concrete failure with a single retry action", () => {
+  vi.useFakeTimers();
+  const retry = vi.fn();
+  const { rerender, container } = render(
+    <SessionRecoveryNotice
+      lifecycle="fenced"
+      attention={recovering}
+      onRetry={retry}
+    />,
+  );
+  act(() => vi.advanceTimersByTime(RECOVERY_NOTICE_DELAY_MS));
+  expect(screen.getByText("Reconnecting…")).toBeInTheDocument();
+  expect(screen.queryByRole("button")).toBeNull();
+  rerender(
+    <SessionRecoveryNotice
+      lifecycle="fenced"
+      attention={blocked}
+      reason={{ type: "orphan_alive" }}
+      onRetry={retry}
+    />,
+  );
+  expect(
+    screen.getByText(
+      blocked.state.type === "needs_you" ? blocked.state.prompt : "",
+    ),
+  ).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "Retry recovery" }));
+  expect(retry).toHaveBeenCalledOnce();
+  rerender(
+    <SessionRecoveryNotice
+      lifecycle="fenced"
+      attention={blocked}
+      reason={{ type: "orphan_alive" }}
+      retrying
+      onRetry={retry}
+    />,
+  );
+  expect(screen.getByRole("button", { name: "Retrying…" })).toBeDisabled();
+  rerender(
+    <SessionRecoveryNotice
+      lifecycle="idle"
+      attention={{ state: { type: "idle" }, source: "lifecycle" }}
+      onRetry={retry}
+    />,
+  );
+  expect(container).toBeEmptyDOMElement();
+});
+
+it.each<FenceReason>([
+  { type: "probe_ambiguous", detail: "Process identity changed" },
+  { type: "repeated_turn_failures", count: 3, detail: "Authentication failed" },
+])("offers explicit retry after the cause is corrected for $type", (reason) => {
+  render(
+    <SessionRecoveryNotice
+      lifecycle="fenced"
+      attention={blocked}
+      reason={reason}
+      onRetry={vi.fn()}
+    />,
+  );
+  expect(screen.getByRole("button", { name: "Retry recovery" })).toBeEnabled();
+  expect(screen.getByRole("status")).toHaveTextContent(
+    "The engine did not stop",
+  );
+});
+
+it("requires explicit consent before continuing without final output", async () => {
+  const retry = vi.fn();
+  render(
+    <SessionRecoveryNotice
+      lifecycle="fenced"
+      attention={blocked}
+      reason={{
+        type: "terminal_flush_missing",
+        detail: "Final output missing",
+      }}
+      onRetry={retry}
+    />,
+  );
+  fireEvent.click(
+    screen.getByRole("button", { name: "Continue with saved transcript" }),
+  );
+  expect(retry).not.toHaveBeenCalled();
+  expect(screen.getByRole("alertdialog")).toHaveTextContent(
+    "The interrupted turn will not run again",
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+  await act(async () => {});
+  expect(retry).not.toHaveBeenCalled();
+  fireEvent.click(
+    screen.getByRole("button", { name: "Continue with saved transcript" }),
+  );
+  const buttons = screen.getAllByRole("button", {
+    name: "Continue with saved transcript",
+  });
+  fireEvent.click(buttons[buttons.length - 1]);
+  await act(async () => {});
+  expect(retry).toHaveBeenCalledOnce();
+});
+
+it("keeps the header quiet briefly, then changes immediately from recovery to a blocker", () => {
+  vi.useFakeTimers();
+  const { container, rerender } = render(
+    <SessionLifecycleIndicator
+      lifecycle="fenced"
+      attention={recovering}
+      harness="codex"
+      unrecognizedEventCount={0}
+    />,
+  );
+  expect(container).toBeEmptyDOMElement();
+  act(() => vi.advanceTimersByTime(RECOVERY_NOTICE_DELAY_MS));
+  expect(screen.getByText("Reconnecting…")).toBeInTheDocument();
+  rerender(
+    <SessionLifecycleIndicator
+      lifecycle="fenced"
+      attention={blocked}
+      harness="codex"
+      unrecognizedEventCount={0}
+    />,
+  );
+  expect(screen.getByText("Needs you")).toBeInTheDocument();
+  expect(screen.queryByText("Reconnecting…")).toBeNull();
+});
+
+it("requires consent for recovery when an older server omits the cause", () => {
+  const retry = vi.fn();
+  render(
+    <SessionRecoveryNotice
+      lifecycle="fenced"
+      attention={blocked}
+      onRetry={retry}
+    />,
+  );
+  fireEvent.click(
+    screen.getByRole("button", { name: "Continue with saved transcript" }),
+  );
+  expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  expect(retry).not.toHaveBeenCalled();
+});

--- a/crates/tidebreak-desktop/ui/src/code/SessionRecoveryNotice.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/SessionRecoveryNotice.tsx
@@ -1,0 +1,105 @@
+import type {
+  Attention,
+  CodeSessionLifecycle,
+  FenceReason,
+} from "../api/types";
+import { recoveryAttention } from "./sessionRecovery";
+import { useConfirm } from "@/components/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { Loader } from "@/components/motion/loader";
+import { useRecoveryDelay } from "./useRecoveryDelay";
+
+export function SessionRecoveryNotice({
+  lifecycle,
+  attention,
+  reason,
+  retrying = false,
+  showProgress = true,
+  allowRetry = true,
+  onRetry,
+}: {
+  lifecycle: CodeSessionLifecycle | undefined;
+  attention: Attention | undefined;
+  reason?: FenceReason;
+  retrying?: boolean;
+  showProgress?: boolean;
+  allowRetry?: boolean;
+  onRetry: () => void;
+}) {
+  attention = recoveryAttention(lifecycle, attention, reason);
+  const { confirm, dialog } = useConfirm();
+  const recovering =
+    lifecycle === "fenced" && attention?.state.type === "fenced";
+  const showRecovery = useRecoveryDelay(recovering);
+  if (lifecycle !== "fenced") return null;
+  if (recovering) {
+    if (!showProgress || !showRecovery) return null;
+    return (
+      <div
+        role="status"
+        className="mx-4 mt-3 flex items-center gap-2 text-sm text-muted-foreground"
+      >
+        <Loader
+          variant="comet"
+          size={12}
+          className="text-muted-foreground"
+          decorative
+        />
+        <span>Reconnecting…</span>
+      </div>
+    );
+  }
+  if (attention?.state.type !== "needs_you") return null;
+  const missingOutput =
+    reason === undefined ||
+    reason?.type === "terminal_flush_missing" ||
+    reason?.type === "incarnation_unresolved" ||
+    reason?.type === "sandbox_lost";
+  const canRetry = allowRetry && lifecycle === "fenced";
+  async function retry() {
+    if (
+      missingOutput &&
+      !(await confirm({
+        title: "Continue without the missing output?",
+        description:
+          "Continue with the saved transcript and release the previous session. Any output that was not saved will remain unavailable. The interrupted turn will not run again.",
+        confirmLabel: "Continue with saved transcript",
+      }))
+    )
+      return;
+    onRetry();
+  }
+  return (
+    <div
+      role="status"
+      className="notice-surface notice-warning mx-4 mt-3 flex flex-col gap-2 rounded-md border px-3 py-2 text-sm"
+    >
+      <p>
+        {attention.state.prompt ||
+          "This session needs your attention before it can continue."}
+      </p>
+      {missingOutput && (
+        <p className="text-muted-foreground">
+          Continuing keeps the saved transcript. The missing final output will
+          not be recovered.
+        </p>
+      )}
+      {canRetry && (
+        <Button
+          type="button"
+          size="sm"
+          className="self-start"
+          disabled={retrying}
+          onClick={() => void retry()}
+        >
+          {retrying
+            ? "Retrying…"
+            : missingOutput
+              ? "Continue with saved transcript"
+              : "Retry recovery"}
+        </Button>
+      )}
+      {dialog}
+    </div>
+  );
+}

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -1,7 +1,8 @@
+import { recoveryDigest } from "./sessionRecovery";
+import { useRecoveryDelay } from "./useRecoveryDelay";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   Archive,
-  Ban,
   Bot,
   CheckCircle2,
   ChevronDown,
@@ -827,6 +828,9 @@ function WorkspaceActivityLine({
   digest: CodeSessionDigest | undefined;
   session: CodeSessionSnapshot | undefined;
 }) {
+  digest = digest ? recoveryDigest(digest) : undefined;
+  const recovering = digest?.attention.state.type === "fenced";
+  const showRecovery = useRecoveryDelay(recovering);
   // The checkout survived, so the workspace is usable — but the setup script
   // never finished, and nothing else on the card would say so.
   if (workspace.status === "setup_failed") {
@@ -845,7 +849,7 @@ function WorkspaceActivityLine({
     );
   }
   const railDigest = digest && isSessionRowWorthy(digest) ? digest : undefined;
-  if (!railDigest) return null;
+  if (!railDigest || (recovering && !showRecovery)) return null;
 
   const activity = workspaceActivitySummary(
     railDigest,
@@ -902,7 +906,7 @@ function WorkspaceActivityLine({
  *
  * The same shapes the compact attention mark draws, so the row and the badge
  * never disagree: a comet is work in motion, a circle-alert wants the
- * reader, a clock went quiet, a ban is fenced, a check is finished and
+ * reader, a clock went quiet, a comet reconnects, a check is finished and
  * unread, a pin was set by hand. Two shapes are the row's own, for a turn
  * that is alive but parked on something else: a bot for subagents and a
  * radar for a monitor, both in the live tone with the live pulse.
@@ -914,6 +918,10 @@ export function SessionStateGlyph({
   digest: CodeSessionDigest;
   pr?: PullRequestDigest;
 }) {
+  digest = recoveryDigest(digest);
+  const recovering = digest.attention.state.type === "fenced";
+  const showRecovery = useRecoveryDelay(recovering);
+  if (recovering && !showRecovery) return null;
   const className = "size-3 shrink-0";
   const attention = digest.attention.state.type;
   const mergeNotice = readyToMergeNotice(
@@ -988,10 +996,11 @@ export function SessionStateGlyph({
       );
     case "fenced":
       return (
-        <Ban
-          className={cn(className, STATUS_MARK.warning)}
-          data-state-glyph="fenced"
-          aria-hidden
+        <Loader
+          variant="comet"
+          size={12}
+          className="text-muted-foreground"
+          decorative
         />
       );
     case "manual":

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceLessSessionRow.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceLessSessionRow.tsx
@@ -1,3 +1,5 @@
+import { recoveryDigest } from "./sessionRecovery";
+import { useRecoveryDelay } from "./useRecoveryDelay";
 import type { CodeSessionDigest } from "../api/types";
 import { cn } from "../lib/utils";
 import { FOCUS_RING, HOVER_TINT } from "./interactive";
@@ -12,8 +14,11 @@ export function WorkspaceLessSessionRow({
   digest: CodeSessionDigest;
   onOpen: (sessionId: string) => void;
 }) {
+  digest = recoveryDigest(digest);
   const title = digest.title?.trim() || "Untitled conversation";
-  const status = sessionRowLabel(digest);
+  const recovering = digest.attention.state.type === "fenced";
+  const showRecovery = useRecoveryDelay(recovering);
+  const status = recovering && !showRecovery ? "" : sessionRowLabel(digest);
   return (
     <button
       type="button"

--- a/crates/tidebreak-desktop/ui/src/code/labels.ts
+++ b/crates/tidebreak-desktop/ui/src/code/labels.ts
@@ -40,7 +40,7 @@ export const LIFECYCLE_LABELS: Record<CodeSessionLifecycle, string> = {
   created: "Created",
   idle: "Idle",
   running: "Running",
-  fenced: "Fenced",
+  fenced: "Reconnecting…",
   ended: "Ended",
 };
 
@@ -144,20 +144,21 @@ export type ModeCaps = Pick<
 >;
 
 export function fenceReasonText(reason: FenceReason): string {
-  if (reason.type === "orphan_alive") {
-    return "An engine process is still running from a previous session. Reap it before starting another turn.";
+  switch (reason.type) {
+    case "orphan_alive":
+      return "Reconnecting to the session. Your transcript is kept.";
+    case "resume_lost":
+      return `The engine cannot restore this session. ${reason.detail} Your transcript is kept.`;
+    case "probe_ambiguous":
+      return `The session's process could not be identified safely. ${reason.detail}`;
+    case "repeated_turn_failures":
+      return `The session stopped after ${reason.count} failed turns. ${reason.detail}`;
+    case "terminal_flush_missing":
+      return `The remote session ended without its final output. ${reason.detail}`;
+    case "incarnation_unresolved":
+    case "sandbox_lost":
+      return `The remote session could not be restored. ${reason.detail} Your transcript is kept.`;
   }
-  if (reason.type === "resume_lost") {
-    return `The engine no longer has this session, so it cannot continue (${reason.detail}). Reap it to start a fresh engine session in this workspace; the transcript above is kept.`;
-  }
-  if (
-    reason.type === "incarnation_unresolved" ||
-    reason.type === "sandbox_lost" ||
-    reason.type === "terminal_flush_missing"
-  ) {
-    return `${reason.detail} Reap the session to close out the remote sandbox and start fresh; the journal above is kept.`;
-  }
-  return reason.detail;
 }
 
 /**
@@ -552,7 +553,7 @@ export function attentionLabel(attention: Attention): string {
     case "idle":
       return "Idle";
     case "fenced":
-      return "Fenced";
+      return "Reconnecting…";
     case "manual":
       return attention.state.note || "Pinned";
   }
@@ -568,6 +569,8 @@ export function attentionTooltip(attention: Attention): string {
       return `Stalled · idle ${attention.state.idle_secs}s`;
     case "needs_you":
       return `${attentionLabel(attention)} · ${attention.state.source}`;
+    case "fenced":
+      return "Reconnecting automatically. Your transcript is kept; the interrupted turn will not run again.";
     case "manual":
       return attention.state.note
         ? `Pinned · ${attention.state.note}`

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -397,6 +397,23 @@ describe("parseCodeSession attention states", () => {
     expect(parsed?.attention.state.type).toBe(state.type);
   });
 
+  it.each(STATES)("preserves %o in the session digest", (state) => {
+    const digest = {
+      workspace: "ws-1",
+      session: "sess-1",
+      kind: "interactive",
+      lifecycle: "idle",
+      attention: { state, source: "lifecycle" },
+      title: "Fix login",
+      turn_count: 3,
+    };
+    expect(parseCodeSessionDigest(digest)).toEqual(digest);
+    expect(parseCodeUpdateNotice({ type: "digest", ...digest })).toEqual({
+      type: "digest",
+      ...digest,
+    });
+  });
+
   it("still rejects a state the server cannot send", () => {
     expect(
       parseCodeSession({
@@ -933,6 +950,37 @@ describe("pull request state in live updates", () => {
     activity: "shell",
     pr_state: richPr,
   };
+
+  it("preserves recovery reasons on pinned snapshots and live notices", () => {
+    const pinned = {
+      ...digest,
+      lifecycle: "fenced",
+      attention: {
+        state: { type: "manual", note: "Review today" },
+        source: "user",
+      },
+      fence_reason: {
+        type: "probe_ambiguous",
+        detail: "Automatic recovery failed",
+      },
+    };
+    expect(parseCodeSessionDigest(pinned)).toEqual(pinned);
+    expect(parseCodeUpdateNotice({ type: "digest", ...pinned })).toEqual({
+      type: "digest",
+      ...pinned,
+    });
+    expect(
+      parseCodeSessionDigest({ ...pinned, fence_reason: { type: "unknown" } }),
+    ).toBeNull();
+    expect(
+      parseCodeUpdateNotice({
+        type: "digest",
+        ...pinned,
+        fence_reason: { type: "unknown" },
+      }),
+    ).toBeNull();
+    expect(parseCodeSessionDigest(digest)).toEqual(digest);
+  });
 
   it("preserves the complete PR digest in a digest notice", () => {
     expect(parseCodeUpdateNotice({ type: "digest", ...digest })).toEqual({

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -4134,20 +4134,6 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
         ...(actor ? { actor } : {}),
       };
     }
-    case "attention_changed": {
-      if (
-        !onlyKeys<Extract<WireCodeEvent, { type: "attention_changed" }>>(
-          value,
-          ["type", "state", "source"],
-        ) ||
-        !isMember(value.source, ATTENTION_SOURCES)
-      ) {
-        return null;
-      }
-      const state = parseAttentionState(value.state);
-      if (!state) return null;
-      return { type: "attention_changed", state, source: value.source };
-    }
     case "file_changed": {
       if (
         !onlyKeys<Extract<WireCodeEvent, { type: "file_changed" }>>(value, [
@@ -4374,6 +4360,7 @@ export function parseCodeSessionDigest(
       "harness_kind",
       "lifecycle",
       "attention",
+      "fence_reason",
       "title",
       "turn_count",
       "trigger_target_at",
@@ -4413,6 +4400,11 @@ export function parseCodeSessionDigest(
   ) {
     return null;
   }
+  const fence_reason =
+    value.fence_reason === undefined
+      ? undefined
+      : parseFenceReason(value.fence_reason);
+  if (value.fence_reason !== undefined && !fence_reason) return null;
   const attention = parseAttention(value.attention);
   if (!attention) return null;
   const pr_state =
@@ -4433,6 +4425,7 @@ export function parseCodeSessionDigest(
       : {}),
     lifecycle: value.lifecycle,
     attention,
+    ...(fence_reason ? { fence_reason } : {}),
     title: value.title,
     turn_count: value.turn_count,
     ...(value.trigger_target_at !== undefined
@@ -4492,6 +4485,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
           "harness_kind",
           "lifecycle",
           "attention",
+          "fence_reason",
           "title",
           "turn_count",
           "trigger_target_at",
@@ -4530,6 +4524,11 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
       ) {
         return null;
       }
+      const fence_reason =
+        value.fence_reason === undefined
+          ? undefined
+          : parseFenceReason(value.fence_reason);
+      if (value.fence_reason !== undefined && !fence_reason) return null;
       const attention = parseAttention(value.attention);
       if (!attention) return null;
       const pr_state =
@@ -4550,6 +4549,7 @@ export function parseCodeUpdateNotice(value: unknown): CodeUpdateNotice | null {
           : {}),
         lifecycle: value.lifecycle,
         attention,
+        ...(fence_reason ? { fence_reason } : {}),
         title: value.title,
         turn_count: value.turn_count,
         ...(value.trigger_target_at !== undefined

--- a/crates/tidebreak-desktop/ui/src/code/sessionRecovery.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/sessionRecovery.dom.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { CodeSessionSnapshot } from "../api/types";
+import { codeDigest, codeSession } from "@/stories/fixtures";
+import { useCodeUpdatesStore, useSessionDigest } from "./CodeUpdatesStore";
+import { SessionRecoveryNotice } from "./SessionRecoveryNotice";
+import { sessionRecoveryState } from "./sessionRecovery";
+
+afterEach(() => {
+  cleanup();
+  useCodeUpdatesStore.getState().resetLive();
+});
+
+function SelectedSession({
+  session,
+  onRetry,
+}: {
+  session: CodeSessionSnapshot;
+  onRetry: () => void;
+}) {
+  const digest = useSessionDigest(
+    session.workspace_id ?? undefined,
+    session.id,
+  );
+  const state = sessionRecoveryState(session, digest);
+  return (
+    <>
+      <textarea aria-label="Message" disabled={state.blocksTurn} />
+      <SessionRecoveryNotice
+        {...state}
+        showProgress={false}
+        onRetry={onRetry}
+      />
+    </>
+  );
+}
+
+it.each(["interactive", "watch"] as const)(
+  "keeps recovery scoped to the selected session beside a %s sibling",
+  (kind) => {
+    const retry = vi.fn();
+    const healthy = {
+      ...codeSession,
+      id: "healthy",
+      lifecycle: "idle" as const,
+      attention: {
+        state: { type: "idle" as const },
+        source: "lifecycle" as const,
+      },
+    };
+    const fenced = {
+      ...codeSession,
+      id: "fenced",
+      kind,
+      lifecycle: "fenced" as const,
+      fence_reason: { type: "orphan_alive" as const },
+    };
+    useCodeUpdatesStore.getState().apply({
+      type: "snapshot",
+      sessions: [
+        codeDigest({
+          session: healthy.id,
+          lifecycle: healthy.lifecycle,
+          attention: healthy.attention,
+        }),
+        codeDigest({
+          session: fenced.id,
+          kind,
+          lifecycle: "fenced",
+          fence_reason: { type: "probe_ambiguous", detail: "Process changed" },
+          attention: {
+            state: {
+              type: "needs_you",
+              prompt: "Inspect the fenced session's process.",
+              source: "lifecycle",
+            },
+            source: "lifecycle",
+          },
+        }),
+      ],
+    });
+    const view = render(<SelectedSession session={healthy} onRetry={retry} />);
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Retry recovery" })).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(retry).not.toHaveBeenCalled();
+
+    view.rerender(<SelectedSession session={fenced} onRetry={retry} />);
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Inspect the fenced session's process.",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Retry recovery" }));
+    expect(retry).toHaveBeenCalledOnce();
+
+    view.rerender(<SelectedSession session={healthy} onRetry={retry} />);
+    expect(screen.getByRole("textbox", { name: "Message" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Retry recovery" })).toBeNull();
+  },
+);

--- a/crates/tidebreak-desktop/ui/src/code/sessionRecovery.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/sessionRecovery.test.ts
@@ -3,6 +3,7 @@ import type { CodeSessionDigest, CodeSessionSnapshot } from "../api/types";
 import { sessionRecoveryState } from "./sessionRecovery";
 
 const snapshot = {
+  id: "selected",
   lifecycle: "fenced",
   fence_reason: { type: "orphan_alive" },
   attention: {
@@ -13,6 +14,7 @@ const snapshot = {
 
 it("unblocks the composer when a live digest recovers a stale snapshot", () => {
   const digest = {
+    session: snapshot.id,
     lifecycle: "idle",
     attention: { state: { type: "idle" }, source: "lifecycle" },
   } as CodeSessionDigest;
@@ -26,6 +28,7 @@ it("unblocks the composer when a live digest recovers a stale snapshot", () => {
 
 it("shows the live failure prompt while the snapshot still says recovery is pending", () => {
   const digest = {
+    session: snapshot.id,
     lifecycle: "fenced",
     attention: {
       state: {
@@ -46,6 +49,7 @@ it("shows the live failure prompt while the snapshot still says recovery is pend
 
 it("takes the live reason when recovery fails on a pinned session", () => {
   const digest = {
+    session: snapshot.id,
     lifecycle: "fenced",
     fence_reason: {
       type: "probe_ambiguous",
@@ -67,6 +71,7 @@ it("takes the live reason when recovery fails on a pinned session", () => {
 
 it("offers manual recovery for older servers without recovery digest fields", () => {
   const digest = {
+    session: snapshot.id,
     lifecycle: "fenced",
     attention: snapshot.attention,
   } as CodeSessionDigest;
@@ -80,6 +85,7 @@ it("offers manual recovery for older servers without recovery digest fields", ()
 
 it("shows a safe manual fallback for an older server's pinned recovery", () => {
   const digest = {
+    session: snapshot.id,
     lifecycle: "fenced",
     attention: {
       state: { type: "manual", note: "Review today" },
@@ -89,4 +95,52 @@ it("shows a safe manual fallback for an older server's pinned recovery", () => {
   const result = sessionRecoveryState(snapshot, digest);
   expect(result.attention?.state).toMatchObject({ type: "needs_you" });
   expect(result.reason).toBeUndefined();
+});
+
+it("ignores a fenced sibling digest when the selected session is healthy", () => {
+  const selected = {
+    ...snapshot,
+    lifecycle: "idle" as const,
+    fence_reason: undefined,
+    attention: {
+      state: { type: "idle" as const },
+      source: "lifecycle" as const,
+    },
+  };
+  const sibling = {
+    session: "sibling",
+    lifecycle: "fenced",
+    fence_reason: {
+      type: "probe_ambiguous",
+      detail: "Sibling recovery stopped",
+    },
+    attention: {
+      state: {
+        type: "needs_you",
+        prompt: "Retry the sibling session.",
+        source: "lifecycle",
+      },
+      source: "lifecycle",
+    },
+  } as CodeSessionDigest;
+  expect(sessionRecoveryState(selected, sibling)).toEqual({
+    lifecycle: "idle",
+    attention: selected.attention,
+    reason: undefined,
+    blocksTurn: false,
+  });
+});
+
+it("ignores a healthy sibling digest when the selected session is fenced", () => {
+  const sibling = {
+    session: "sibling",
+    lifecycle: "idle",
+    attention: { state: { type: "idle" }, source: "lifecycle" },
+  } as CodeSessionDigest;
+  expect(sessionRecoveryState(snapshot, sibling)).toEqual({
+    lifecycle: "fenced",
+    attention: snapshot.attention,
+    reason: snapshot.fence_reason,
+    blocksTurn: true,
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/sessionRecovery.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/sessionRecovery.test.ts
@@ -1,0 +1,92 @@
+import { expect, it } from "vitest";
+import type { CodeSessionDigest, CodeSessionSnapshot } from "../api/types";
+import { sessionRecoveryState } from "./sessionRecovery";
+
+const snapshot = {
+  lifecycle: "fenced",
+  fence_reason: { type: "orphan_alive" },
+  attention: {
+    state: { type: "fenced", reason: { type: "orphan_alive" } },
+    source: "lifecycle",
+  },
+} as CodeSessionSnapshot;
+
+it("unblocks the composer when a live digest recovers a stale snapshot", () => {
+  const digest = {
+    lifecycle: "idle",
+    attention: { state: { type: "idle" }, source: "lifecycle" },
+  } as CodeSessionDigest;
+  expect(sessionRecoveryState(snapshot, digest)).toEqual({
+    lifecycle: "idle",
+    attention: digest.attention,
+    blocksTurn: false,
+    reason: undefined,
+  });
+});
+
+it("shows the live failure prompt while the snapshot still says recovery is pending", () => {
+  const digest = {
+    lifecycle: "fenced",
+    attention: {
+      state: {
+        type: "needs_you",
+        prompt: "Check the engine credentials before retrying.",
+        source: "lifecycle",
+      },
+      source: "lifecycle",
+    },
+  } as CodeSessionDigest;
+  expect(sessionRecoveryState(snapshot, digest)).toEqual({
+    lifecycle: "fenced",
+    attention: digest.attention,
+    blocksTurn: true,
+    reason: undefined,
+  });
+});
+
+it("takes the live reason when recovery fails on a pinned session", () => {
+  const digest = {
+    lifecycle: "fenced",
+    fence_reason: {
+      type: "probe_ambiguous",
+      detail: "Automatic recovery failed. Inspect the previous process.",
+    },
+    attention: {
+      state: { type: "manual", note: "Review today" },
+      source: "user",
+    },
+  } as CodeSessionDigest;
+  const result = sessionRecoveryState(snapshot, digest);
+  expect(result.reason).toEqual(digest.fence_reason);
+  expect(result.attention?.state).toMatchObject({
+    type: "needs_you",
+    prompt: expect.stringContaining("Inspect the previous process"),
+  });
+  expect(digest.attention.state.type).toBe("manual");
+});
+
+it("offers manual recovery for older servers without recovery digest fields", () => {
+  const digest = {
+    lifecycle: "fenced",
+    attention: snapshot.attention,
+  } as CodeSessionDigest;
+  const result = sessionRecoveryState(snapshot, digest);
+  expect(result.attention?.state).toMatchObject({
+    type: "needs_you",
+    prompt: expect.stringContaining("Retry recovery"),
+  });
+  expect(result.reason?.type).toBe("orphan_alive");
+});
+
+it("shows a safe manual fallback for an older server's pinned recovery", () => {
+  const digest = {
+    lifecycle: "fenced",
+    attention: {
+      state: { type: "manual", note: "Review today" },
+      source: "user",
+    },
+  } as CodeSessionDigest;
+  const result = sessionRecoveryState(snapshot, digest);
+  expect(result.attention?.state).toMatchObject({ type: "needs_you" });
+  expect(result.reason).toBeUndefined();
+});

--- a/crates/tidebreak-desktop/ui/src/code/sessionRecovery.ts
+++ b/crates/tidebreak-desktop/ui/src/code/sessionRecovery.ts
@@ -37,11 +37,12 @@ export function recoveryAttention(
   };
 }
 
-/** The live digest supersedes the snapshot, including a stale recovery reason. */
+/** A matching live digest supersedes the snapshot and its recovery reason. */
 export function sessionRecoveryState(
   session: CodeSessionSnapshot | null | undefined,
   digest: CodeSessionDigest | undefined,
 ) {
+  if (session && digest?.session !== session.id) digest = undefined;
   const lifecycle = digest?.lifecycle ?? session?.lifecycle;
   const rawAttention = digest?.attention ?? session?.attention;
   const reason = digest

--- a/crates/tidebreak-desktop/ui/src/code/sessionRecovery.ts
+++ b/crates/tidebreak-desktop/ui/src/code/sessionRecovery.ts
@@ -1,0 +1,80 @@
+import type {
+  Attention,
+  CodeSessionDigest,
+  CodeSessionSnapshot,
+  FenceReason,
+} from "../api/types";
+import { fenceReasonText } from "./labels";
+
+export function automaticRecoveryReason(
+  reason: FenceReason | undefined,
+): boolean {
+  return (
+    reason?.type === "orphan_alive" ||
+    reason?.type === "resume_lost" ||
+    reason?.type === "sandbox_lost"
+  );
+}
+
+/** Recovery status stays visible even when the reader has pinned the session. */
+export function recoveryAttention(
+  lifecycle: CodeSessionSnapshot["lifecycle"] | undefined,
+  attention: Attention | undefined,
+  reason: FenceReason | undefined,
+): Attention | undefined {
+  if (lifecycle !== "fenced" || attention?.state.type === "needs_you")
+    return attention;
+  if (!reason) return attention;
+  if (automaticRecoveryReason(reason))
+    return { state: { type: "fenced", reason }, source: "lifecycle" };
+  return {
+    state: {
+      type: "needs_you",
+      prompt: fenceReasonText(reason),
+      source: "lifecycle",
+    },
+    source: "lifecycle",
+  };
+}
+
+/** The live digest supersedes the snapshot, including a stale recovery reason. */
+export function sessionRecoveryState(
+  session: CodeSessionSnapshot | null | undefined,
+  digest: CodeSessionDigest | undefined,
+) {
+  const lifecycle = digest?.lifecycle ?? session?.lifecycle;
+  const rawAttention = digest?.attention ?? session?.attention;
+  const reason = digest
+    ? (digest.fence_reason ??
+      (digest.attention.state.type === "fenced"
+        ? digest.attention.state.reason
+        : undefined))
+    : session?.fence_reason;
+  return {
+    lifecycle,
+    attention:
+      digest &&
+      lifecycle === "fenced" &&
+      !digest.fence_reason &&
+      rawAttention?.state.type !== "needs_you"
+        ? ({
+            state: {
+              type: "needs_you",
+              prompt:
+                "The engine connection stopped. Retry recovery to continue with the saved transcript.",
+              source: "lifecycle",
+            },
+            source: "lifecycle",
+          } as Attention)
+        : recoveryAttention(lifecycle, rawAttention, reason),
+    reason,
+    blocksTurn: lifecycle === "fenced",
+  };
+}
+
+export function recoveryDigest(digest: CodeSessionDigest): CodeSessionDigest {
+  const state = sessionRecoveryState(undefined, digest);
+  return state.attention && state.attention !== digest.attention
+    ? { ...digest, attention: state.attention }
+    : digest;
+}

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.test.ts
@@ -32,7 +32,7 @@ describe("attentionStatusTone", () => {
     expect(STATUS_MOTION[tone]).toBeTruthy();
   });
 
-  it("separates the two warnings from the one critical", () => {
+  it("separates recovery progress, warnings, and a direct need", () => {
     const tone = (state: Attention["state"]) =>
       attentionStatusTone({ state, source: "lifecycle" });
     expect(tone({ type: "needs_you", prompt: "", source: "structured" })).toBe(
@@ -40,7 +40,7 @@ describe("attentionStatusTone", () => {
     );
     expect(tone({ type: "stalled", idle_secs: 90 })).toBe("warning");
     expect(tone({ type: "fenced", reason: { type: "orphan_alive" } })).toBe(
-      "warning",
+      "pending",
     );
     expect(tone({ type: "done_unreviewed" })).toBe("neutral");
   });

--- a/crates/tidebreak-desktop/ui/src/code/statusTone.ts
+++ b/crates/tidebreak-desktop/ui/src/code/statusTone.ts
@@ -109,8 +109,9 @@ export function attentionStatusTone(attention: Attention): StatusTone {
     case "needs_you":
       return "critical";
     case "stalled":
-    case "fenced":
       return "warning";
+    case "fenced":
+      return "pending";
     case "manual":
       return "pending";
     case "done_unreviewed":

--- a/crates/tidebreak-desktop/ui/src/code/useRecoveryDelay.ts
+++ b/crates/tidebreak-desktop/ui/src/code/useRecoveryDelay.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+/** Brief disconnects settle before recovery adds status text. */
+export const RECOVERY_NOTICE_DELAY_MS = 1500;
+
+export function useRecoveryDelay(recovering: boolean): boolean {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    setVisible(false);
+    if (!recovering) return;
+    const timer = setTimeout(() => setVisible(true), RECOVERY_NOTICE_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [recovering]);
+  return recovering && visible;
+}

--- a/crates/tidebreak-desktop/ui/src/code/workspace/badges.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/badges.dom.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { SessionAttentionBadge } from "./badges";
+
+vi.mock("./CodeSessionPane", () => ({
+  useRegisteredCodeSession: () => {
+    throw new Error("Attention comes from the session digest");
+  },
+}));
+
+afterEach(cleanup);
+
+it("updates the header when digest attention changes", () => {
+  const { container, rerender } = render(
+    <SessionAttentionBadge
+      attention={{ state: { type: "working" }, source: "lifecycle" }}
+    />,
+  );
+  expect(container).toBeEmptyDOMElement();
+
+  rerender(
+    <SessionAttentionBadge
+      attention={{
+        state: {
+          type: "needs_you",
+          prompt: "Approve the write",
+          source: "structured",
+        },
+        source: "structured",
+      }}
+    />,
+  );
+  expect(screen.getByLabelText("Approve the write")).toHaveAttribute(
+    "data-attention",
+    "needs_you",
+  );
+
+  rerender(
+    <SessionAttentionBadge
+      attention={{ state: { type: "idle" }, source: "lifecycle" }}
+    />,
+  );
+  expect(container).toBeEmptyDOMElement();
+});

--- a/crates/tidebreak-desktop/ui/src/code/workspace/badges.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/badges.tsx
@@ -8,20 +8,14 @@ import { followScrollBehavior } from "@/ChatScroll";
 import { useRegisteredCodeSession } from "./CodeSessionPane";
 
 export function SessionAttentionBadge({
-  sessionId,
-  client,
-  fallback,
+  attention,
 }: {
-  sessionId: string;
-  client: ApiClient;
-  fallback: Attention | undefined;
+  attention: Attention | undefined;
 }) {
-  const store = useRegisteredCodeSession(sessionId, client);
-  const live = store((state) => state.attention);
-  const attention = live ?? fallback;
   // The lifecycle indicator owns live motion in this header. Keep the
   // attention mark for states that carry separate information.
-  if (attention?.state.type === "working") return null;
+  if (attention?.state.type === "working" || attention?.state.type === "fenced")
+    return null;
   return <AttentionBadge compact attention={attention} />;
 }
 

--- a/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspace/useWorkspaceSessions.ts
@@ -392,8 +392,10 @@ export function useWorkspaceSessions({
     }
   }
 
-  async function reap() {
-    if (!session) return;
+  const [retryingRecovery, setRetryingRecovery] = useState(false);
+  async function retryRecovery() {
+    if (!session || retryingRecovery) return;
+    setRetryingRecovery(true);
     try {
       const next = await client.reapCodeSession(session.id);
       catalog.rememberSession(next);
@@ -401,7 +403,9 @@ export function useWorkspaceSessions({
         current.map((entry) => (entry.id === next.id ? next : entry)),
       );
     } catch (err) {
-      toast.error(friendlyErrorMessage(err, "Could not reap the session"));
+      toast.error(friendlyErrorMessage(err, "Could not recover the session"));
+    } finally {
+      setRetryingRecovery(false);
     }
   }
 
@@ -578,7 +582,8 @@ export function useWorkspaceSessions({
     error,
     retry: () => setReloadToken((token) => token + 1),
     startSession,
-    reap,
+    retryRecovery,
+    retryingRecovery,
     selectConversation,
     newConversation,
     forkConversation,

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.test.ts
@@ -679,7 +679,7 @@ describe("workspaceStatusRank", () => {
     ).toBe("running");
   });
 
-  it("ranks a stale stall and a fenced session with needs-you", () => {
+  it("ranks a stale stall as needs-you and automatic recovery as running", () => {
     expect(
       workspaceStatusRank(
         workspace("ws-a", "app"),
@@ -695,13 +695,15 @@ describe("workspaceStatusRank", () => {
       workspaceStatusRank(
         workspace("ws-a", "app"),
         digest("ws-a", {
+          lifecycle: "fenced",
+          fence_reason: { type: "orphan_alive" },
           attention: {
             state: { type: "fenced", reason: { type: "orphan_alive" } },
             source: "structured",
           },
         }),
       ),
-    ).toBe("needs_you");
+    ).toBe("running");
   });
 
   it("ranks an idle session with turns as done, and an empty one as idle", () => {

--- a/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
+++ b/crates/tidebreak-desktop/ui/src/code/workspaceCards.ts
@@ -1,3 +1,4 @@
+import { recoveryDigest } from "./sessionRecovery";
 import type {
   Attention,
   CodeRepoSnapshot,
@@ -193,7 +194,7 @@ export function readyToMergeNotice(
  *
  * A stalled state is only a silence heuristic. While the lifecycle still says
  * running, the workspace stays with live work and the session row carries the
- * warning. A stale stalled state and a fenced session join needs-you. Ready to
+ * warning. A stale stalled state joins needs-you; automatic recovery stays with live work. Ready to
  * merge does not: notify and watch store it as needs-you, but it is a
  * successful pull-request state, and a merged or closed pull request makes
  * that prompt stale. Idle or ended sessions with turns join Done, matching
@@ -205,17 +206,18 @@ export function workspaceStatusRank(
   workspace: CodeWorkspaceSnapshot,
   digest: CodeSessionDigest | undefined,
 ): WorkspaceStatusRank {
+  digest = digest ? recoveryDigest(digest) : undefined;
   if (isPutAway(workspace)) return "archived";
   const attentionType = digest?.attention.state.type;
   const pr = digest?.pr_state ?? workspace.pr;
   if (
-    (attentionType === "needs_you" &&
-      !isReadyToMergeAttention(digest?.attention)) ||
-    attentionType === "fenced"
+    attentionType === "needs_you" &&
+    !isReadyToMergeAttention(digest?.attention)
   ) {
     return "needs_you";
   }
-  if (digest?.lifecycle === "running") return "running";
+  if (digest?.lifecycle === "running" || attentionType === "fenced")
+    return "running";
   if (attentionType === "stalled") return "needs_you";
   if (pr) {
     const lifecycle = pullRequestLifecycle(pr);
@@ -489,6 +491,7 @@ export function isSessionRowWorthy(
 
 /** Short lifecycle word for the nested session row. */
 export function sessionRowLabel(digest: CodeSessionDigest): string {
+  digest = recoveryDigest(digest);
   if (digest.attention.state.type === "needs_you") {
     const notice = readyToMergeNotice(digest.attention, digest.pr_state);
     if (notice === "ready") {
@@ -501,7 +504,7 @@ export function sessionRowLabel(digest: CodeSessionDigest): string {
     case "stalled":
       return "Stalled";
     case "fenced":
-      return "Fenced";
+      return "Reconnecting…";
     case "done_unreviewed":
       return "Done";
     case "manual":
@@ -531,6 +534,7 @@ export function sessionActivityLineLabel(
   digest: CodeSessionDigest,
   pr: PrStateInput | undefined = digest.pr_state,
 ): string {
+  digest = recoveryDigest(digest);
   if (digest.attention.state.type === "needs_you") {
     const notice = readyToMergeNotice(digest.attention, pr);
     if (notice !== "stale") {
@@ -545,6 +549,7 @@ export function sessionActivityLineLabel(
     if (detail && !hasRunningSubagents(digest)) return detail;
     return sessionActivityLabel(digest);
   }
+  if (digest.attention.state.type === "fenced") return "Reconnecting…";
   const recap = digest.recap?.trim();
   if (recap) return recap;
   return sessionRowLabel(digest);

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2298,15 +2298,7 @@ message: string,
 /**
  * Bounded remedy sentence for the person.
  */
-remediation: string, } | { "type": "attention_changed",
-/**
- * New state.
- */
-state: AttentionState,
-/**
- * Who or what set it.
- */
-source: AttentionSource, } | { "type": "stream_interrupted" } | { "type": "tool_args_delta",
+remediation: string, } | { "type": "stream_interrupted" } | { "type": "tool_args_delta",
 /**
  * The call these args belong to.
  */
@@ -4825,7 +4817,11 @@ can_open_chat?: boolean, session: SessionId, kind: SessionKind,
  * one workspace row. Optional on the wire so a desktop can still read a
  * digest from an older server during an update.
  */
-harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
+harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention,
+/**
+ * Recovery cause, independent of a manual attention pin.
+ */
+fence_reason?: FenceReason, title: string, turn_count: number,
 /**
  * Timestamp trigger delivery uses to rank candidate sessions: the newest
  * turn start, or session creation before the first turn. Optional so a
@@ -5708,7 +5704,7 @@ sessions: Array<SessionDigest>, } | { "type": "digest", workspace: WorkspaceId |
 /**
  * Engine identity for the session represented by this digest.
  */
-harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
+harness_kind?: HarnessKind, lifecycle: SessionLifecycle, fence_reason?: FenceReason, attention: Attention, title: string, turn_count: number,
 /**
  * Timestamp trigger delivery uses to rank candidate sessions.
  */

--- a/crates/tidebreak-desktop/ui/src/stories/AttentionBadge.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/AttentionBadge.stories.tsx
@@ -47,7 +47,7 @@ export const DoneUnreviewed: Story = {
   args: { attention: attentionDoneUnreviewed },
 };
 
-export const Fenced: Story = {
+export const Reconnecting: Story = {
   args: { attention: attentionFenced },
 };
 

--- a/crates/tidebreak-desktop/ui/src/stories/SessionAttentionBadge.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SessionAttentionBadge.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Attention } from "@/api/types";
+import { SessionAttentionBadge } from "@/code/workspace/badges";
+import {
+  attentionDoneUnreviewed,
+  attentionFenced,
+  attentionManual,
+  attentionNeedsYou,
+  attentionStalled,
+  attentionWorking,
+} from "./fixtures";
+
+const meta = {
+  title: "Code/Session attention badge",
+  component: SessionAttentionBadge,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof SessionAttentionBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const states: Array<{ label: string; attention: Attention | undefined }> = [
+  { label: "Loading", attention: undefined },
+  { label: "Working", attention: attentionWorking },
+  {
+    label: "Idle",
+    attention: { state: { type: "idle" }, source: "lifecycle" },
+  },
+  { label: "Needs you", attention: attentionNeedsYou },
+  { label: "Stalled", attention: attentionStalled },
+  { label: "Done", attention: attentionDoneUnreviewed },
+  { label: "Reconnecting", attention: attentionFenced },
+  { label: "Pinned", attention: attentionManual },
+];
+
+export const DigestStates: Story = {
+  args: { attention: attentionNeedsYou },
+  render: () => (
+    <div className="flex max-w-sm flex-col divide-y divide-border text-sm">
+      {states.map(({ label, attention }) => (
+        <div key={label} className="flex min-h-10 items-center gap-3 py-2">
+          <span className="w-24 shrink-0 text-muted-foreground">{label}</span>
+          <SessionAttentionBadge attention={attention} />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/crates/tidebreak-desktop/ui/src/stories/SessionRecovery.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/SessionRecovery.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, waitFor, within } from "storybook/test";
+import type { Attention, FenceReason } from "@/api/types";
+import { recoveryAttention } from "@/code/sessionRecovery";
+import { SessionRecoveryNotice } from "@/code/SessionRecoveryNotice";
+import { SessionLifecycleIndicator } from "@/code/SessionLifecycleIndicator";
+import { attentionFenced } from "./fixtures";
+
+const meta = {
+  title: "Code/Session recovery",
+  component: SessionRecoveryNotice,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof SessionRecoveryNotice>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const blockers: Array<{ title: string; reason: FenceReason; prompt: string }> =
+  [
+    {
+      title: "Sign-in required",
+      reason: {
+        type: "repeated_turn_failures",
+        count: 3,
+        detail: "Authentication failed",
+      },
+      prompt:
+        "The session stopped after repeated authentication failures. Sign in to the engine, then retry recovery.",
+    },
+    {
+      title: "Process needs inspection",
+      reason: { type: "probe_ambiguous", detail: "Process identity changed" },
+      prompt:
+        "The previous process could not be identified safely. Inspect the process before retrying recovery.",
+    },
+    {
+      title: "Final output unavailable",
+      reason: {
+        type: "terminal_flush_missing",
+        detail: "Final output unavailable",
+      },
+      prompt:
+        "The remote session ended without final output. Inspect the saved transcript before continuing.",
+    },
+  ];
+
+export const States: Story = {
+  args: { onRetry: () => {}, lifecycle: "fenced", attention: attentionFenced },
+  render: () => (
+    <div className="flex max-w-xl flex-col gap-6">
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Reconnecting</h2>
+        <SessionLifecycleIndicator
+          lifecycle="fenced"
+          attention={attentionFenced}
+          harness="codex"
+          unrecognizedEventCount={0}
+        />
+        <SessionRecoveryNotice
+          showProgress={false}
+          lifecycle="fenced"
+          attention={attentionFenced}
+          onRetry={() => {}}
+        />
+      </section>
+      {blockers.map(({ title, reason, prompt }) => {
+        const attention: Attention =
+          reason.type === "probe_ambiguous"
+            ? {
+                state: { type: "manual", note: "Review today" },
+                source: "user",
+              }
+            : {
+                state: { type: "needs_you", source: "lifecycle", prompt },
+                source: "lifecycle",
+              };
+        return (
+          <section key={title} className="flex flex-col gap-2">
+            <h2 className="text-sm font-medium">{title}</h2>
+            <SessionLifecycleIndicator
+              lifecycle="fenced"
+              attention={recoveryAttention("fenced", attention, reason)}
+              harness="codex"
+              unrecognizedEventCount={0}
+            />
+            <SessionRecoveryNotice
+              lifecycle="fenced"
+              attention={attention}
+              reason={reason}
+              onRetry={() => {}}
+            />
+          </section>
+        );
+      })}
+      <section className="flex flex-col gap-2">
+        <h2 className="text-sm font-medium">Recovered</h2>
+        <SessionLifecycleIndicator
+          lifecycle="idle"
+          attention={{ state: { type: "idle" }, source: "lifecycle" }}
+          harness="codex"
+          unrecognizedEventCount={0}
+        />
+        <SessionRecoveryNotice
+          lifecycle="idle"
+          attention={{ state: { type: "idle" }, source: "lifecycle" }}
+          onRetry={() => {}}
+        />
+      </section>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await waitFor(
+      () =>
+        expect(
+          within(canvasElement).getAllByText("Reconnecting…"),
+        ).toHaveLength(1),
+      { timeout: 3000 },
+    );
+  },
+};

--- a/crates/tidebreak-desktop/ui/src/stories/StateIndicators.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/StateIndicators.stories.tsx
@@ -35,8 +35,8 @@ const attentionStates: Array<{
     attention: attentionStalled,
   },
   {
-    label: "Fenced",
-    description: "The session cannot continue safely.",
+    label: "Reconnecting",
+    description: "The connection recovers automatically.",
     attention: attentionFenced,
   },
   {
@@ -79,8 +79,8 @@ const headerStates: Array<{
     attention: attentionStalled,
   },
   {
-    label: "Fenced",
-    description: "The blocked mark stays distinct from a temporary stall.",
+    label: "Reconnecting",
+    description: "Brief disconnects stay quiet before progress appears.",
     lifecycle: "fenced",
     attention: attentionFenced,
   },
@@ -108,7 +108,7 @@ function StatusRow({
   description: string;
 }) {
   return (
-    <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-center gap-4 border-t border-border-subtle px-4 py-3 first:border-t-0">
+    <div className="grid grid-cols-[9rem_minmax(0,1fr)] items-center gap-4 border-t border-border-subtle px-4 py-3 first:border-t-0">
       <div className="flex min-h-7 items-center gap-2">{mark}</div>
       <div className="min-w-0">
         <p className="text-sm font-medium">{label}</p>
@@ -170,11 +170,13 @@ function StateIndicators() {
                 key={state.label}
                 mark={
                   <>
-                    {state.attention && (
-                      <AttentionBadge attention={state.attention} compact />
-                    )}
+                    {state.attention &&
+                      state.attention.state.type !== "fenced" && (
+                        <AttentionBadge attention={state.attention} compact />
+                      )}
                     <SessionLifecycleIndicator
                       lifecycle={state.lifecycle}
+                      attention={state.attention}
                       harness="codex"
                       version="0.84.0"
                       unrecognizedEventCount={state.unrecognizedEventCount ?? 0}

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceHeader.stories.tsx
@@ -114,7 +114,12 @@ function HeaderState({
         loading ? undefined : (
           <>
             {attention?.state.type !== "working" && (
-              <AttentionBadge attention={attention} compact />
+              <AttentionBadge
+                attention={
+                  attention?.state.type === "fenced" ? undefined : attention
+                }
+                compact
+              />
             )}
             {pendingApprovals > 0 && (
               <Badge variant="warning" size="sm">
@@ -124,6 +129,7 @@ function HeaderState({
             )}
             <SessionLifecycleIndicator
               lifecycle={lifecycle}
+              attention={attention}
               harness="codex"
               version="0.84.0"
               unrecognizedEventCount={unrecognizedEventCount}
@@ -224,7 +230,7 @@ export const Stalled: Story = {
   },
 };
 
-export const Fenced: Story = {
+export const Reconnecting: Story = {
   args: {
     snapshot: openPrGit,
     attention: attentionFenced,

--- a/crates/tidebreak-server-api/fixtures/code-frames.json
+++ b/crates/tidebreak-server-api/fixtures/code-frames.json
@@ -566,6 +566,63 @@
   },
   {
     "kind": "session_digest",
+    "name": "recovery digest with manual attention",
+    "value": {
+      "attention": {
+        "source": "user",
+        "state": {
+          "note": "Review these edits",
+          "type": "manual"
+        }
+      },
+      "fence_reason": {
+        "detail": "The previous engine process could not be identified",
+        "type": "probe_ambiguous"
+      },
+      "harness_kind": "claude_code",
+      "kind": "interactive",
+      "lifecycle": "fenced",
+      "pr_count": 1,
+      "pr_state": {
+        "auto_merge_enabled": true,
+        "base_branch": "main",
+        "check_counts": {
+          "failing": 0,
+          "passing": 10,
+          "pending": 3,
+          "skipped": 2
+        },
+        "checks_summary": "3 pending",
+        "draft": false,
+        "head_branch": "thet/cli-wire-mirror",
+        "head_sha": "24b451ab7248eb057445718f2ad6304a43915f37",
+        "in_merge_queue": false,
+        "merge_state_status": "BLOCKED",
+        "mergeable": "MERGEABLE",
+        "merged": false,
+        "number": 3006,
+        "review_decision": "APPROVED",
+        "state": "open",
+        "title": "refactor(cli): decode the chat event socket",
+        "url": "https://github.com/brightwave-inc/tidebreak/pull/3006"
+      },
+      "recap": "The parser bounds every field; the tests are next.",
+      "session": "00000000-0000-0000-0000-000000000003",
+      "subagents": [
+        {
+          "call_id": "call-explore",
+          "name": "Explore",
+          "status": "running"
+        }
+      ],
+      "title": "Bound the code parser",
+      "trigger_target_at": "2025-09-01T04:15:00Z",
+      "turn_count": 3,
+      "workspace": "00000000-0000-0000-0000-000000000002"
+    }
+  },
+  {
+    "kind": "session_digest",
     "name": "watch digest",
     "value": {
       "attention": {
@@ -1094,22 +1151,6 @@
         "type": "harness_notice"
       },
       "seq": 54
-    }
-  },
-  {
-    "kind": "event_frame",
-    "name": "event: attention_changed",
-    "value": {
-      "event": {
-        "source": "structured",
-        "state": {
-          "prompt": "Approve the write to /etc/hosts?",
-          "source": "structured",
-          "type": "needs_you"
-        },
-        "type": "attention_changed"
-      },
-      "seq": 55
     }
   },
   {

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -135,11 +135,6 @@ pub fn app(state: AppState) -> Router {
                 .layer(DefaultBodyLimit::max(routes::MAX_IMAGE_ATTACHMENT_BYTES)),
         )
         .route(
-            "/code/sessions/{id}/attachments/images",
-            post(routes::code::publish_session_image)
-                .layer(DefaultBodyLimit::max(routes::MAX_IMAGE_ATTACHMENT_BYTES)),
-        )
-        .route(
             "/sessions/{id}/attachments/images",
             post(routes::code::publish_session_image)
                 .layer(DefaultBodyLimit::max(routes::MAX_IMAGE_ATTACHMENT_BYTES)),
@@ -1141,83 +1136,6 @@ pub fn app(state: AppState) -> Router {
             post(routes::code::create_session).get(routes::code::list_workspace_sessions),
         )
         .route(
-            "/code/sessions",
-            post(routes::code::create_internal_session).get(routes::code::list_internal_sessions),
-        )
-        .route("/code/sessions/{id}", get(routes::code::get_session))
-        .route(
-            "/code/sessions/{id}/turns",
-            post(routes::code::submit_turn).get(routes::code::list_session_turns),
-        )
-        .route(
-            "/code/sessions/{id}/queued",
-            get(routes::code::list_queued_turns),
-        )
-        .route(
-            "/code/sessions/{id}/queued/{queued_id}",
-            axum::routing::patch(routes::code::patch_queued_turn)
-                .delete(routes::code::delete_queued_turn),
-        )
-        .route(
-            "/code/sessions/{id}/queue-paused",
-            axum::routing::put(routes::code::put_queue_paused),
-        )
-        .route(
-            "/code/sessions/{id}/queued/send-now",
-            post(routes::code::post_queue_send_now),
-        )
-        .route(
-            "/code/sessions/{id}/attachments/images/{blob_id}",
-            get(routes::code::get_session_image),
-        )
-        .route(
-            "/code/sessions/{id}/steer",
-            post(routes::code::steer_session),
-        )
-        .route(
-            "/code/sessions/{id}/interrupt",
-            post(routes::code::interrupt_session),
-        )
-        .route("/code/sessions/{id}/reap", post(routes::code::reap_session))
-        .route(
-            "/code/sessions/{id}/mode",
-            post(routes::code::set_session_permission_mode),
-        )
-        .route(
-            "/code/sessions/{id}/effort",
-            post(routes::code::set_session_reasoning_effort),
-        )
-        .route(
-            "/code/sessions/{id}/fast-mode",
-            post(routes::code::set_session_fast_mode),
-        )
-        .route("/code/sessions/{id}/fork", post(routes::code::fork_session))
-        .route(
-            "/code/sessions/{id}/debug",
-            get(routes::code::get_session_debug),
-        )
-        .route(
-            "/code/sessions/{id}/attention",
-            post(routes::code::set_attention),
-        )
-        .route(
-            "/code/sessions/{id}/events",
-            get(routes::code::session_events),
-        )
-        .route(
-            "/code/sessions/{id}/access",
-            get(routes::code::list_session_access).post(routes::code::add_session_access),
-        )
-        .route(
-            "/code/sessions/{id}/access/{subject}",
-            delete(routes::code::revoke_session_access),
-        )
-        .route(
-            "/code/sessions/{id}/visibility",
-            post(routes::code::set_session_visibility),
-        )
-        .route("/code/updates", get(routes::code::code_updates))
-        .route(
             "/code/workspaces/{id}/terminals",
             post(routes::code::create_terminal)
                 .get(routes::code::list_terminals)
@@ -1238,11 +1156,6 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/code/workspaces/{id}/terminals/{tid}/resize",
             post(routes::code::resize_terminal),
-        )
-        .route("/code/approvals", get(routes::code::list_approvals))
-        .route(
-            "/code/approvals/{id}/decision",
-            post(routes::code::decide_approval),
         )
         .merge(client_executor_api)
         // Merged before the bearer layer, so `require_token` wraps outside

--- a/crates/tidebreak-server-api/src/tests/code.rs
+++ b/crates/tidebreak-server-api/src/tests/code.rs
@@ -504,7 +504,7 @@ async fn plan_is_the_only_session_mode_and_a_turn_journals_end_to_end() {
 
     let turn = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -518,7 +518,7 @@ async fn plan_is_the_only_session_mode_and_a_turn_journals_end_to_end() {
 
     let busy = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)

--- a/crates/tidebreak-server-api/src/tests/code_approvals.rs
+++ b/crates/tidebreak-server-api/src/tests/code_approvals.rs
@@ -106,7 +106,7 @@ async fn ran_one_ask_turn(
     let turn = tokio::time::timeout(
         Duration::from_secs(10),
         client
-            .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+            .post(format!("http://{addr}/sessions/{session_id}/turns"))
             .bearer_auth(&token)
             .json(&serde_json::json!({ "message": "run it" }))
             .send(),
@@ -126,9 +126,7 @@ async fn approvals_for(
     session_id: SessionId,
 ) -> Vec<serde_json::Value> {
     client
-        .get(format!(
-            "http://{addr}/code/approvals?session_id={session_id}"
-        ))
+        .get(format!("http://{addr}/approvals?session_id={session_id}"))
         .bearer_auth(token)
         .send()
         .await
@@ -187,7 +185,7 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -199,7 +197,7 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -231,7 +229,7 @@ async fn mid_turn_decision_is_delivered_while_run_turn_is_still_executing() {
     let decided = tokio::time::timeout(Duration::from_secs(2), async {
         client
             .post(format!(
-                "http://{addr}/code/approvals/{}/decision",
+                "http://{addr}/approvals/{}/decision",
                 approval["id"].as_str().unwrap()
             ))
             .bearer_auth(&token)
@@ -316,7 +314,7 @@ async fn concurrent_approval_decisions_deliver_exactly_once() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -327,7 +325,7 @@ async fn concurrent_approval_decisions_deliver_exactly_once() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -350,9 +348,7 @@ async fn concurrent_approval_decisions_deliver_exactly_once() {
         let approval_id = approval_id.clone();
         async move {
             client
-                .post(format!(
-                    "http://{addr}/code/approvals/{approval_id}/decision"
-                ))
+                .post(format!("http://{addr}/approvals/{approval_id}/decision"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "decision": decision }))
                 .send()
@@ -434,7 +430,7 @@ async fn a_definite_native_approval_delivery_failure_is_abandoned() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -445,7 +441,7 @@ async fn a_definite_native_approval_delivery_failure_is_abandoned() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -464,7 +460,7 @@ async fn a_definite_native_approval_delivery_failure_is_abandoned() {
 
     let refused = client
         .post(format!(
-            "http://{addr}/code/approvals/{}/decision",
+            "http://{addr}/approvals/{}/decision",
             approval["id"].as_str().unwrap()
         ))
         .bearer_auth(&token)
@@ -487,9 +483,7 @@ async fn a_definite_native_approval_delivery_failure_is_abandoned() {
     );
 
     let interrupted = client
-        .post(format!(
-            "http://{addr}/code/sessions/{session_id}/interrupt"
-        ))
+        .post(format!("http://{addr}/sessions/{session_id}/interrupt"))
         .bearer_auth(&token)
         .send()
         .await
@@ -534,7 +528,7 @@ async fn shutdown_waits_for_an_accepted_approval_to_finish_durably() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -545,7 +539,7 @@ async fn shutdown_waits_for_an_accepted_approval_to_finish_durably() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -569,9 +563,7 @@ async fn shutdown_waits_for_an_accepted_approval_to_finish_durably() {
         let approval_id = approval_id.clone();
         async move {
             client
-                .post(format!(
-                    "http://{addr}/code/approvals/{approval_id}/decision"
-                ))
+                .post(format!("http://{addr}/approvals/{approval_id}/decision"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "decision": "approve" }))
                 .send()
@@ -660,7 +652,7 @@ async fn an_unknown_approval_delivery_stays_claimed_until_restart_recovery() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -671,7 +663,7 @@ async fn an_unknown_approval_delivery_stays_claimed_until_restart_recovery() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -694,9 +686,7 @@ async fn an_unknown_approval_delivery_stays_claimed_until_restart_recovery() {
         .unwrap();
 
     let unknown = client
-        .post(format!(
-            "http://{addr}/code/approvals/{approval_id}/decision"
-        ))
+        .post(format!("http://{addr}/approvals/{approval_id}/decision"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "decision": "approve" }))
         .send()
@@ -790,7 +780,7 @@ async fn deny_feedback_reaches_the_scripted_engine() {
         let session_id = json_id(&session).to_owned();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -802,7 +792,7 @@ async fn deny_feedback_reaches_the_scripted_engine() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -856,7 +846,7 @@ async fn deny_feedback_reaches_the_scripted_engine() {
 
     let decided = client
         .post(format!(
-            "http://{addr}/code/approvals/{}/decision",
+            "http://{addr}/approvals/{}/decision",
             approval["id"].as_str().unwrap()
         ))
         .bearer_auth(&token)
@@ -919,7 +909,7 @@ async fn restart_abandons_an_approval_whose_native_waiter_was_lost() {
         let session_id = session_id.clone();
         async move {
             let _ = client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -929,7 +919,7 @@ async fn restart_abandons_an_approval_whose_native_waiter_was_lost() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -974,7 +964,7 @@ async fn restart_abandons_an_approval_whose_native_waiter_was_lost() {
     let addr2 = serve(app(state)).await;
 
     let pending = reqwest::Client::new()
-        .get(format!("http://{addr2}/code/approvals?state=pending"))
+        .get(format!("http://{addr2}/approvals?state=pending"))
         .bearer_auth(&token2)
         .send()
         .await
@@ -985,9 +975,7 @@ async fn restart_abandons_an_approval_whose_native_waiter_was_lost() {
     assert!(pending.is_empty());
 
     let rows = reqwest::Client::new()
-        .get(format!(
-            "http://{addr2}/code/approvals?session_id={session_id}"
-        ))
+        .get(format!("http://{addr2}/approvals?session_id={session_id}"))
         .bearer_auth(&token2)
         .send()
         .await
@@ -1018,7 +1006,7 @@ async fn restart_abandons_an_approval_whose_native_waiter_was_lost() {
 
     let decided = reqwest::Client::new()
         .post(format!(
-            "http://{addr2}/code/approvals/{}/decision",
+            "http://{addr2}/approvals/{}/decision",
             approval["id"].as_str().unwrap()
         ))
         .bearer_auth(&token2)
@@ -1051,7 +1039,7 @@ async fn an_approval_is_abandoned_when_its_tool_call_resolves_undecided() {
     );
 
     let pending: Vec<serde_json::Value> = client
-        .get(format!("http://{addr}/code/approvals?state=pending"))
+        .get(format!("http://{addr}/approvals?state=pending"))
         .bearer_auth(&token)
         .send()
         .await
@@ -1096,7 +1084,7 @@ async fn a_stale_worker_completion_cannot_abandon_a_reused_call_id() {
     let session = session.json::<serde_json::Value>().await.unwrap();
     let session_id = json_id(&session).parse::<SessionId>().unwrap();
     let turn = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "finish" }))
         .send()
@@ -1189,9 +1177,7 @@ async fn deciding_an_abandoned_approval_is_refused() {
     let rows = approvals_for(&client, addr, &token, session_id).await;
     let approval_id = rows[0]["id"].as_str().unwrap().to_owned();
     let refused = client
-        .post(format!(
-            "http://{addr}/code/approvals/{approval_id}/decision"
-        ))
+        .post(format!("http://{addr}/approvals/{approval_id}/decision"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "decision": "approve" }))
         .send()
@@ -1281,7 +1267,7 @@ async fn oversized_write_approval_is_still_decidable() {
         let session_id = json_id(&session).to_owned();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -1293,7 +1279,7 @@ async fn oversized_write_approval_is_still_decidable() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -1318,7 +1304,7 @@ async fn oversized_write_approval_is_still_decidable() {
 
     let decided = client
         .post(format!(
-            "http://{addr}/code/approvals/{}/decision",
+            "http://{addr}/approvals/{}/decision",
             approval["id"].as_str().unwrap()
         ))
         .bearer_auth(&token)
@@ -1370,7 +1356,7 @@ async fn attention_follows_approval_completion_and_view() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "write it" }))
                 .send()
@@ -1383,7 +1369,7 @@ async fn attention_follows_approval_completion_and_view() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -1416,7 +1402,7 @@ async fn attention_follows_approval_completion_and_view() {
 
     let decided = client
         .post(format!(
-            "http://{addr}/code/approvals/{}/decision",
+            "http://{addr}/approvals/{}/decision",
             approval["id"].as_str().unwrap()
         ))
         .bearer_auth(&token)
@@ -1458,7 +1444,7 @@ async fn attention_follows_approval_completion_and_view() {
     .unwrap();
     assert_eq!(row.attention.state, AttentionState::DoneUnreviewed);
 
-    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+    let mut request = format!("ws://{addr}/sessions/{session_id}/events?after=0")
         .into_client_request()
         .unwrap();
     request
@@ -1515,9 +1501,7 @@ async fn user_can_pin_and_clear_attention() {
     let session_id = json_id(&session);
 
     let pinned = client
-        .post(format!(
-            "http://{addr}/code/sessions/{session_id}/attention"
-        ))
+        .post(format!("http://{addr}/sessions/{session_id}/attention"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "note": "look at this later" }))
         .send()
@@ -1559,9 +1543,7 @@ async fn user_can_pin_and_clear_attention() {
     );
 
     let cleared = client
-        .post(format!(
-            "http://{addr}/code/sessions/{session_id}/attention"
-        ))
+        .post(format!("http://{addr}/sessions/{session_id}/attention"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "clear": true }))
         .send()

--- a/crates/tidebreak-server-api/src/tests/code_archive.rs
+++ b/crates/tidebreak-server-api/src/tests/code_archive.rs
@@ -137,7 +137,7 @@ async fn no_force_archive_of_a_dirty_workspace_leaves_an_idle_session() {
 
     let turn = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -638,7 +638,7 @@ async fn archive_refuses_a_running_session_without_force() {
         let token = token.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "busy" }))
                 .send()

--- a/crates/tidebreak-server-api/src/tests/code_attachments.rs
+++ b/crates/tidebreak-server-api/src/tests/code_attachments.rs
@@ -45,7 +45,7 @@ async fn publish_one_pixel_png(
 ) -> String {
     let response = client
         .post(format!(
-            "http://{addr}/code/sessions/{session_id}/attachments/images"
+            "http://{addr}/sessions/{session_id}/attachments/images"
         ))
         .bearer_auth(token)
         .header(reqwest::header::CONTENT_TYPE, "image/png")
@@ -91,7 +91,7 @@ async fn an_engine_with_no_image_protocol_is_handed_the_file_and_its_path() {
     let pixels = crate::routes::image_attachment::png_header(4, 4);
     let published = client
         .post(format!(
-            "http://{addr}/code/sessions/{session}/attachments/images"
+            "http://{addr}/sessions/{session}/attachments/images"
         ))
         .bearer_auth(&token)
         .header(reqwest::header::CONTENT_TYPE, "image/png")
@@ -107,7 +107,7 @@ async fn an_engine_with_no_image_protocol_is_handed_the_file_and_its_path() {
         let client = client.clone();
         let token = token.clone();
         let blob_id = blob_id.clone();
-        let turn_url = format!("http://{addr}/code/sessions/{session}/turns");
+        let turn_url = format!("http://{addr}/sessions/{session}/turns");
         tokio::spawn(async move {
             client
                 .post(turn_url)
@@ -166,7 +166,7 @@ async fn an_engine_with_no_image_protocol_is_handed_the_file_and_its_path() {
 
     // The transcript keeps what was typed, not what the engine was handed.
     let turns: Vec<serde_json::Value> = client
-        .get(format!("http://{addr}/code/sessions/{session}/turns"))
+        .get(format!("http://{addr}/sessions/{session}/turns"))
         .bearer_auth(&token)
         .send()
         .await
@@ -200,7 +200,7 @@ async fn an_engine_that_states_image_input_is_still_handed_the_bytes() {
 
     let published = client
         .post(format!(
-            "http://{addr}/code/sessions/{session}/attachments/images"
+            "http://{addr}/sessions/{session}/attachments/images"
         ))
         .bearer_auth(&token)
         .header(reqwest::header::CONTENT_TYPE, "image/png")
@@ -212,7 +212,7 @@ async fn an_engine_that_states_image_input_is_still_handed_the_bytes() {
     let attachment: serde_json::Value = published.json().await.unwrap();
 
     let accepted = client
-        .post(format!("http://{addr}/code/sessions/{session}/turns"))
+        .post(format!("http://{addr}/sessions/{session}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "message": "what is in this",
@@ -280,7 +280,7 @@ async fn attachments_are_accepted_and_journaled_when_the_adapter_declares_suppor
 
     let accepted = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -306,7 +306,7 @@ async fn attachments_are_accepted_and_journaled_when_the_adapter_declares_suppor
 
     let listed = client
         .get(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -345,7 +345,7 @@ async fn a_live_session_image_upload_is_idempotently_published() {
     for _ in 0..2 {
         let response = client
             .post(format!(
-                "http://{addr}/code/sessions/{session}/attachments/images"
+                "http://{addr}/sessions/{session}/attachments/images"
             ))
             .bearer_auth(&token)
             .header(reqwest::header::CONTENT_TYPE, "image/png")
@@ -402,7 +402,7 @@ async fn an_image_upload_losing_the_session_end_race_conflicts_and_queues_retire
         async move {
             client
                 .post(format!(
-                    "http://{addr}/code/sessions/{session}/attachments/images"
+                    "http://{addr}/sessions/{session}/attachments/images"
                 ))
                 .bearer_auth(&token)
                 .header(reqwest::header::CONTENT_TYPE, "image/png")
@@ -501,7 +501,7 @@ async fn a_session_cannot_attach_an_image_published_to_another_session() {
     ];
     let published = client
         .post(format!(
-            "http://{addr}/code/sessions/{owning}/attachments/images"
+            "http://{addr}/sessions/{owning}/attachments/images"
         ))
         .bearer_auth(&token)
         .header(reqwest::header::CONTENT_TYPE, "image/png")
@@ -528,7 +528,7 @@ async fn a_session_cannot_attach_an_image_published_to_another_session() {
         let blob_id = blob_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session}/turns"))
+                .post(format!("http://{addr}/sessions/{session}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({
                     "message": "look at this",
@@ -651,7 +651,7 @@ async fn the_first_turn_of_a_new_session_accepts_an_image_published_after_create
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/code/sessions/{session_id}/attachments/images"))
+                .uri(format!("/sessions/{session_id}/attachments/images"))
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "image/png")
                 .body(Body::from(one_pixel_png()))
@@ -676,7 +676,7 @@ async fn the_first_turn_of_a_new_session_accepts_an_image_published_after_create
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/code/sessions/{session_id}/turns"))
+                .uri(format!("/sessions/{session_id}/turns"))
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
@@ -712,7 +712,7 @@ async fn the_first_turn_of_a_new_session_accepts_an_image_published_after_create
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/code/sessions/{session_id}/turns"))
+                .uri(format!("/sessions/{session_id}/turns"))
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(

--- a/crates/tidebreak-server-api/src/tests/code_clone.rs
+++ b/crates/tidebreak-server-api/src/tests/code_clone.rs
@@ -153,7 +153,7 @@ async fn clone_from_a_local_origin_registers_the_repo() {
     let parent = dir.path().join("checkouts");
     std::fs::create_dir_all(&parent).unwrap();
 
-    let mut request = format!("ws://{addr}/code/updates")
+    let mut request = format!("ws://{addr}/updates")
         .into_client_request()
         .unwrap();
     request

--- a/crates/tidebreak-server-api/src/tests/code_create.rs
+++ b/crates/tidebreak-server-api/src/tests/code_create.rs
@@ -85,7 +85,7 @@ async fn listing_session_turns_returns_user_input_and_usage() {
     let (_repo, workspace) = register_and_workspace(&client, addr, &token, &repo).await;
     let missing = client
         .get(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             uuid::Uuid::new_v4()
         ))
         .bearer_auth(&token)
@@ -112,7 +112,7 @@ async fn listing_session_turns_returns_user_input_and_usage() {
         .unwrap();
     let empty = client
         .get(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -125,7 +125,7 @@ async fn listing_session_turns_returns_user_input_and_usage() {
 
     let first = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -138,7 +138,7 @@ async fn listing_session_turns_returns_user_input_and_usage() {
         .unwrap();
     let second = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -151,7 +151,7 @@ async fn listing_session_turns_returns_user_input_and_usage() {
         .unwrap();
     let listed = client
         .get(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -941,7 +941,7 @@ async fn first_turn_starts_when_the_repository_has_no_main_ref() {
 
     let turn = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -1037,4 +1037,63 @@ async fn workspace_create_does_not_fall_through_an_explicit_missing_ref() {
         !message.contains("trunk"),
         "an explicit miss must not walk sibling defaults: {message}"
     );
+}
+
+/// Retired aliases must reach the router's empty 404 fallback, including the
+/// separately mounted image-publication route.
+#[tokio::test]
+async fn code_prefixed_session_routes_are_not_registered() {
+    let (router, token, _runtime, _dir) = code_app(plain_text_script()).await;
+    let id = uuid::Uuid::new_v4();
+    let paths = [
+        ("GET", "/code/sessions"),
+        ("POST", "/code/sessions"),
+        ("GET", "/code/sessions/{id}"),
+        ("GET", "/code/sessions/{id}/turns"),
+        ("POST", "/code/sessions/{id}/turns"),
+        ("GET", "/code/sessions/{id}/queued"),
+        ("PATCH", "/code/sessions/{id}/queued/{id}"),
+        ("DELETE", "/code/sessions/{id}/queued/{id}"),
+        ("PUT", "/code/sessions/{id}/queue-paused"),
+        ("POST", "/code/sessions/{id}/queued/send-now"),
+        ("POST", "/code/sessions/{id}/attachments/images"),
+        ("GET", "/code/sessions/{id}/attachments/images/{id}"),
+        ("POST", "/code/sessions/{id}/steer"),
+        ("POST", "/code/sessions/{id}/interrupt"),
+        ("POST", "/code/sessions/{id}/reap"),
+        ("POST", "/code/sessions/{id}/mode"),
+        ("POST", "/code/sessions/{id}/effort"),
+        ("POST", "/code/sessions/{id}/fast-mode"),
+        ("POST", "/code/sessions/{id}/fork"),
+        ("GET", "/code/sessions/{id}/debug"),
+        ("POST", "/code/sessions/{id}/attention"),
+        ("GET", "/code/sessions/{id}/events"),
+        ("GET", "/code/sessions/{id}/access"),
+        ("POST", "/code/sessions/{id}/access"),
+        ("DELETE", "/code/sessions/{id}/access/{id}"),
+        ("POST", "/code/sessions/{id}/visibility"),
+        ("GET", "/code/updates"),
+        ("GET", "/code/approvals"),
+        ("POST", "/code/approvals/{id}/decision"),
+    ];
+
+    for (method, path) in paths {
+        let path = path.replace("{id}", &id.to_string());
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(&path)
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{method} {path}");
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(body.is_empty(), "{method} {path}: {body:?}");
+    }
 }

--- a/crates/tidebreak-server-api/src/tests/code_doctor.rs
+++ b/crates/tidebreak-server-api/src/tests/code_doctor.rs
@@ -622,10 +622,7 @@ async fn hosted_claude_efforts_follow_the_gateway_catalog() {
                 assert_eq!(status, reqwest::StatusCode::CREATED, "{effort}: {body}");
                 assert_eq!(body["reasoning_effort"], effort, "{body}");
                 let stored: serde_json::Value = client
-                    .get(format!(
-                        "http://{addr}/code/sessions/{}/debug",
-                        json_id(&body)
-                    ))
+                    .get(format!("http://{addr}/sessions/{}/debug", json_id(&body)))
                     .bearer_auth(token.as_ref())
                     .send()
                     .await
@@ -907,7 +904,7 @@ async fn unread_engine_events_accumulate_on_the_session_row_and_reach_the_doctor
     for message in ["hello", "again"] {
         let turn = client
             .post(format!(
-                "http://{addr}/code/sessions/{}/turns",
+                "http://{addr}/sessions/{}/turns",
                 json_id(&session)
             ))
             .bearer_auth(&token)
@@ -991,7 +988,7 @@ async fn a_lost_resume_fences_the_session_instead_of_failing_every_turn() {
         .unwrap());
 
     let failed = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "carry on" }))
         .send()
@@ -1027,7 +1024,7 @@ async fn a_lost_resume_fences_the_session_instead_of_failing_every_turn() {
     // Fenced, so the next turn is refused with the reap the UI offers rather
     // than another identical failure.
     let refused = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "again" }))
         .send()

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -816,7 +816,7 @@ async fn web_follow_ups_and_recovery_keep_a_slack_session_in_its_sandbox() {
     assert_eq!(fake.spawns.lock().unwrap().len(), 1);
 
     let queued = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "continue from the browser" }))
         .send()
@@ -888,9 +888,7 @@ async fn web_follow_ups_and_recovery_keep_a_slack_session_in_its_sandbox() {
     .await
     .expect("the queued turn drains after the send lands");
     let interrupted = client
-        .post(format!(
-            "http://{addr}/code/sessions/{session_id}/interrupt"
-        ))
+        .post(format!("http://{addr}/sessions/{session_id}/interrupt"))
         .bearer_auth(&token)
         .send()
         .await
@@ -934,7 +932,7 @@ async fn a_runtime_places_only_external_sessions_in_the_sandbox() {
     assert_eq!(created.status(), reqwest::StatusCode::CREATED);
     let session_id = bound_session_id(&runtime, &owner, "T1/C-place/1.1").await;
     let snapshot = client
-        .get(format!("http://{addr}/code/sessions/{session_id}"))
+        .get(format!("http://{addr}/sessions/{session_id}"))
         .bearer_auth(&token)
         .send()
         .await
@@ -4182,7 +4180,7 @@ async fn external_bindings_attach_idempotently_and_refuse_foreign_or_ended_targe
     assert_eq!(bindings[0]["external_key"], "T1/C1/1.1");
     assert_eq!(bindings[1]["session_id"], created["session_id"]);
     let snapshot: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{id}"))
+        .get(format!("http://{addr}/sessions/{id}"))
         .bearer_auth(&token)
         .send()
         .await
@@ -4291,7 +4289,7 @@ async fn external_bindings_attach_idempotently_and_refuse_foreign_or_ended_targe
             "/code/workspaces/{}/sessions",
             snapshot["workspace_id"].as_str().unwrap()
         ),
-        format!("/code/sessions/{id}/debug"),
+        format!("/sessions/{id}/debug"),
     ] {
         let response: serde_json::Value = client
             .get(format!("http://{addr}{path}"))

--- a/crates/tidebreak-server-api/src/tests/code_internal.rs
+++ b/crates/tidebreak-server-api/src/tests/code_internal.rs
@@ -5,7 +5,7 @@
 //! approval rows. This module is the tripwire for that: chat's plan
 //! proposals, user questions, tool approvals with grant ladders, and
 //! mid-turn steering all have to be reachable over the shared session routes.
-//! The `/chats/*` and `/code/sessions/*` families stay as compatibility aliases.
+//! The `/chats/*` and `/sessions/*` families stay as compatibility aliases.
 
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -536,7 +536,7 @@ async fn canonical_and_compatibility_routes_share_session_rows() {
         .await
         .unwrap();
     let code_alias: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session_id}"))
+        .get(format!("http://{addr}/sessions/{session_id}"))
         .bearer_auth(&token)
         .send()
         .await
@@ -567,9 +567,7 @@ async fn canonical_and_compatibility_routes_share_session_rows() {
         .await
         .unwrap();
     let code_approvals: serde_json::Value = client
-        .get(format!(
-            "http://{addr}/code/approvals?session_id={session_id}"
-        ))
+        .get(format!("http://{addr}/approvals?session_id={session_id}"))
         .bearer_auth(&token)
         .send()
         .await
@@ -958,7 +956,7 @@ async fn canonical_and_compatibility_routes_share_conversation_rows() {
         .await
         .unwrap();
     let code_session: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session_id}"))
+        .get(format!("http://{addr}/sessions/{session_id}"))
         .bearer_auth(&token)
         .send()
         .await
@@ -996,7 +994,7 @@ async fn canonical_and_compatibility_routes_share_conversation_rows() {
 
     let code_approvals: Vec<serde_json::Value> = client
         .get(format!(
-            "http://{addr}/code/approvals?session_id={session_id}&state=pending"
+            "http://{addr}/approvals?session_id={session_id}&state=pending"
         ))
         .bearer_auth(&token)
         .send()
@@ -1029,7 +1027,7 @@ async fn canonical_and_compatibility_routes_share_conversation_rows() {
         .await
         .unwrap();
     let code_turns: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .get(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .send()
         .await
@@ -1063,7 +1061,7 @@ async fn canonical_and_compatibility_routes_share_conversation_rows() {
         .await
         .unwrap();
     let code_queue: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session_id}/queued"))
+        .get(format!("http://{addr}/sessions/{session_id}/queued"))
         .bearer_auth(&token)
         .send()
         .await

--- a/crates/tidebreak-server-api/src/tests/code_owner_scope.rs
+++ b/crates/tidebreak-server-api/src/tests/code_owner_scope.rs
@@ -999,7 +999,7 @@ async fn the_single_owner_profile_keeps_its_default_behavior() {
     let session = owned_session(&client, addr, &token, &repo).await;
 
     let snapshot = client
-        .get(format!("http://{addr}/code/sessions/{session}"))
+        .get(format!("http://{addr}/sessions/{session}"))
         .bearer_auth(&*token)
         .send()
         .await
@@ -1013,7 +1013,7 @@ async fn the_single_owner_profile_keeps_its_default_behavior() {
     );
 
     let listed = client
-        .get(format!("http://{addr}/code/sessions/{session}/access"))
+        .get(format!("http://{addr}/sessions/{session}/access"))
         .bearer_auth(&*token)
         .send()
         .await
@@ -1032,7 +1032,7 @@ async fn the_single_owner_profile_keeps_its_default_behavior() {
             &client,
             addr,
             &token,
-            &format!("/code/sessions/{session}/access"),
+            &format!("/sessions/{session}/access"),
             serde_json::json!({ "subject": "whoever", "level": "view" }),
         )
         .await,
@@ -1044,7 +1044,7 @@ async fn the_single_owner_profile_keeps_its_default_behavior() {
             &client,
             addr,
             &token,
-            &format!("/code/sessions/{session}/access"),
+            &format!("/sessions/{session}/access"),
             serde_json::json!({ "subject": "principal:someone-else", "level": "view" }),
         )
         .await,
@@ -1053,17 +1053,11 @@ async fn the_single_owner_profile_keeps_its_default_behavior() {
 
     // The owner's own reads and writes are untouched by any of it.
     assert_eq!(
-        get_status(
-            &client,
-            addr,
-            &token,
-            &format!("/code/sessions/{session}/turns")
-        )
-        .await,
+        get_status(&client, addr, &token, &format!("/sessions/{session}/turns")).await,
         reqwest::StatusCode::OK,
     );
     let submitted = client
-        .post(format!("http://{addr}/code/sessions/{session}/turns"))
+        .post(format!("http://{addr}/sessions/{session}/turns"))
         .bearer_auth(&*token)
         .json(&serde_json::json!({ "message": "still mine to send" }))
         .send()

--- a/crates/tidebreak-server-api/src/tests/code_policy.rs
+++ b/crates/tidebreak-server-api/src/tests/code_policy.rs
@@ -70,7 +70,7 @@ async fn a_managed_ceiling_refuses_over_ceiling_code_session_modes() {
 
     // The mode route carries the same ceiling.
     let refused = client
-        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .post(format!("http://{addr}/sessions/{session}/mode"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "auto" }))
         .send()
@@ -82,7 +82,7 @@ async fn a_managed_ceiling_refuses_over_ceiling_code_session_modes() {
 
     // A ceiling names a maximum, so dialing down stays open.
     let allowed = client
-        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .post(format!("http://{addr}/sessions/{session}/mode"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "plan" }))
         .send()

--- a/crates/tidebreak-server-api/src/tests/code_recap.rs
+++ b/crates/tidebreak-server-api/src/tests/code_recap.rs
@@ -339,7 +339,7 @@ async fn start_turn(
         tidebreak_core::SessionId(uuid::Uuid::parse_str(session["id"].as_str().unwrap()).unwrap());
 
     let turn = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(token)
         .json(&serde_json::json!({
             "message": "Fix the flaky retry test in the auth crate"

--- a/crates/tidebreak-server-api/src/tests/code_rewrite.rs
+++ b/crates/tidebreak-server-api/src/tests/code_rewrite.rs
@@ -267,7 +267,7 @@ async fn complete_one_turn(
     let session_id = session["id"].as_str().unwrap().to_owned();
 
     let turn = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(token)
         .json(&serde_json::json!({
             "message": "Fix the flaky retry test in the auth crate"

--- a/crates/tidebreak-server-api/src/tests/code_settings.rs
+++ b/crates/tidebreak-server-api/src/tests/code_settings.rs
@@ -43,7 +43,7 @@ async fn a_session_can_leave_plan_mode_and_the_engine_relaunches_under_the_new_o
         let session = session.clone();
         async move {
             let response = client
-                .post(format!("http://{addr}/code/sessions/{session}/mode"))
+                .post(format!("http://{addr}/sessions/{session}/mode"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "permission_mode": mode }))
                 .send()
@@ -65,7 +65,7 @@ async fn a_session_can_leave_plan_mode_and_the_engine_relaunches_under_the_new_o
     // It stuck, and the engine came back up under it rather than being left
     // stopped by the relaunch.
     let reread: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session}/debug"))
+        .get(format!("http://{addr}/sessions/{session}/debug"))
         .bearer_auth(&token)
         .send()
         .await
@@ -93,7 +93,7 @@ async fn a_session_can_leave_plan_mode_and_the_engine_relaunches_under_the_new_o
         "an unhonored mode must be refused: {body}"
     );
     let still: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session}/debug"))
+        .get(format!("http://{addr}/sessions/{session}/debug"))
         .bearer_auth(&token)
         .send()
         .await
@@ -129,7 +129,7 @@ async fn a_mode_change_a_relaunch_cannot_carry_is_refused_rather_than_recorded()
 
     // A turn is what gives the engine a session to resume into.
     let accepted = client
-        .post(format!("http://{addr}/code/sessions/{session}/turns"))
+        .post(format!("http://{addr}/sessions/{session}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "one" }))
         .send()
@@ -138,7 +138,7 @@ async fn a_mode_change_a_relaunch_cannot_carry_is_refused_rather_than_recorded()
     assert_eq!(accepted.status(), reqwest::StatusCode::ACCEPTED);
 
     let response = client
-        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .post(format!("http://{addr}/sessions/{session}/mode"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "auto" }))
         .send()
@@ -156,7 +156,7 @@ async fn a_mode_change_a_relaunch_cannot_carry_is_refused_rather_than_recorded()
     );
 
     let still: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session}/debug"))
+        .get(format!("http://{addr}/sessions/{session}/debug"))
         .bearer_auth(&token)
         .send()
         .await
@@ -222,7 +222,7 @@ async fn opencode_reasoning_is_never_reported_as_active() {
         ("effort", serde_json::json!({ "reasoning_effort": "high" })),
     ] {
         let refused = client
-            .post(format!("http://{addr}/code/sessions/{session_id}/{path}"))
+            .post(format!("http://{addr}/sessions/{session_id}/{path}"))
             .bearer_auth(&token)
             .json(&body)
             .send()
@@ -234,7 +234,7 @@ async fn opencode_reasoning_is_never_reported_as_active() {
     }
 
     let debug: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session_id}/debug"))
+        .get(format!("http://{addr}/sessions/{session_id}/debug"))
         .bearer_auth(&token)
         .send()
         .await
@@ -393,7 +393,7 @@ async fn unsupported_fast_mode_is_refused_on_create_and_live_update() {
     let session: serde_json::Value = created.json().await.unwrap();
     let refused = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/fast-mode",
+            "http://{addr}/sessions/{}/fast-mode",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -443,7 +443,7 @@ async fn a_model_switch_deactivates_incompatible_execution_settings() {
     let session_id = json_id(&session);
 
     let turn = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "switch", "model": "steady" }))
         .send()
@@ -459,7 +459,7 @@ async fn a_model_switch_deactivates_incompatible_execution_settings() {
     assert!(!inputs[0].fast_mode);
 
     let debug: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session_id}/debug"))
+        .get(format!("http://{addr}/sessions/{session_id}/debug"))
         .bearer_auth(&token)
         .send()
         .await
@@ -515,7 +515,7 @@ async fn a_queued_turn_receives_the_validated_effective_settings() {
         let session_id = session_id.clone();
         tokio::spawn(async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "first" }))
                 .send()
@@ -525,7 +525,7 @@ async fn a_queued_turn_receives_the_validated_effective_settings() {
     };
     let _ = wait_for_open_turn(&runtime, parsed).await;
     let queued = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "second", "model": "steady" }))
         .send()
@@ -602,7 +602,7 @@ async fn a_live_setting_update_becomes_active_only_after_its_exact_write_commits
     .await;
 
     let response = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/effort"))
+        .post(format!("http://{addr}/sessions/{session_id}/effort"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "reasoning_effort": "low" }))
         .send()
@@ -613,7 +613,7 @@ async fn a_live_setting_update_becomes_active_only_after_its_exact_write_commits
     assert_eq!(body["kind"], "session_settings_changed", "{body}");
 
     let turn = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "still default" }))
         .send()
@@ -638,7 +638,7 @@ async fn an_engine_without_an_effort_ladder_refuses_the_route() {
         .remove(0);
 
     let response = client
-        .post(format!("http://{addr}/code/sessions/{session}/effort"))
+        .post(format!("http://{addr}/sessions/{session}/effort"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "reasoning_effort": "high" }))
         .send()
@@ -667,7 +667,7 @@ async fn a_mode_switch_uses_the_engine_channel_before_it_relaunches() {
         .remove(0);
 
     let response = client
-        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .post(format!("http://{addr}/sessions/{session}/mode"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "auto" }))
         .send()
@@ -687,7 +687,7 @@ async fn a_mode_switch_uses_the_engine_channel_before_it_relaunches() {
     // the old mode back: the worker holds its own copy of the row, and every
     // turn persists the whole thing.
     let response = client
-        .post(format!("http://{addr}/code/sessions/{session}/turns"))
+        .post(format!("http://{addr}/sessions/{session}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "after the switch" }))
         .send()
@@ -696,7 +696,7 @@ async fn a_mode_switch_uses_the_engine_channel_before_it_relaunches() {
     assert_eq!(response.status(), reqwest::StatusCode::ACCEPTED);
 
     let reread: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session}/debug"))
+        .get(format!("http://{addr}/sessions/{session}/debug"))
         .bearer_auth(&token)
         .send()
         .await
@@ -739,7 +739,7 @@ async fn a_permission_mode_intent_persistence_failure_never_reaches_the_engine()
     .await;
 
     let response = client
-        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .post(format!("http://{addr}/sessions/{session}/mode"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "auto" }))
         .send()
@@ -791,7 +791,7 @@ async fn a_permission_mode_confirmation_failure_terminates_and_fences_the_engine
     .await;
 
     let response = client
-        .post(format!("http://{addr}/code/sessions/{session}/mode"))
+        .post(format!("http://{addr}/sessions/{session}/mode"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "permission_mode": "auto" }))
         .send()
@@ -820,7 +820,7 @@ async fn a_permission_mode_confirmation_failure_terminates_and_fences_the_engine
     ));
 
     let blocked = client
-        .post(format!("http://{addr}/code/sessions/{session}/turns"))
+        .post(format!("http://{addr}/sessions/{session}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "must not run" }))
         .send()

--- a/crates/tidebreak-server-api/src/tests/code_steer.rs
+++ b/crates/tidebreak-server-api/src/tests/code_steer.rs
@@ -41,7 +41,7 @@ async fn unsupported_explicit_steer_is_refused_without_queueing() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "first" }))
                 .send()
@@ -51,7 +51,7 @@ async fn unsupported_explicit_steer_is_refused_without_queueing() {
     });
     let active_turn_id = wait_for_open_turn(&runtime, parsed).await;
     let refused = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .post(format!("http://{addr}/sessions/{session_id}/steer"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "expected_turn_id": active_turn_id,
@@ -106,7 +106,7 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "first" }))
                 .send()
@@ -126,7 +126,7 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -144,7 +144,7 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
     .expect("pending approval never appeared");
 
     let first_steer = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .post(format!("http://{addr}/sessions/{session_id}/steer"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "expected_turn_id": active_turn_id,
@@ -152,7 +152,7 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
         }))
         .send();
     let second_steer = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .post(format!("http://{addr}/sessions/{session_id}/steer"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "expected_turn_id": active_turn_id,
@@ -168,7 +168,7 @@ async fn supported_steer_reaches_the_active_turn_once_without_creating_a_follow_
 
     let decided = client
         .post(format!(
-            "http://{addr}/code/approvals/{}/decision",
+            "http://{addr}/approvals/{}/decision",
             approval["id"].as_str().unwrap()
         ))
         .bearer_auth(&token)
@@ -245,7 +245,7 @@ async fn supported_steer_requires_an_active_turn() {
 
     let refused = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/steer",
+            "http://{addr}/sessions/{}/steer",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -294,7 +294,7 @@ async fn steer_rejects_blank_nul_and_oversized_guidance() {
     ] {
         let refused = client
             .post(format!(
-                "http://{addr}/code/sessions/{}/steer",
+                "http://{addr}/sessions/{}/steer",
                 json_id(&session)
             ))
             .bearer_auth(&token)
@@ -345,7 +345,7 @@ async fn stale_turn_steering_is_rejected_before_reaching_the_adapter() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "first" }))
                 .send()
@@ -362,7 +362,7 @@ async fn stale_turn_steering_is_rejected_before_reaching_the_adapter() {
     };
 
     let refused = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .post(format!("http://{addr}/sessions/{session_id}/steer"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "expected_turn_id": stale_turn_id,
@@ -424,7 +424,7 @@ async fn stalled_native_steering_times_out_without_wedging_turn_completion() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "first" }))
                 .send()
@@ -436,7 +436,7 @@ async fn stalled_native_steering_times_out_without_wedging_turn_completion() {
     let approval = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let listed = client
-                .get(format!("http://{addr}/code/approvals?state=pending"))
+                .get(format!("http://{addr}/approvals?state=pending"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -455,7 +455,7 @@ async fn stalled_native_steering_times_out_without_wedging_turn_completion() {
 
     let started = tokio::time::Instant::now();
     let refused = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .post(format!("http://{addr}/sessions/{session_id}/steer"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "expected_turn_id": active_turn_id,
@@ -474,7 +474,7 @@ async fn stalled_native_steering_times_out_without_wedging_turn_completion() {
 
     let decided = client
         .post(format!(
-            "http://{addr}/code/approvals/{}/decision",
+            "http://{addr}/approvals/{}/decision",
             approval["id"].as_str().unwrap()
         ))
         .bearer_auth(&token)
@@ -530,7 +530,7 @@ async fn terminal_turn_event_closes_steering_before_a_late_command_is_admitted()
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "first" }))
                 .send()
@@ -552,7 +552,7 @@ async fn terminal_turn_event_closes_steering_before_a_late_command_is_admitted()
     .expect("turn never completed");
 
     let refused = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .post(format!("http://{addr}/sessions/{session_id}/steer"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "expected_turn_id": active_turn_id.expect("turn id"),
@@ -604,7 +604,7 @@ async fn a_native_steer_rejection_does_not_fail_or_redirect_the_turn() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "first" }))
                 .send()
@@ -623,7 +623,7 @@ async fn a_native_steer_rejection_does_not_fail_or_redirect_the_turn() {
     .expect("turn never started");
 
     let refused = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/steer"))
+        .post(format!("http://{addr}/sessions/{session_id}/steer"))
         .bearer_auth(&token)
         .json(&serde_json::json!({
             "expected_turn_id": active_turn_id,

--- a/crates/tidebreak-server-api/src/tests/code_titling.rs
+++ b/crates/tidebreak-server-api/src/tests/code_titling.rs
@@ -309,7 +309,7 @@ async fn a_first_turn_names_an_untitled_workspace_without_moving_it() {
 
     let turn = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             session["id"].as_str().unwrap()
         ))
         .bearer_auth(&token)

--- a/crates/tidebreak-server-api/src/tests/code_turns.rs
+++ b/crates/tidebreak-server-api/src/tests/code_turns.rs
@@ -102,7 +102,7 @@ async fn interrupt_stops_a_running_turn_without_ending_its_browser_channel() {
 
     let turn_req = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -119,7 +119,7 @@ async fn interrupt_stops_a_running_turn_without_ending_its_browser_channel() {
         }
         client
             .post(format!(
-                "http://{addr}/code/sessions/{}/interrupt",
+                "http://{addr}/sessions/{}/interrupt",
                 json_id(&session)
             ))
             .bearer_auth(&token)
@@ -197,7 +197,7 @@ async fn reap_replaces_browser_authority_without_tombstoning_the_session() {
         .unwrap();
 
     let reaped = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/reap"))
+        .post(format!("http://{addr}/sessions/{session_id}/reap"))
         .bearer_auth(&token)
         .send()
         .await
@@ -292,7 +292,7 @@ async fn an_engine_that_dies_without_saying_so_journals_an_interrupted_turn() {
 
     let turn_req = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)
@@ -309,7 +309,7 @@ async fn an_engine_that_dies_without_saying_so_journals_an_interrupted_turn() {
         }
         client
             .post(format!(
-                "http://{addr}/code/sessions/{}/interrupt",
+                "http://{addr}/sessions/{}/interrupt",
                 json_id(&session)
             ))
             .bearer_auth(&token)
@@ -334,10 +334,7 @@ async fn turn_statuses(
     session: &serde_json::Value,
 ) -> Vec<String> {
     let listed: Vec<serde_json::Value> = client
-        .get(format!(
-            "http://{addr}/code/sessions/{}/turns",
-            json_id(session)
-        ))
+        .get(format!("http://{addr}/sessions/{}/turns", json_id(session)))
         .bearer_auth(token)
         .send()
         .await
@@ -399,7 +396,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
         let session_id = session_id.clone();
         async move {
             client
-                .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+                .post(format!("http://{addr}/sessions/{session_id}/turns"))
                 .bearer_auth(&token)
                 .json(&serde_json::json!({ "message": "first" }))
                 .send()
@@ -428,7 +425,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
     .expect("first turn never reached Running");
 
     let follow = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "follow-up" }))
         .send()
@@ -454,7 +451,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
     // Depth is no longer one (decision 69): a second mid-turn send parks
     // behind the first instead of refusing with queue_full.
     let second = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "second follow-up" }))
         .send()
@@ -468,7 +465,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
     // The queue is durable and addressable while the live turn runs: list,
     // edit, and retract are real routes, exactly as on a chat.
     let listed: serde_json::Value = client
-        .get(format!("http://{addr}/code/sessions/{session_id}/queued"))
+        .get(format!("http://{addr}/sessions/{session_id}/queued"))
         .bearer_auth(&token)
         .send()
         .await
@@ -483,7 +480,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
 
     let edited: serde_json::Value = client
         .patch(format!(
-            "http://{addr}/code/sessions/{session_id}/queued/{second_id}"
+            "http://{addr}/sessions/{session_id}/queued/{second_id}"
         ))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "second follow-up, edited" }))
@@ -497,7 +494,7 @@ async fn a_mid_turn_send_queues_and_runs_after_the_current_turn() {
 
     let removed = client
         .delete(format!(
-            "http://{addr}/code/sessions/{session_id}/queued/{second_id}"
+            "http://{addr}/sessions/{session_id}/queued/{second_id}"
         ))
         .bearer_auth(&token)
         .send()
@@ -590,7 +587,7 @@ async fn a_session_whose_turns_keep_failing_is_fenced_rather_than_left_idle() {
         let token = token.clone();
         async move {
             let body: serde_json::Value = client
-                .get(format!("http://{addr}/code/sessions/{session}/debug"))
+                .get(format!("http://{addr}/sessions/{session}/debug"))
                 .bearer_auth(&token)
                 .send()
                 .await
@@ -604,7 +601,7 @@ async fn a_session_whose_turns_keep_failing_is_fenced_rather_than_left_idle() {
 
     for attempt in 1..=3 {
         let response = client
-            .post(format!("http://{addr}/code/sessions/{session}/turns"))
+            .post(format!("http://{addr}/sessions/{session}/turns"))
             .bearer_auth(&token)
             .json(&serde_json::json!({ "message": format!("attempt {attempt}") }))
             .send()
@@ -668,7 +665,7 @@ async fn a_fenced_session_closes_its_whole_workspace_to_turns() {
         .unwrap();
 
     let refused = client
-        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .post(format!("http://{addr}/sessions/{}/turns", ids[1]))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "while a sibling is fenced" }))
         .send()
@@ -680,7 +677,7 @@ async fn a_fenced_session_closes_its_whole_workspace_to_turns() {
 
     // Reaping the fenced session reopens the workspace.
     let reaped = client
-        .post(format!("http://{addr}/code/sessions/{}/reap", ids[0]))
+        .post(format!("http://{addr}/sessions/{}/reap", ids[0]))
         .bearer_auth(&token)
         .send()
         .await
@@ -689,7 +686,7 @@ async fn a_fenced_session_closes_its_whole_workspace_to_turns() {
     let body = reaped.text().await.unwrap();
     assert_eq!(status, reqwest::StatusCode::OK, "reap failed: {body}");
     let accepted = client
-        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .post(format!("http://{addr}/sessions/{}/turns", ids[1]))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "after the reap" }))
         .send()
@@ -738,7 +735,7 @@ async fn a_sibling_fenced_for_repeated_failures_does_not_close_the_workspace() {
         .unwrap();
 
     let accepted = client
-        .post(format!("http://{addr}/code/sessions/{}/turns", ids[1]))
+        .post(format!("http://{addr}/sessions/{}/turns", ids[1]))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "while a sibling is fenced" }))
         .send()
@@ -833,7 +830,7 @@ async fn a_recovered_session_accepts_a_turn() {
     let addr2 = serve(app(state)).await;
 
     let turn = reqwest::Client::new()
-        .post(format!("http://{addr2}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr2}/sessions/{session_id}/turns"))
         .bearer_auth(&token2)
         .json(&serde_json::json!({ "message": "after restart" }))
         .send()
@@ -886,7 +883,7 @@ async fn a_recovered_session_accepts_a_turn() {
     let client3 = reqwest::Client::new();
 
     let after_orphan_exit = client3
-        .post(format!("http://{addr3}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr3}/sessions/{session_id}/turns"))
         .bearer_auth(&token3)
         .json(&serde_json::json!({ "message": "after orphan exit" }))
         .send()
@@ -937,7 +934,7 @@ async fn a_failed_checkpoint_does_not_fail_the_turn() {
 
     let turn = client
         .post(format!(
-            "http://{addr}/code/sessions/{}/turns",
+            "http://{addr}/sessions/{}/turns",
             json_id(&session)
         ))
         .bearer_auth(&token)

--- a/crates/tidebreak-server-api/src/tests/code_ws.rs
+++ b/crates/tidebreak-server-api/src/tests/code_ws.rs
@@ -49,7 +49,7 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
         .unwrap();
     let session_id = json_id(&session).to_owned();
 
-    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+    let mut request = format!("ws://{addr}/sessions/{session_id}/events?after=0")
         .into_client_request()
         .unwrap();
     request
@@ -58,7 +58,7 @@ async fn ws_replays_then_lives_without_gaps_or_duplicates() {
     let (mut socket, _) = connect_async(request).await.unwrap();
 
     let _ = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "hi" }))
         .send()
@@ -208,7 +208,7 @@ async fn ws_replay_emits_every_durable_sequence_after_the_cursor_in_order() {
     .unwrap();
 
     let mut replay_request =
-        format!("ws://{addr}/code/sessions/{session_id}/events?after={replay_after_seq}")
+        format!("ws://{addr}/sessions/{session_id}/events?after={replay_after_seq}")
             .into_client_request()
             .unwrap();
     replay_request
@@ -289,7 +289,7 @@ async fn a_turn_journals_its_message_and_none_of_the_deltas_that_built_it() {
     let session_id = json_id(&session).to_owned();
     let parsed: SessionId = session_id.parse().unwrap();
 
-    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+    let mut request = format!("ws://{addr}/sessions/{session_id}/events?after=0")
         .into_client_request()
         .unwrap();
     request
@@ -298,7 +298,7 @@ async fn a_turn_journals_its_message_and_none_of_the_deltas_that_built_it() {
     let (mut socket, _) = connect_async(request).await.unwrap();
 
     let turn = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "hi" }))
         .send()
@@ -372,7 +372,7 @@ async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
     let session_id = json_id(&session).to_owned();
     let parsed: SessionId = session_id.parse().unwrap();
 
-    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after=0")
+    let mut request = format!("ws://{addr}/sessions/{session_id}/events?after=0")
         .into_client_request()
         .unwrap();
     request
@@ -462,7 +462,7 @@ async fn reconnecting_mid_answer_replaces_with_the_complete_live_tail() {
         },
     );
 
-    let mut request = format!("ws://{addr}/code/sessions/{session_id}/events?after={cursor}")
+    let mut request = format!("ws://{addr}/sessions/{session_id}/events?after={cursor}")
         .into_client_request()
         .unwrap();
     request
@@ -582,7 +582,7 @@ async fn updates_channel_restates_the_full_digest_on_reconnect() {
         .unwrap();
     let session_id = json_id(&session);
 
-    let mut request = format!("ws://{addr}/code/updates")
+    let mut request = format!("ws://{addr}/updates")
         .into_client_request()
         .unwrap();
     request
@@ -599,7 +599,7 @@ async fn updates_channel_restates_the_full_digest_on_reconnect() {
     assert_eq!(sessions[0]["turn_count"], 0);
 
     let _ = client
-        .post(format!("http://{addr}/code/sessions/{session_id}/turns"))
+        .post(format!("http://{addr}/sessions/{session_id}/turns"))
         .bearer_auth(&token)
         .json(&serde_json::json!({ "message": "hi" }))
         .send()
@@ -623,7 +623,7 @@ async fn updates_channel_restates_the_full_digest_on_reconnect() {
     assert!(saw_turn, "live digest must carry the new turn count");
     drop(socket);
 
-    let mut request = format!("ws://{addr}/code/updates")
+    let mut request = format!("ws://{addr}/updates")
         .into_client_request()
         .unwrap();
     request

--- a/crates/tidebreak-server-api/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server-api/src/wire_code_fixtures.rs
@@ -248,6 +248,7 @@ fn digest() -> SessionDigest {
         harness_kind: Some(HarnessKind::ClaudeCode),
         lifecycle: SessionLifecycle::Running,
         attention: attention(),
+        fence_reason: None,
         title: "Bound the code parser".to_owned(),
         turn_count: 3,
         trigger_target_at: Some(at(1_756_700_100)),
@@ -294,6 +295,7 @@ fn digest_notice(d: SessionDigest) -> UpdateNotice {
         kind: d.kind,
         harness_kind: d.harness_kind,
         lifecycle: d.lifecycle,
+        fence_reason: d.fence_reason.map(Box::new),
         attention: d.attention,
         title: d.title,
         turn_count: d.turn_count,
@@ -631,6 +633,20 @@ pub(crate) fn code_frame_fixtures() -> Vec<Fixture> {
         ),
         fixture("session digest", "session_digest", &digest()),
         fixture(
+            "recovery digest with manual attention",
+            "session_digest",
+            &SessionDigest {
+                lifecycle: SessionLifecycle::Fenced,
+                attention: Attention::manual("Review these edits"),
+                fence_reason: Some(FenceReason::ProbeAmbiguous {
+                    detail: "The previous engine process could not be identified".to_owned(),
+                }),
+                activity: None,
+                activity_detail: None,
+                ..digest()
+            },
+        ),
+        fixture(
             "watch digest",
             "session_digest",
             &SessionDigest {
@@ -928,19 +944,6 @@ fn event_frames() -> Vec<Fixture> {
                 Event::HarnessNotice {
                     level: HarnessNoticeLevel::Warning,
                     message: "context is 80% full".to_owned(),
-                },
-            ),
-        ),
-        (
-            "event: attention_changed",
-            frame(
-                55,
-                Event::AttentionChanged {
-                    state: AttentionState::NeedsYou {
-                        prompt: "Approve the write to /etc/hosts?".to_owned(),
-                        source: AttentionSource::Structured,
-                    },
-                    source: AttentionSource::Structured,
                 },
             ),
         ),

--- a/crates/tidebreak-server/src/code/attention.rs
+++ b/crates/tidebreak-server/src/code/attention.rs
@@ -160,6 +160,9 @@ pub async fn compute_attention(
     opts: ComputeOpts,
 ) -> Result<Attention, tidebreak_core::AgentError> {
     if session.lifecycle == SessionLifecycle::Fenced {
+        if matches!(session.attention.state, AttentionState::NeedsYou { .. }) {
+            return Ok(session.attention.clone());
+        }
         if let Some(reason) = session.fence_reason.clone() {
             return Ok(Attention::new(
                 AttentionState::Fenced { reason },
@@ -530,6 +533,7 @@ async fn build_digest(
         harness_kind: session.harness_kind,
         lifecycle: session.lifecycle,
         attention: session.attention.clone(),
+        fence_reason: session.fence_reason.clone(),
         title,
         turn_count,
         trigger_target_at,

--- a/crates/tidebreak-server/src/code/bus.rs
+++ b/crates/tidebreak-server/src/code/bus.rs
@@ -58,6 +58,8 @@ pub struct SessionDigest {
     pub harness_kind: HarnessKind,
     pub lifecycle: SessionLifecycle,
     pub attention: Attention,
+    /// Recovery cause, independent of a manual attention pin.
+    pub fence_reason: Option<tidebreak_core::FenceReason>,
     pub title: String,
     pub turn_count: i64,
     /// Timestamp trigger delivery uses to rank candidate sessions: the newest

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -460,8 +460,24 @@ mod tests {
     use super::*;
 
     #[derive(Default)]
+    struct ProvisionGate {
+        entered: Notify,
+        release: Notify,
+    }
+
+    async fn wait_for_provision_gate(gate: &StdMutex<Option<Arc<ProvisionGate>>>) {
+        let gate = gate.lock().unwrap().clone();
+        if let Some(gate) = gate {
+            gate.entered.notify_one();
+            gate.release.notified().await;
+        }
+    }
+
+    #[derive(Default)]
     struct FakeProvisioner {
         spawns: StdMutex<Vec<SpawnArguments>>,
+        spawn_gate: StdMutex<Option<Arc<ProvisionGate>>>,
+        send_gate: StdMutex<Option<Arc<ProvisionGate>>>,
         spawn_errors: StdMutex<VecDeque<RemoteSandboxError>>,
         sends: StdMutex<Vec<String>>,
         event_reads: StdMutex<VecDeque<SandboxEvents>>,
@@ -478,6 +494,7 @@ mod tests {
             _session: tidebreak_core::SessionId,
             arguments: &SpawnArguments,
         ) -> Result<SandboxLease, RemoteSandboxError> {
+            wait_for_provision_gate(&self.spawn_gate).await;
             self.spawns.lock().unwrap().push(arguments.clone());
             if let Some(error) = self.spawn_errors.lock().unwrap().pop_front() {
                 return Err(error);
@@ -536,6 +553,7 @@ mod tests {
             _sandbox_id: &str,
             message: &SandboxMessage,
         ) -> Result<MessageReceipt, RemoteSandboxError> {
+            wait_for_provision_gate(&self.send_gate).await;
             let super::super::wire::SupervisorMessageBody::Input(body) = &message.body;
             self.sends.lock().unwrap().push(body.clone());
             Ok(MessageReceipt {
@@ -925,6 +943,117 @@ mod tests {
             fake.sends.lock().unwrap().as_slice(),
             &["and then".to_owned()]
         );
+    }
+
+    #[tokio::test]
+    async fn recovery_waits_for_remote_spawn_and_queued_send_admission() {
+        for queued in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
+            let workspace = runtime
+                .create_remote_workspace(&owner, repo.id, Some("remote".into()))
+                .await
+                .unwrap();
+            let session = runtime
+                .create_remote_session(
+                    &owner,
+                    None,
+                    workspace.id,
+                    HarnessKind::ClaudeCode,
+                    session_settings(),
+                )
+                .await
+                .unwrap();
+            if queued {
+                runtime
+                    .submit_turn(&owner, session.id, "first".into(), None, None, vec![], None)
+                    .await
+                    .unwrap();
+                runtime
+                    .submit_turn(&owner, session.id, "next".into(), None, None, vec![], None)
+                    .await
+                    .unwrap();
+                fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                    sandbox_id: "sb-1".into(),
+                    state: SandboxState::Running,
+                    latest_event_seq: 2,
+                    events: vec![
+                        event(1, "turn_started", serde_json::json!({ "turn": 1 })),
+                        event(
+                            2,
+                            "turn_completed",
+                            serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                        ),
+                    ],
+                });
+                let mut live = runtime.get_session(&owner, session.id).await.unwrap();
+                runtime
+                    .remote_sessions()
+                    .unwrap()
+                    .driver(&runtime.db, runtime.bus.as_ref())
+                    .pump(&mut live, 0)
+                    .await
+                    .unwrap();
+            }
+            let gate = Arc::new(ProvisionGate::default());
+            if queued {
+                *fake.send_gate.lock().unwrap() = Some(gate.clone());
+            } else {
+                *fake.spawn_gate.lock().unwrap() = Some(gate.clone());
+            }
+            let admission = tokio::spawn({
+                let runtime = runtime.clone();
+                let owner = owner.clone();
+                async move {
+                    if queued {
+                        runtime.promote_remote_queue_heads().await
+                    } else {
+                        runtime
+                            .submit_turn(
+                                &owner,
+                                session.id,
+                                "first".into(),
+                                None,
+                                None,
+                                vec![],
+                                None,
+                            )
+                            .await
+                            .map(|_| ())
+                    }
+                }
+            });
+            tokio::time::timeout(std::time::Duration::from_secs(5), gate.entered.notified())
+                .await
+                .expect("remote admission reaches the provisioner");
+            let recovery = runtime.reap(&owner, session.id);
+            tokio::pin!(recovery);
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(50), &mut recovery)
+                    .await
+                    .is_err(),
+                "recovery must wait until remote admission commits, queued={queued}"
+            );
+            gate.release.notify_one();
+            admission.await.unwrap().unwrap();
+            assert_eq!(recovery.await.unwrap_err().kind(), "not_fenced");
+            let current = runtime.get_session(&owner, session.id).await.unwrap();
+            assert_eq!(current.lifecycle, SessionLifecycle::Running);
+            assert_eq!(current.spawn_epoch, session.spawn_epoch);
+            let turn = latest_turn(&runtime.db, &owner, session.id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(turn.status, TurnStatus::Running);
+            assert_eq!(turn.ordinal, if queued { 2 } else { 1 });
+            assert!(runtime
+                .list_queued_turns(&owner, session.id)
+                .await
+                .unwrap()
+                .0
+                .is_empty());
+            assert!(fake.cancels.lock().unwrap().is_empty());
+        }
     }
 
     /// Remote session creation must serialize with workspace lifecycle

--- a/crates/tidebreak-server/src/code/runtime/auto_recovery.rs
+++ b/crates/tidebreak-server/src/code/runtime/auto_recovery.rs
@@ -1,0 +1,934 @@
+//! Recover interrupted connections without submitting or replaying a turn.
+
+use super::*;
+use tidebreak_core::{AttentionState, ExecutionLocation, IncarnationState};
+
+const RECOVERY_INTERVAL: Duration = Duration::from_secs(2);
+const RECOVERY_BACKOFF: Duration = Duration::from_secs(10);
+const RECOVERY_WINDOW: Duration = Duration::from_secs(5 * 60);
+const MAX_RECOVERY_ATTEMPTS: u8 = 2;
+
+pub(super) struct RecoveryAttempt {
+    count: u8,
+    next: Instant,
+    started: Instant,
+}
+
+pub(super) struct RecoverySweepGuard(tokio::task::JoinHandle<()>);
+
+impl Drop for RecoverySweepGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// A pinned attention value does not hide the connection's underlying cause.
+pub(super) fn recovery_message(session: &Session) -> String {
+    if let AttentionState::NeedsYou { prompt, .. } = &session.attention.state {
+        return prompt.clone();
+    }
+    recovery_reason_message(session)
+}
+
+fn recovery_reason_message(session: &Session) -> String {
+    match &session.fence_reason {
+        Some(FenceReason::OrphanAlive | FenceReason::ResumeLost { .. }) => {
+            "The engine connection is recovering. Your interrupted turn will not restart automatically.".into()
+        }
+        Some(FenceReason::ProbeAmbiguous { detail }) => format!(
+            "Recovery needs attention: {detail}. Check the previous engine before trying again."
+        ),
+        Some(FenceReason::RepeatedTurnFailures { detail, .. }) => {
+            format!("The engine keeps failing: {detail}. Resolve this problem before sending another message.")
+        }
+        Some(FenceReason::IncarnationUnresolved { detail }) => {
+            format!("The previous sandbox could not be confirmed: {detail}. Check its status before starting more work.")
+        }
+        Some(FenceReason::TerminalFlushMissing { detail }) => {
+            format!("Some output from the previous sandbox is missing: {detail}. Review the sandbox before accepting the missing output.")
+        }
+        Some(FenceReason::SandboxLost { detail }) => {
+            format!("The sandbox stopped: {detail}. Recovery is checking its final output.")
+        }
+        None => "The connection stopped without a recorded cause. Check the engine before trying again.".into(),
+    }
+}
+
+fn recovery_cause(session: &Session) -> &str {
+    match &session.fence_reason {
+        Some(FenceReason::OrphanAlive) => "The previous engine process was still running",
+        Some(
+            FenceReason::ResumeLost { detail }
+            | FenceReason::ProbeAmbiguous { detail }
+            | FenceReason::RepeatedTurnFailures { detail, .. }
+            | FenceReason::IncarnationUnresolved { detail }
+            | FenceReason::SandboxLost { detail }
+            | FenceReason::TerminalFlushMissing { detail },
+        ) => detail,
+        None => "The connection stopped without a recorded cause",
+    }
+}
+
+impl CodeRuntime {
+    pub(super) fn session_recovery_lock(&self, id: SessionId) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.recovery_locks.lock().expect("session recovery locks");
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(&id).and_then(std::sync::Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(id, Arc::downgrade(&lock));
+        lock
+    }
+
+    pub(super) fn ensure_recovery_sweep(self: &Arc<Self>) {
+        if self.recovery_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let weak = Arc::downgrade(self);
+        let task = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(RECOVERY_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let Some(runtime) = weak.upgrade() else {
+                    return;
+                };
+                if let Err(error) = runtime.recover_fenced_sessions().await {
+                    tracing::warn!(error = %error.message(), "could not recover interrupted engine connections");
+                }
+            }
+        });
+        *self.recovery_sweep.lock().expect("recovery sweep") = Some(RecoverySweepGuard(task));
+    }
+
+    pub(super) async fn recover_fenced_sessions(&self) -> Result<(), ServerError> {
+        if self.update_quiesce_active() {
+            return Ok(());
+        }
+        let sessions = tidebreak_core::db::code::list_sessions_by_lifecycle_all_owners(
+            &self.db,
+            SessionLifecycle::Fenced,
+        )
+        .await?;
+        for session in sessions {
+            let _workspace_guard = match session.workspace_id {
+                Some(id) => Some(self.workspace_lifecycle_lock(id).lock_owned().await),
+                None => None,
+            };
+            // The per-session lock also covers explicit recovery, permission
+            // mode changes, and ending a session. Re-read after acquiring it.
+            let lock = self.session_recovery_lock(session.id);
+            let Ok(_guard) = lock.try_lock_owned() else {
+                continue;
+            };
+            let Some(session) = get_session(&self.db, &session.owner, session.id).await? else {
+                continue;
+            };
+            if session.lifecycle != SessionLifecycle::Fenced || self.update_quiesce_active() {
+                continue;
+            }
+            if let Some(workspace) = self.session_workspace(&session).await? {
+                if workspace.status != CodeWorkspaceStatus::Active {
+                    continue;
+                }
+            }
+            self.recover_fenced_session(session).await?;
+        }
+        Ok(())
+    }
+
+    async fn recover_fenced_session(&self, mut session: Session) -> Result<(), ServerError> {
+        let eligible = match (&session.execution_location, &session.fence_reason) {
+            (
+                ExecutionLocation::Machine,
+                Some(FenceReason::OrphanAlive | FenceReason::ResumeLost { .. }),
+            ) => true,
+            (ExecutionLocation::Sandbox, Some(FenceReason::SandboxLost { .. })) => {
+                let row = tidebreak_core::db::code::latest_incarnation(
+                    &self.db,
+                    &session.owner,
+                    session.id,
+                )
+                .await?;
+                match row {
+                    Some(row)
+                        if row.state == IncarnationState::Stopped
+                            && row.terminal_events_journaled =>
+                    {
+                        if let Some((_, message)) =
+                            crate::code::remote::driver::recovery_block(&row)
+                        {
+                            session.fence_reason = Some(FenceReason::IncarnationUnresolved {
+                                detail: message.into(),
+                            });
+                            false
+                        } else {
+                            true
+                        }
+                    }
+                    Some(row) if row.state == IncarnationState::Stopped => {
+                        session.fence_reason = Some(FenceReason::TerminalFlushMissing {
+                            detail: "The stopped sandbox did not deliver its final events".into(),
+                        });
+                        false
+                    }
+                    _ => {
+                        session.fence_reason = Some(FenceReason::IncarnationUnresolved {
+                            detail: "The previous sandbox has not been confirmed stopped".into(),
+                        });
+                        false
+                    }
+                }
+            }
+            _ => false,
+        };
+        if !eligible {
+            return self.publish_recovery_blocker(session).await;
+        }
+
+        let now = Instant::now();
+        let attempt = {
+            let mut attempts = self.recovery_attempts.lock().expect("recovery attempts");
+            let attempt = attempts.entry(session.id).or_insert(RecoveryAttempt {
+                count: 0,
+                next: now,
+                started: now,
+            });
+            if now.duration_since(attempt.started) >= RECOVERY_WINDOW {
+                *attempt = RecoveryAttempt {
+                    count: 0,
+                    next: now,
+                    started: now,
+                };
+            }
+            if now < attempt.next {
+                return Ok(());
+            }
+            if attempt.count >= MAX_RECOVERY_ATTEMPTS {
+                None
+            } else {
+                attempt.count += 1;
+                attempt.next = now + RECOVERY_BACKOFF;
+                Some(attempt.count)
+            }
+        };
+        let Some(attempt) = attempt else {
+            let detail = format!(
+                "Automatic recovery failed again. Original cause: {}",
+                recovery_cause(&session)
+            );
+            session.fence_reason = Some(
+                if session.execution_location == ExecutionLocation::Sandbox {
+                    FenceReason::IncarnationUnresolved { detail }
+                } else {
+                    FenceReason::ProbeAmbiguous { detail }
+                },
+            );
+            return self.publish_recovery_blocker(session).await;
+        };
+
+        // A resumed worker normally drains its queue immediately. Recovery
+        // never grants permission to run queued or interrupted work.
+        tidebreak_core::db::code::set_queue_paused(&self.db, &session.owner, session.id, true)
+            .await?;
+        let result = if session.execution_location == ExecutionLocation::Sandbox {
+            // Do not call remote driver.reap: it accepts missing terminal
+            // output and cancellation failure on behalf of an explicit user.
+            recovery::reap_session(&self.db, &self.bus, session.clone())
+                .await
+                .map_err(|error| {
+                    ServerError::conflict_kind("session_not_reaped", error.to_string())
+                })
+        } else {
+            self.reap_inner(&session.owner, session.id).await
+        };
+        match result {
+            Ok(recovered) => {
+                // Preserve a manual pin. Otherwise show queued work that needs
+                // review, or let the composer accept a fresh message.
+                let queued = tidebreak_core::db::code::list_queued_turns(
+                    &self.db,
+                    &recovered.owner,
+                    recovered.id,
+                )
+                .await?;
+                let attention = if queued.is_empty() {
+                    Attention::new(AttentionState::Idle, AttentionSource::Lifecycle)
+                } else {
+                    Attention::needs_you(
+                        "Connection restored. Review the paused messages before sending them.",
+                        AttentionSource::Lifecycle,
+                    )
+                };
+                crate::code::attention::apply_attention(
+                    &self.db,
+                    &self.bus,
+                    &recovered.owner,
+                    recovered.id,
+                    attention,
+                    false,
+                )
+                .await?;
+            }
+            Err(error) => {
+                let Some(mut current) = get_session(&self.db, &session.owner, session.id).await?
+                else {
+                    return Ok(());
+                };
+                if current.lifecycle == SessionLifecycle::Ended {
+                    return Ok(());
+                }
+                let detail = error.message().to_owned();
+                if attempt >= MAX_RECOVERY_ATTEMPTS || error.kind() == "session_not_reaped" {
+                    let detail = format!(
+                        "Automatic recovery failed: {detail}. {}",
+                        recovery_cause(&session)
+                    );
+                    current.fence_reason = Some(
+                        if current.execution_location == ExecutionLocation::Sandbox {
+                            FenceReason::IncarnationUnresolved { detail }
+                        } else {
+                            FenceReason::ProbeAmbiguous { detail }
+                        },
+                    );
+                    let reason = current
+                        .fence_reason
+                        .clone()
+                        .expect("recovery failure has a cause");
+                    recovery::fence_session(&self.db, &self.bus, &mut current, reason).await?;
+                    self.publish_recovery_blocker(current).await?;
+                } else {
+                    // A launch can advance the epoch before failing. Retain
+                    // that current identity and prevent turn admission until
+                    // the bounded retry has settled it.
+                    let reason = current
+                        .fence_reason
+                        .clone()
+                        .or(session.fence_reason.clone())
+                        .unwrap_or(FenceReason::ProbeAmbiguous { detail });
+                    recovery::fence_session(&self.db, &self.bus, &mut current, reason).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn retain_failed_recovery(
+        &self,
+        previous: &Session,
+        detail: &str,
+    ) -> Result<(), ServerError> {
+        let Some(mut current) = get_session(&self.db, &previous.owner, previous.id).await? else {
+            return Ok(());
+        };
+        if current.lifecycle == SessionLifecycle::Ended {
+            return Ok(());
+        }
+        let detail = format!("Recovery failed: {detail}. {}", recovery_cause(previous));
+        let reason = if current.execution_location == ExecutionLocation::Sandbox {
+            FenceReason::IncarnationUnresolved { detail }
+        } else {
+            FenceReason::ProbeAmbiguous { detail }
+        };
+        recovery::fence_session(&self.db, &self.bus, &mut current, reason).await?;
+        self.publish_recovery_blocker(current).await
+    }
+
+    async fn publish_recovery_blocker(&self, mut session: Session) -> Result<(), ServerError> {
+        // Manual pins remain untouched; fence_reason still carries the cause
+        // for connection controls, independently of attention badges.
+        let message = recovery_reason_message(&session);
+        crate::code::attention::replace_attention(
+            &mut session,
+            Attention::needs_you(message, AttentionSource::Lifecycle),
+            false,
+        );
+        if let Some(current) = get_session(&self.db, &session.owner, session.id).await? {
+            if current.lifecycle != SessionLifecycle::Fenced
+                || current.spawn_epoch != session.spawn_epoch
+            {
+                return Ok(());
+            }
+            if current.attention == session.attention
+                && current.fence_reason == session.fence_reason
+            {
+                return Ok(());
+            }
+        }
+        crate::code::attention::persist_session(&self.db, &self.bus, &session).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scripted_harness::{plain_text_script, ScriptedAdapter};
+    use async_trait::async_trait;
+    use std::sync::atomic::AtomicUsize;
+    use tidebreak_core::{HarnessCaps, TurnStatus};
+    use tidebreak_harness::HarnessSession;
+
+    struct CountLaunches {
+        inner: ScriptedAdapter,
+        launches: Arc<AtomicUsize>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl HarnessAdapter for CountLaunches {
+        fn kind(&self) -> HarnessKind {
+            self.inner.kind()
+        }
+        async fn probe(&self, host: &HostEnv) -> HarnessProbe {
+            self.inner.probe(host).await
+        }
+        fn capabilities(&self, probe: &HarnessProbe) -> HarnessCaps {
+            self.inner.capabilities(probe)
+        }
+        async fn launch(&self, spec: SessionSpec) -> Result<Box<dyn HarnessSession>, HarnessError> {
+            self.launches.fetch_add(1, Ordering::SeqCst);
+            assert!(
+                spec.resume_ref.is_none(),
+                "recovery must discard expired context"
+            );
+            if self.fail {
+                return Err(HarnessError::NotFound);
+            }
+            self.inner.launch(spec).await
+        }
+    }
+
+    pub(super) async fn fixture(
+        reason: FenceReason,
+        fail: bool,
+    ) -> (
+        tempfile::TempDir,
+        Arc<CodeRuntime>,
+        Session,
+        Arc<AtomicUsize>,
+    ) {
+        fixture_at(reason, fail, ExecutionLocation::Machine).await
+    }
+
+    pub(super) async fn fixture_at(
+        reason: FenceReason,
+        fail: bool,
+        location: ExecutionLocation,
+    ) -> (
+        tempfile::TempDir,
+        Arc<CodeRuntime>,
+        Session,
+        Arc<AtomicUsize>,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("code.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let launches = Arc::new(AtomicUsize::new(0));
+        let mut registry = AdapterRegistry::new();
+        registry.register(Arc::new(CountLaunches {
+            inner: ScriptedAdapter::new(plain_text_script()),
+            launches: launches.clone(),
+            fail,
+        }));
+        let runtime = Arc::new(CodeRuntime::with_registry(
+            db,
+            dir.path().to_path_buf(),
+            registry,
+        ));
+        let session = Session {
+            visibility: tidebreak_core::SessionVisibility::Private,
+            id: SessionId::new(),
+            owner: OwnerId::local(),
+            owner_kind: None,
+            workspace_id: None,
+            kind: SessionKind::Interactive,
+            harness_kind: HarnessKind::ClaudeCode,
+            harness_version: None,
+            harness_resume_ref: matches!(reason, FenceReason::ResumeLost { .. })
+                .then(|| "expired-context".into()),
+            permission_mode: PermissionMode::Plan,
+            model: None,
+            reasoning_effort: None,
+            fast_mode: false,
+            lifecycle: SessionLifecycle::Fenced,
+            fence_reason: Some(reason.clone()),
+            child_pid: None,
+            child_process_identity: None,
+            spawn_epoch: 1,
+            attention: Attention::new(
+                AttentionState::Fenced { reason },
+                AttentionSource::Lifecycle,
+            ),
+            unrecognized_event_count: 0,
+            subagents: Vec::new(),
+            created_at: Utc::now(),
+            execution_location: location,
+            acts_as: None,
+        };
+        insert_session(&runtime.db, &session).await.unwrap();
+        (dir, runtime, session, launches)
+    }
+
+    pub(super) fn resume_lost() -> FenceReason {
+        FenceReason::ResumeLost {
+            detail: "saved engine session expired".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn recovery_is_single_flight_and_does_not_replay_open_or_queued_turns() {
+        let (_dir, runtime, session, launches) = fixture(resume_lost(), false).await;
+        let turn_id = TurnId::new();
+        tidebreak_core::db::code::insert_turn(
+            &runtime.db,
+            &session.owner,
+            &Turn {
+                actor: None,
+                id: turn_id,
+                session_id: session.id,
+                ordinal: 1,
+                status: TurnStatus::Running,
+                model: None,
+                fast_mode: false,
+                user_input: "do not replay this".into(),
+                user_input_blob_id: None,
+                attachments: Vec::new(),
+                checkpoint_ref: None,
+                diffstat: None,
+                usage: None,
+                narrative: None,
+                rewrite: None,
+                started_at: Utc::now(),
+                ended_at: None,
+                park_ref: None,
+                park_wait: None,
+            },
+        )
+        .await
+        .unwrap();
+        let queued = QueuedTurn {
+            id: TurnId::new(),
+            session_id: session.id,
+            message: "do not start queued work".into(),
+            actor: None,
+            attachments: Vec::new(),
+            position: 0,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        tidebreak_core::db::code::enqueue_queued_turn(&runtime.db, &session.owner, &queued)
+            .await
+            .unwrap();
+        let (first, second) = tokio::join!(
+            runtime.recover_fenced_sessions(),
+            runtime.recover_fenced_sessions()
+        );
+        first.unwrap();
+        second.unwrap();
+        assert_eq!(launches.load(Ordering::SeqCst), 1);
+        let current = runtime
+            .get_session(&session.owner, session.id)
+            .await
+            .unwrap();
+        assert_eq!(current.lifecycle, SessionLifecycle::Idle);
+        assert!(
+            matches!(current.attention.state, AttentionState::NeedsYou { ref prompt, .. } if prompt.contains("paused"))
+        );
+        assert!(
+            tidebreak_core::db::code::queue_paused(&runtime.db, &session.owner, session.id)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            tidebreak_core::db::code::get_turn(&runtime.db, &session.owner, turn_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            TurnStatus::Interrupted
+        );
+        assert_eq!(
+            tidebreak_core::db::code::list_queued_turns(&runtime.db, &session.owner, session.id)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        let events = list_events(
+            &runtime.db,
+            &session.owner,
+            session.id,
+            0,
+            MAX_REPLAY_EVENTS,
+        )
+        .await
+        .unwrap();
+        assert!(events.events.iter().any(|event| matches!(&event.event, Event::HarnessNotice { message, .. } if message.contains("fresh engine"))));
+    }
+
+    #[tokio::test]
+    async fn recovery_allows_a_fresh_message_without_releasing_the_queue_pause() {
+        let (_dir, runtime, session, _) = fixture(resume_lost(), false).await;
+        runtime.recover_fenced_sessions().await.unwrap();
+        let result = runtime
+            .submit_turn(
+                &session.owner,
+                session.id,
+                "new instruction".into(),
+                None,
+                None,
+                vec![],
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(result, SubmitTurnOutcome::Ran(_)));
+    }
+
+    #[tokio::test]
+    async fn failed_launch_backs_off_then_stops_with_a_concrete_blocker() {
+        let (_dir, runtime, session, launches) = fixture(resume_lost(), true).await;
+        runtime.recover_fenced_sessions().await.unwrap();
+        runtime.recover_fenced_sessions().await.unwrap();
+        assert_eq!(
+            launches.load(Ordering::SeqCst),
+            1,
+            "the second sweep respects backoff"
+        );
+        runtime
+            .recovery_attempts
+            .lock()
+            .unwrap()
+            .get_mut(&session.id)
+            .unwrap()
+            .next = Instant::now();
+        runtime.recover_fenced_sessions().await.unwrap();
+        let current = runtime
+            .get_session(&session.owner, session.id)
+            .await
+            .unwrap();
+        assert!(
+            matches!(&current.attention.state, AttentionState::NeedsYou { prompt, .. } if prompt.contains("engine binary not found"))
+        );
+        assert!(
+            matches!(&current.fence_reason, Some(FenceReason::ProbeAmbiguous { detail }) if detail.starts_with("Automatic recovery failed:"))
+        );
+        runtime.recover_fenced_sessions().await.unwrap();
+        assert_eq!(
+            launches.load(Ordering::SeqCst),
+            2,
+            "a blocked connection cannot respawn again"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_failures_preserve_manual_pins_and_do_not_respawn() {
+        let reason = FenceReason::RepeatedTurnFailures {
+            count: 3,
+            detail: "Sign in to your provider".into(),
+        };
+        let (_dir, runtime, mut session, launches) = fixture(reason.clone(), false).await;
+        session.attention = Attention::manual("review this later");
+        tidebreak_core::db::code::replace_session_attention(
+            &runtime.db,
+            &session.owner,
+            session.id,
+            &session.attention,
+            true,
+        )
+        .await
+        .unwrap();
+        runtime.recover_fenced_sessions().await.unwrap();
+        let current = runtime
+            .get_session(&session.owner, session.id)
+            .await
+            .unwrap();
+        assert_eq!(current.attention, session.attention);
+        assert_eq!(current.fence_reason, Some(reason.clone()));
+        let mut updates = runtime.bus.subscribe_updates(&session.owner);
+        crate::code::attention::emit_digest(&runtime.db, &runtime.bus, &current).await;
+        let crate::code::bus::CodeLiveUpdate::Digest(digest) = updates.recv().await.unwrap() else {
+            panic!("expected digest")
+        };
+        assert_eq!(digest.attention, session.attention);
+        assert_eq!(digest.fence_reason, Some(reason));
+        assert!(recovery_message(&current).contains("Sign in"));
+        assert_eq!(launches.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn a_missing_process_identity_blocks_recovery_without_signaling() {
+        let (_dir, runtime, mut session, launches) = fixture(FenceReason::OrphanAlive, false).await;
+        session.child_pid = Some(i64::from(std::process::id()));
+        tidebreak_core::db::code::save_session(&runtime.db, &session)
+            .await
+            .unwrap();
+        runtime.recover_fenced_sessions().await.unwrap();
+        let current = runtime
+            .get_session(&session.owner, session.id)
+            .await
+            .unwrap();
+        assert_eq!(current.lifecycle, SessionLifecycle::Fenced);
+        assert_eq!(current.child_pid, session.child_pid);
+        assert!(
+            matches!(current.attention.state, AttentionState::NeedsYou { ref prompt, .. } if prompt.contains("identity"))
+        );
+        assert_eq!(launches.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn a_remote_sandbox_without_confirmed_final_state_needs_input() {
+        let (_dir, runtime, session, launches) = fixture_at(
+            FenceReason::SandboxLost {
+                detail: "connection lost".into(),
+            },
+            false,
+            ExecutionLocation::Sandbox,
+        )
+        .await;
+        runtime.recover_fenced_sessions().await.unwrap();
+        let current = runtime
+            .get_session(&session.owner, session.id)
+            .await
+            .unwrap();
+        assert!(matches!(
+            current.fence_reason,
+            Some(FenceReason::IncarnationUnresolved { .. })
+        ));
+        assert!(matches!(
+            current.attention.state,
+            AttentionState::NeedsYou { .. }
+        ));
+        assert_eq!(launches.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn foreign_reap_cannot_reset_the_retry_budget() {
+        let (_dir, runtime, session, _) = fixture(resume_lost(), true).await;
+        runtime.recover_fenced_sessions().await.unwrap();
+        assert!(runtime
+            .reap(&OwnerId::new("other").unwrap(), session.id)
+            .await
+            .is_err());
+        assert_eq!(
+            runtime
+                .recovery_attempts
+                .lock()
+                .unwrap()
+                .get(&session.id)
+                .unwrap()
+                .count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn a_new_blocker_replaces_a_stale_approval_prompt() {
+        let (_dir, runtime, session, _) = fixture(
+            FenceReason::RepeatedTurnFailures {
+                count: 3,
+                detail: "provider signed out".into(),
+            },
+            false,
+        )
+        .await;
+        tidebreak_core::db::code::replace_session_attention(
+            &runtime.db,
+            &session.owner,
+            session.id,
+            &Attention::needs_you("approve a write", AttentionSource::Structured),
+            false,
+        )
+        .await
+        .unwrap();
+        runtime.recover_fenced_sessions().await.unwrap();
+        let current = runtime
+            .get_session(&session.owner, session.id)
+            .await
+            .unwrap();
+        assert!(
+            matches!(current.attention.state, AttentionState::NeedsYou { ref prompt, .. } if prompt.contains("provider signed out"))
+        );
+    }
+}
+
+#[cfg(test)]
+mod remote_and_admission_tests {
+    use super::tests::{fixture, fixture_at, resume_lost};
+    use super::*;
+    use tidebreak_core::db::code::{
+        activate_incarnation, create_incarnation_intent, ingest_incarnation_event,
+        latest_incarnation, stop_incarnation, IncarnationSideEffects,
+    };
+
+    #[tokio::test]
+    async fn automatic_remote_recovery_preserves_output_checkpoint_and_spend_gates() {
+        for (stop, checkpoint, terminal, recovered) in [
+            ("failed", None, true, false),
+            ("ceiling_exceeded", Some("refs/heads/wip"), true, false),
+            ("expired", Some("refs/heads/wip"), false, false),
+            ("expired", Some("refs/heads/wip"), true, true),
+        ] {
+            let (_dir, runtime, session, launches) = fixture_at(
+                FenceReason::SandboxLost {
+                    detail: stop.into(),
+                },
+                false,
+                ExecutionLocation::Sandbox,
+            )
+            .await;
+            let tidebreak_core::IncarnationAdmission::Admitted(row) =
+                create_incarnation_intent(&runtime.db, &session.owner, session.id, 1, 1)
+                    .await
+                    .unwrap()
+            else {
+                panic!("expected admission")
+            };
+            activate_incarnation(&runtime.db, &session.owner, row.id, "sandbox-test")
+                .await
+                .unwrap();
+            ingest_incarnation_event(
+                &runtime.db,
+                &session.owner,
+                session.id,
+                session.spawn_epoch,
+                row.id,
+                1,
+                IncarnationSideEffects {
+                    journal: &[],
+                    task_output: None,
+                    wip_ref: checkpoint,
+                    terminal_events_journaled: terminal,
+                },
+            )
+            .await
+            .unwrap();
+            stop_incarnation(&runtime.db, &session.owner, row.id, Some(stop))
+                .await
+                .unwrap();
+            runtime.recover_fenced_sessions().await.unwrap();
+            let current = runtime
+                .get_session(&session.owner, session.id)
+                .await
+                .unwrap();
+            assert_eq!(
+                current.lifecycle == SessionLifecycle::Idle,
+                recovered,
+                "stop={stop} checkpoint={checkpoint:?} terminal={terminal}"
+            );
+            let latest = latest_incarnation(&runtime.db, &session.owner, session.id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(latest.id, row.id, "recovery must not provision a successor");
+            assert_eq!(
+                latest.terminal_events_journaled, terminal,
+                "recovery must never accept missing output"
+            );
+            assert_eq!(latest.stop_reason.as_deref(), Some(stop));
+            assert_eq!(launches.load(Ordering::SeqCst), 0);
+            if !recovered {
+                assert!(matches!(
+                    current.attention.state,
+                    AttentionState::NeedsYou { .. }
+                ));
+                assert!(!current.fence_reason.unwrap().blocks_workspace());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn rejected_reap_leaves_a_healthy_queue_unchanged() {
+        let (_dir, runtime, session, _) = fixture(resume_lost(), false).await;
+        runtime.recover_fenced_sessions().await.unwrap();
+        runtime
+            .set_queue_paused(&session.owner, session.id, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            runtime
+                .reap(&session.owner, session.id)
+                .await
+                .unwrap_err()
+                .kind(),
+            "not_fenced"
+        );
+        assert!(
+            !tidebreak_core::db::code::queue_paused(&runtime.db, &session.owner, session.id)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_admission_waits_for_recovery_and_rereads_the_session() {
+        let (_dir, runtime, session, _) = fixture(resume_lost(), false).await;
+        runtime.recover_fenced_sessions().await.unwrap();
+        let lock = runtime.session_recovery_lock(session.id).lock_owned().await;
+        let task_runtime = runtime.clone();
+        let owner = session.owner.clone();
+        let mut turn = tokio::spawn(async move {
+            task_runtime
+                .submit_turn(
+                    &owner,
+                    session.id,
+                    "new message".into(),
+                    None,
+                    None,
+                    vec![],
+                    None,
+                )
+                .await
+        });
+        assert!(tokio::time::timeout(Duration::from_millis(30), &mut turn)
+            .await
+            .is_err());
+        let mut current = runtime
+            .get_session(&session.owner, session.id)
+            .await
+            .unwrap();
+        current.lifecycle = SessionLifecycle::Ended;
+        tidebreak_core::db::code::save_session(&runtime.db, &current)
+            .await
+            .unwrap();
+        drop(lock);
+        let error = turn
+            .await
+            .unwrap()
+            .err()
+            .expect("ending during recovery refuses the turn");
+        assert_eq!(error.kind(), "session_ended");
+    }
+
+    #[tokio::test]
+    async fn unused_recovery_locks_are_pruned() {
+        let (_dir, runtime, _, _) = fixture(resume_lost(), false).await;
+        for _ in 0..100 {
+            drop(runtime.session_recovery_lock(SessionId::new()));
+        }
+        assert_eq!(runtime.recovery_locks.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_failed_explicit_retry_keeps_the_connection_blocked() {
+        let (_dir, runtime, session, _) = fixture(resume_lost(), true).await;
+        assert!(runtime.reap(&session.owner, session.id).await.is_err());
+        let current = runtime
+            .get_session(&session.owner, session.id)
+            .await
+            .unwrap();
+        assert_eq!(current.lifecycle, SessionLifecycle::Fenced);
+        assert!(
+            matches!(current.attention.state, AttentionState::NeedsYou { ref prompt, .. } if prompt.contains("engine binary not found"))
+        );
+        assert!(!runtime.has_worker(session.id));
+    }
+}

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -91,6 +91,7 @@ use crate::managed_policy::ManagedPolicy;
 
 mod adapters;
 mod approvals;
+mod auto_recovery;
 mod recover;
 mod remote;
 pub use remote::ExternalActsAsView;
@@ -243,6 +244,10 @@ pub struct CodeRuntime {
     /// Last pin-install failure per kind. Cleared on a successful install.
     pin_install_errors: Mutex<HashMap<HarnessKind, String>>,
     workers: Mutex<HashMap<SessionId, WorkerHandle>>,
+    recovery_locks: Mutex<HashMap<SessionId, std::sync::Weak<tokio::sync::Mutex<()>>>>,
+    recovery_attempts: Mutex<HashMap<SessionId, auto_recovery::RecoveryAttempt>>,
+    recovery_sweep: Mutex<Option<auto_recovery::RecoverySweepGuard>>,
+    recovery_started: AtomicBool,
     /// Sessions whose worker must move to the selected engine binary once
     /// their turn in flight ends. See `resync_workers_to_selected_binaries`.
     deferred_resyncs: Mutex<HashSet<SessionId>>,
@@ -519,6 +524,10 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            recovery_locks: Mutex::new(HashMap::new()),
+            recovery_attempts: Mutex::new(HashMap::new()),
+            recovery_sweep: Mutex::new(None),
+            recovery_started: AtomicBool::new(false),
             deferred_resyncs: Mutex::new(HashSet::new()),
             update_quiesce: watch::channel(false).0,
             workspace_lifecycles: Mutex::new(HashMap::new()),
@@ -629,6 +638,7 @@ impl CodeRuntime {
             // After recovery so resumed watch sessions have workers to drive;
             // the sweep reads its work list from the `code_watch` table, so
             // active watches resume with no extra state.
+            runtime.ensure_recovery_sweep();
             runtime.ensure_watch_sweep();
             runtime.ensure_trigger_sweep();
             runtime.ensure_reconcile_sweep();
@@ -692,6 +702,10 @@ impl CodeRuntime {
             probes: Mutex::new(HashMap::new()),
             pin_install_errors: Mutex::new(HashMap::new()),
             workers: Mutex::new(HashMap::new()),
+            recovery_locks: Mutex::new(HashMap::new()),
+            recovery_attempts: Mutex::new(HashMap::new()),
+            recovery_sweep: Mutex::new(None),
+            recovery_started: AtomicBool::new(false),
             deferred_resyncs: Mutex::new(HashSet::new()),
             update_quiesce: watch::channel(false).0,
             workspace_lifecycles: Mutex::new(HashMap::new()),

--- a/crates/tidebreak-server/src/code/runtime/recover.rs
+++ b/crates/tidebreak-server/src/code/runtime/recover.rs
@@ -210,6 +210,20 @@ impl CodeRuntime {
                 );
             }
         }
+        let fenced = list_sessions_all_owners(&self.db)
+            .await?
+            .into_iter()
+            .filter(|session| {
+                session.execution_location == tidebreak_core::ExecutionLocation::Machine
+                    && session.lifecycle == SessionLifecycle::Fenced
+                    && matches!(
+                        session.fence_reason,
+                        Some(FenceReason::OrphanAlive | FenceReason::ResumeLost { .. })
+                    )
+            })
+            .collect::<Vec<_>>();
+        self.prepare_recovered_harnesses(&fenced).await;
+        self.recover_fenced_sessions().await?;
         let recovered_sessions = list_sessions_all_owners(&self.db).await?;
         for session in &recovered_sessions {
             if session.lifecycle == SessionLifecycle::Ended {

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -1023,6 +1023,7 @@ impl CodeRuntime {
         let Some(remote) = self.remote_sessions() else {
             return Ok(());
         };
+        let _recovery_guard = self.session_recovery_lock(session.id).lock_owned().await;
         let lock = remote.promotion_lock(session.id);
         let _guard = lock.lock().await;
         let mut session = self.get_session(&session.owner, session.id).await?;

--- a/crates/tidebreak-server/src/code/runtime/sessions.rs
+++ b/crates/tidebreak-server/src/code/runtime/sessions.rs
@@ -566,6 +566,7 @@ impl CodeRuntime {
         owner: &OwnerId,
         session_id: SessionId,
     ) -> Result<(), ServerError> {
+        let _guard = self.session_recovery_lock(session_id).lock_owned().await;
         let Some(mut session) = get_session(&self.db, owner, session_id).await? else {
             return Ok(());
         };

--- a/crates/tidebreak-server/src/code/runtime/settings.rs
+++ b/crates/tidebreak-server/src/code/runtime/settings.rs
@@ -159,6 +159,7 @@ impl CodeRuntime {
         id: SessionId,
         mode: PermissionMode,
     ) -> Result<Session, ServerError> {
+        let _recovery_guard = self.session_recovery_lock(id).lock_owned().await;
         let session = self.get_session(owner, id).await?;
         if session.permission_mode == mode {
             return Ok(session);
@@ -266,7 +267,7 @@ impl CodeRuntime {
                     if fenced.is_some() {
                         Err(ServerError::conflict_kind(
                             "permission_mode_unconfirmed",
-                            "the engine accepted the permission mode, but the durable session changed before confirmation; reap the fenced session before another turn",
+                            "the engine accepted the permission mode, but the durable session changed before confirmation; resolve the connection problem before another turn",
                         ))
                     } else {
                         Err(ServerError::conflict_kind(
@@ -343,7 +344,7 @@ impl CodeRuntime {
                 }
                 return Err(ServerError::conflict_kind(
                     "permission_mode_unconfirmed",
-                    "the session worker did not stop while changing permission mode; reap the fenced session before another turn",
+                    "the session worker did not stop while changing permission mode; resolve the connection problem before another turn",
                 ));
             }
         }
@@ -363,7 +364,7 @@ impl CodeRuntime {
                 crate::code::attention::emit_digest(&self.db, &self.bus, &fenced).await;
                 return Err(ServerError::conflict_kind(
                     "permission_mode_unconfirmed",
-                    "the session changed while its worker stopped for the permission mode update; reap the fenced session before another turn",
+                    "the session changed while its worker stopped for the permission mode update; resolve the connection problem before another turn",
                 ));
             }
             let _ = discard_permission_mode_change(&self.db, owner, &intent).await?;
@@ -590,6 +591,7 @@ impl CodeRuntime {
         id: SessionId,
         effort: Option<ReasoningEffort>,
     ) -> Result<Session, ServerError> {
+        let _recovery_guard = self.session_recovery_lock(id).lock_owned().await;
         let session = self.get_session(owner, id).await?;
         if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
             let mut next = SessionExecutionSettings::from(&session);
@@ -655,6 +657,7 @@ impl CodeRuntime {
         id: SessionId,
         fast_mode: bool,
     ) -> Result<Session, ServerError> {
+        let _recovery_guard = self.session_recovery_lock(id).lock_owned().await;
         let session = self.get_session(owner, id).await?;
         if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
             let mut requested = session.clone();

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -155,6 +155,7 @@ impl CodeRuntime {
                 return Ok(SubmitTurnOutcome::AlreadyDelivered);
             }
         }
+        let recovery_guard = self.session_recovery_lock(id).lock_owned().await;
         let mut session = self.get_session(owner, id).await?;
         let workspace = self.session_workspace(&session).await?;
         if let Some(workspace) = &workspace {
@@ -168,7 +169,7 @@ impl CodeRuntime {
         if session.lifecycle == SessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
                 "session_fenced",
-                "session is fenced until it is reaped",
+                super::auto_recovery::recovery_message(&session),
             ));
         }
         if session.lifecycle == SessionLifecycle::Ended {
@@ -310,6 +311,7 @@ impl CodeRuntime {
             })
             .await
             .map_err(|_| ServerError::internal("session worker is gone"))?;
+        drop(recovery_guard);
         let turn = match rx
             .await
             .map_err(|_| ServerError::internal("session worker dropped the turn"))?
@@ -518,6 +520,7 @@ impl CodeRuntime {
         id: SessionId,
         paused: bool,
     ) -> Result<(), ServerError> {
+        let _recovery_guard = self.session_recovery_lock(id).lock_owned().await;
         let session = self.get_session(owner, id).await?;
         tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, paused).await?;
         if !paused {
@@ -530,6 +533,7 @@ impl CodeRuntime {
     /// head row. The tray composes send-now client-side exactly as chat does:
     /// pause, move the row first, stop the live turn, then this.
     pub async fn send_queued_now(&self, owner: &OwnerId, id: SessionId) -> Result<(), ServerError> {
+        let _recovery_guard = self.session_recovery_lock(id).lock_owned().await;
         let session = self.get_session(owner, id).await?;
         tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, false).await?;
         self.wake_queue_for_location(&session);
@@ -737,12 +741,46 @@ impl CodeRuntime {
     }
 
     pub async fn reap(&self, owner: &OwnerId, id: SessionId) -> Result<Session, ServerError> {
+        let _guard = self.session_recovery_lock(id).lock_owned().await;
         let session = self.get_session(owner, id).await?;
         if session.lifecycle != SessionLifecycle::Fenced {
             return Err(ServerError::conflict_kind(
                 "not_fenced",
-                "only a fenced session can be reaped",
+                "this session does not need connection recovery",
             ));
+        }
+        self.recovery_attempts
+            .lock()
+            .expect("recovery attempts")
+            .remove(&id);
+        tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, true).await?;
+        let result = self.reap_inner(owner, id).await;
+        if let Err(error) = &result {
+            self.retain_failed_recovery(&session, error.message())
+                .await?;
+        }
+        result
+    }
+
+    pub(super) async fn reap_inner(
+        &self,
+        owner: &OwnerId,
+        id: SessionId,
+    ) -> Result<Session, ServerError> {
+        let mut session = self.get_session(owner, id).await?;
+        if session.lifecycle != SessionLifecycle::Fenced {
+            return Err(ServerError::conflict_kind(
+                "not_fenced",
+                "this session does not need connection recovery",
+            ));
+        }
+        let fresh_context = matches!(session.fence_reason, Some(FenceReason::ResumeLost { .. }));
+        if fresh_context && session.harness_resume_ref.is_some() {
+            let reason = session
+                .fence_reason
+                .clone()
+                .expect("resume loss has a cause");
+            recovery::fence_session(&self.db, &self.bus, &mut session, reason).await?;
         }
         if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
             // No worker to shut down and nothing to relaunch: the driver
@@ -775,7 +813,16 @@ impl CodeRuntime {
             // the new spawn must not be started against a row it is still
             // moving. Wait for it, then reap the row as it stands now.
             Some(handle) => {
-                Self::shut_down_worker(id, handle).await;
+                if !Self::shut_down_worker(id, handle.clone()).await {
+                    self.workers
+                        .lock()
+                        .expect("code workers")
+                        .insert(id, handle);
+                    return Err(ServerError::conflict_kind(
+                        "session_not_reaped",
+                        "The previous engine did not stop. Wait for it to exit before retrying recovery.",
+                    ));
+                }
                 self.get_session(owner, id).await?
             }
             None => session,
@@ -786,6 +833,18 @@ impl CodeRuntime {
                 recovery::ReapSessionError::Store(error) => ServerError::from(error),
                 other => ServerError::conflict_kind("session_not_reaped", other.to_string()),
             })?;
-        self.attach_and_spawn_worker(session).await
+        let attached = self.attach_and_spawn_worker(session).await?;
+        if fresh_context {
+            if let Err(error) = crate::code::session_worker::journal_event(
+                &self.db, &self.bus, &attached.owner, attached.id, attached.spawn_epoch,
+                Event::HarnessNotice {
+                    level: tidebreak_core::HarnessNoticeLevel::Info,
+                    message: "The previous engine context expired. A fresh engine is ready; your saved transcript remains, and the interrupted turn was not replayed.".into(),
+                },
+            ).await {
+                tracing::warn!(session = %attached.id, %error, "could not journal fresh engine context after recovery");
+            }
+        }
+        Ok(attached)
     }
 }

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -549,6 +549,7 @@ impl CodeRuntime {
                 .map(|(id, handle)| (*id, handle.spawn_epoch, handle.sink.owner().clone()))
                 .collect();
             for (id, spawn_epoch, owner) in stale {
+                let _recovery_guard = self.session_recovery_lock(id).lock_owned().await;
                 let Ok(session) = self.get_session(&owner, id).await else {
                     continue;
                 };
@@ -559,11 +560,23 @@ impl CodeRuntime {
                     self.defer_worker_resync(*kind, id, owner);
                     continue;
                 }
+                if matches!(
+                    session.lifecycle,
+                    SessionLifecycle::Fenced | SessionLifecycle::Ended
+                ) {
+                    continue;
+                }
                 let Some(handle) = self.take_worker_for_epoch(id, spawn_epoch) else {
                     continue;
                 };
                 self.revoke_worker_channels(id);
-                Self::shut_down_worker(id, handle).await;
+                if !Self::shut_down_worker(id, handle.clone()).await {
+                    self.workers
+                        .lock()
+                        .expect("code workers")
+                        .insert(id, handle);
+                    continue;
+                }
                 let respawned = match self.get_session(&owner, id).await {
                     Ok(session) => self.attach_and_spawn_worker(session).await,
                     Err(error) => Err(error),

--- a/crates/tidebreak-server/src/code/runtime/workspaces.rs
+++ b/crates/tidebreak-server/src/code/runtime/workspaces.rs
@@ -1137,7 +1137,11 @@ impl CodeRuntime {
     ) -> Result<bool, ServerError> {
         let mut all_stopped = true;
         let sessions = list_sessions_for_workspace(&self.db, owner, workspace_id).await?;
-        for mut session in sessions {
+        for session in sessions {
+            let _recovery_guard = self.session_recovery_lock(session.id).lock_owned().await;
+            let Some(mut session) = get_session(&self.db, owner, session.id).await? else {
+                continue;
+            };
             if session.lifecycle == SessionLifecycle::Ended {
                 self.bus.forget(session.id);
                 continue;

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -150,6 +150,7 @@ pub(crate) enum WorkerError {
     UpdateQuiesced,
 }
 
+#[derive(Clone)]
 pub(crate) struct WorkerHandle {
     pub spawn_epoch: i64,
     /// The engine executable this worker launches, copied from the probe at

--- a/crates/tidebreak-server/src/code/types.rs
+++ b/crates/tidebreak-server/src/code/types.rs
@@ -1804,6 +1804,10 @@ pub struct SessionDigest {
     pub harness_kind: Option<HarnessKind>,
     pub lifecycle: SessionLifecycle,
     pub attention: Attention,
+    /// Recovery cause, independent of a manual attention pin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub fence_reason: Option<FenceReason>,
     pub title: String,
     pub turn_count: i64,
     /// Timestamp trigger delivery uses to rank candidate sessions: the newest
@@ -1867,6 +1871,7 @@ impl From<crate::code::bus::SessionDigest> for SessionDigest {
             harness_kind: Some(digest.harness_kind),
             lifecycle: digest.lifecycle,
             attention: digest.attention,
+            fence_reason: digest.fence_reason,
             title: digest.title,
             turn_count: digest.turn_count,
             trigger_target_at: Some(digest.trigger_target_at),
@@ -1905,6 +1910,9 @@ pub enum UpdateNotice {
         #[ts(optional)]
         harness_kind: Option<HarnessKind>,
         lifecycle: SessionLifecycle,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        fence_reason: Option<Box<tidebreak_core::FenceReason>>,
         attention: Attention,
         title: String,
         turn_count: i64,
@@ -2043,6 +2051,7 @@ impl UpdateNotice {
             kind: wire.kind,
             harness_kind: wire.harness_kind,
             lifecycle: wire.lifecycle,
+            fence_reason: wire.fence_reason.map(Box::new),
             attention: wire.attention,
             title: wire.title,
             turn_count: wire.turn_count,

--- a/docs-site/content/docs/headless.mdx
+++ b/docs-site/content/docs/headless.mdx
@@ -469,7 +469,7 @@ elapses. `code_wait` re-follows an in-flight or queued turn. `code_decide`
 applies the decision and follows to the next settle point. `code_approvals`
 lists what is parked.
 
-`status` is the chat set plus **`queued`**. `POST /code/sessions/{id}/turns`
+`status` is the chat set plus **`queued`**. `POST /sessions/{id}/turns`
 waits for the worker to finish or to park the message on the durable session
 queue. A queued receipt returns immediately with the queue position and the
 turn id the promoted turn will run under — it is not a failure. Re-check with

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -257,26 +257,42 @@ describe the current schema, not the frozen baseline.
   ([`0050`](decisions/0050-watch-and-fix-is-a-durable-task.md)).
 
 Boot recovery (`code/recovery.rs`, per
-[`0032`](decisions/0032-code-workspaces-worktrees-checkpoints.md)): sessions
-recorded `Running` are probed by recorded pid. Dead → the open turn closes
-as `Interrupted` (journaled), session `Idle`, attention
-`NeedsYou { source: Lifecycle }`. Alive → `Fenced { OrphanAlive }` until an
-explicit reap. Never signal a pid not recorded at spawn; `EPERM` counts as
-alive. A pid is reused once its original process exits, so the probe also
-matches the recorded `child_process_identity` — the operating system's
-creation identity for that child — before it treats the pid as the session's
-own. A pid that is alive under a different identity is a stranger's process,
-and signalling it is what the match exists to prevent.
+[`0032`](decisions/0032-code-workspaces-worktrees-checkpoints.md)) checks
+sessions recorded as `Running` against their recorded process identity. A
+dead external process closes its open turn as `Interrupted`; the transcript
+stays intact. Internal-engine checkpoints keep their existing durable resume
+path.
 
-A resume ref is only worth persisting once it would actually resume:
-`HarnessSession::resume_ref` reports a token after the engine has committed
-it, not when the engine first names it. Codex, for instance, does not write a
-thread that has run no turn, so a thread id from `thread/start` alone stays
-unreported and a session whose engine dies before its first turn re-attaches
-with a fresh `thread/start`. When an engine does refuse a stored ref, the
-adapter reports `HarnessError::ResumeLost` and the session is
-`Fenced { ResumeLost }` — the fence drops the dead ref, so the reap it asks
-for starts a clean engine session instead of failing every turn identically.
+Routine recovery runs automatically. A verified leftover local process can
+be stopped before a replacement worker attaches. If an engine rejects a
+stored resume reference, recovery drops that reference and starts a fresh
+engine session. Neither path resubmits the interrupted input. Recovery leaves
+queued work paused so an interrupted session does not start another turn
+without a fresh action.
+
+Process ownership remains a hard boundary. Never signal a process without its
+recorded creation identity. A reused process ID belongs to another process,
+and an ambiguous probe must stay blocked. Automatic attempts are bounded and
+serialized with manual recovery. Repeated turn failures require the underlying
+problem to be fixed rather than an automatic restart loop.
+
+Remote recovery also requires proof that the previous sandbox stopped and
+that its terminal events reached the journal. Existing checkpoint and spend
+limits still apply. Automatic recovery never waives
+missing output or treats a best-effort cancellation as proof of termination.
+
+`Fenced` remains an internal lifecycle value. The UI stays quiet during brief
+recovery, shows “Reconnecting…” when it takes longer, and shows the specific
+problem when recovery cannot proceed. An existing manual attention pin remains
+intact. The recovery notice still exposes the blocking reason and any explicit
+retry action. Session digests and live digest notices carry an optional
+`fence_reason` so a manual pin cannot hide a recovery failure. Older clients
+can ignore the added field.
+
+A resume reference is persisted only after the engine commits it.
+`HarnessSession::resume_ref` does not report a token merely because the engine
+names it. For example, Codex does not persist a thread before its first turn,
+so a bare `thread/start` ID is not reused after a restart.
 
 ## The adapter contract
 
@@ -351,7 +367,7 @@ drift from captured reality
 Decision 48 step 5 puts Tidebreak's own agent loop behind the same contract.
 `HarnessKind::Internal` is registered by
 `crates/tidebreak-server/src/engine/internal/`, and a session created with
-no workspace (`POST /code/sessions`) selects it; the workspace-bound create
+no workspace (`POST /sessions`) selects it; the workspace-bound create
 path refuses it. The engine probes as found with no binary, needs no pin,
 and takes its inference from the server's own provider resolution.
 
@@ -383,7 +399,7 @@ Every decision settles the row through the one settle operation in
 `db/ops/code/approval.rs` and journals one `ApprovalResolved` there: the
 chat routes (`POST /chats/{id}/approvals/{call}`, `/questions/{call_id}/answer`,
 `/plans/{call}/decision`), the session route (`POST
-/code/approvals/{id}/decision`, which claims the row, delivers the decision
+/approvals/{id}/decision`, which claims the row, delivers the decision
 to `decide`, and settles on acknowledgement), the internal engine's
 Auto-mode judge, and the turn lane's cancellation and terminal sweeps. The
 agent loop journals no decision of its own; it reads the settled row and
@@ -467,7 +483,6 @@ bounded):
 | `TurnInterrupted` | usage up to the interruption, when the engine reports it |
 | `CheckpointRecorded` | turn id, diffstat |
 | `HarnessNotice` | level, message — the visible-degradation channel |
-| `AttentionChanged` | state, source |
 | `CredentialRefused` | provider and refusal message |
 
 The internal engine's own rows, which no external adapter writes:
@@ -497,12 +512,13 @@ whose completion payload carries no arguments leaves it unset.
 The block below is the spine, not the whole router. `crates/tidebreak-server-api/src/lib.rs`
 carries the complete list, and the generated wire types are what clients bind
 to; transcribing every route here only buys a page that drifts.
+Sessions, updates, and approvals use the unprefixed routes shown here.
 
 ```
 POST/GET        /code/repos                GET/PATCH/DELETE /code/repos/{id}
 GET             /code/repos/sources        POST /code/repos/clone    GET /code/repos/clone/{job}
-POST/GET        /code/sessions             a session with no workspace (internal engine)
-GET             /code/sessions/{id}
+POST/GET        /sessions                  a session with no workspace (internal engine)
+GET             /sessions/{id}
 GET             /code/harnesses            doctor    POST /code/harnesses/refresh
 POST            /code/harnesses/{kind}/install       warm the pinned install (0045)
 GET             /code/harnesses/{kind}/models
@@ -515,26 +531,26 @@ POST            /code/workspaces/{id}/restore        back from a reclaim tier (0
 POST            /code/workspaces/{id}/retry-setup    run setup again on the same worktree
 POST            /code/workspaces/{id}/sessions       {harness, permission_mode,
                                                      model?, reasoning_effort?, fast_mode?}
-POST/GET        /code/sessions/{id}/turns            {message}  (queued while running —
+POST/GET        /sessions/{id}/turns                 {message}  (queued while running —
                                                      the chat product's queue-default rule;
                                                      steering is the explicit alternative,
                                                      available only where the adapter's
                                                      mid_turn_steering capability carries it)
-GET             /code/sessions/{id}/queued           the durable queue (0069)
-PATCH/DELETE    /code/sessions/{id}/queued/{queued_id}
-PUT             /code/sessions/{id}/queue-paused
-POST            /code/sessions/{id}/queued/send-now
-POST            /code/sessions/{id}/steer            one mid-turn message
-POST            /code/sessions/{id}/interrupt | /reap | /fork
-POST            /code/sessions/{id}/mode | /effort | /fast-mode | /attention
-WS              /code/sessions/{id}/events?after=    snapshot → replay → live
+GET             /sessions/{id}/queued                the durable queue (0069)
+PATCH/DELETE    /sessions/{id}/queued/{queued_id}
+PUT             /sessions/{id}/queue-paused
+POST            /sessions/{id}/queued/send-now
+POST            /sessions/{id}/steer                 one mid-turn message
+POST            /sessions/{id}/interrupt | /reap | /fork
+POST            /sessions/{id}/mode | /effort | /fast-mode | /attention
+WS              /sessions/{id}/events?after=         snapshot → replay → live
                                                      (replay is capped and flags truncation;
                                                      assistant deltas ride the same socket
                                                      as live-only frames — record 0058)
-WS              /code/updates                        digests, restated on connect
+WS              /updates                             digests, restated on connect
 
-GET             /code/approvals?state=pending
-POST            /code/approvals/{id}/decision        {decision: approve | deny | approve_with_grant | answers | plan_decision, ...}
+GET             /approvals?state=pending
+POST            /approvals/{id}/decision             {decision: approve | deny | approve_with_grant | answers | plan_decision, ...}
 POST            /code/mcp/approval-prompt            loopback approval endpoint (0033)
 POST            /code/mcp/connected-apps             loopback MCP bridge over every mounted MCP server, for external engines
 
@@ -556,11 +572,11 @@ POST            /code/delivery/pull-requests/query | /detail | /action
 POST            /code/delivery/runs/query  | /detail | /action
 POST            /code/workspace-title      generate a workspace title
 
-POST/GET        /sessions                 shared conversation collection
+POST/GET        /sessions                      shared conversation collection
 GET/POST        /sessions/{id}/...        turns, queue, events, controls, access
-GET             /approvals                pending approvals
-POST            /approvals/{id}/decision  settle an approval
-WS              /updates                  shared updates stream
+GET             /approvals                     pending approvals
+POST            /approvals/{id}/decision       settle an approval
+WS              /updates                       shared updates stream
 
 POST/GET/DELETE /code/workspaces/{id}/terminals      DELETE closes every terminal at once
 DELETE          /code/workspaces/{id}/terminals/{tid}    close one
@@ -614,7 +630,7 @@ of its own: registering one opens the new-workspace dialog, and picking one on
   "Workspaces" header carrying list settings, add repo, and new workspace,
   then workspace cards with attention badges, and the mode switch back to
   chat.
-- `CodeUpdatesStore.ts` — one singleton store fed by `/code/updates`;
+- `CodeUpdatesStore.ts` — one singleton store fed by `/updates`;
   everything list-shaped reads from it.
 - `CodeSessionRegistry.ts` — `Map<sessionId, {store, controller, refCount}>`
   of per-session stores from a `createCodeSessionStore()` factory; only

--- a/docs/decisions/0035-code-mode-wire-contract.md
+++ b/docs/decisions/0035-code-mode-wire-contract.md
@@ -34,12 +34,12 @@ rides that pipeline.
 **Per-session journals, identical discipline.** Code sessions journal into
 their own table (`code_event`: session id, monotonic per-session sequence,
 event payload), written before any live publication. The per-session
-WebSocket (`/code/sessions/{id}/events?after=`) implements exactly the chat
+WebSocket (`/sessions/{id}/events?after=`) implements exactly the chat
 contract: subscribe live first, snapshot, replay `seq > after`, then live,
 with sequence-based dedupe. One socket exists per *open* session view; a
 session nobody is looking at streams to no one.
 
-**One install-wide updates channel.** A single WebSocket (`/code/updates`)
+**One install-wide updates channel.** A single WebSocket (`/updates`)
 carries unsequenced digest notices: per-session
 `{workspace, session, lifecycle, attention, title, turn count, pull-request
 state}`. Digests are restated in full on connect, so a dropped notice costs

--- a/docs/decisions/0046-rich-turn-input-rides-harness-capabilities.md
+++ b/docs/decisions/0046-rich-turn-input-rides-harness-capabilities.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-Code-mode turns today are plain text: `POST /code/sessions/{id}/turns`
+Code-mode turns today are plain text: `POST /sessions/{id}/turns`
 accepts `{message, model}`, and the composer offers nothing the wire cannot
 carry. Three requested inputs go beyond that:
 

--- a/docs/decisions/0048-one-interaction-model.md
+++ b/docs/decisions/0048-one-interaction-model.md
@@ -35,7 +35,7 @@ than hypothetical. What exists twice today:
    creation and refused per declared harness capability (decisions 38, 39).
 2. Two journals implementing the same snapshot-replay-live contract: the
    `event` table with `/chats/{id}/events`, and `code_event` with
-   `/code/sessions/{id}/events` plus the unsequenced `/code/updates` channel
+   `/sessions/{id}/events` plus the unsequenced `/updates` channel
    (decision 35).
 3. Two approval models: chat's grant ladders and approval judge; code's
    verbatim-payload rows with deny-with-feedback and deliberately no

--- a/docs/decisions/0055-multiple-sessions-per-workspace.md
+++ b/docs/decisions/0055-multiple-sessions-per-workspace.md
@@ -133,3 +133,22 @@ the watch guard still refuses a second watch. Three tests cover the races the
 lock exists for — two idle siblings sending at once get one turn and one queue
 rather than two turns and a held request, an interrupt reaches a queued turn
 before it starts, and a fenced sibling refuses turns until it is reaped.
+
+## Amendment: automatic session recovery (2026-09-11)
+
+The workspace exclusion above remains in force while an unaccounted local
+process may still write to the checkout. Resolving that exclusion does not
+normally require a user action. Tidebreak can automatically stop an exact,
+identity-verified leftover process and recover the session before attaching a
+replacement worker. It can also replace a rejected engine resume reference.
+
+Recovery does not replay interrupted input. It keeps queued work paused and
+preserves the existing journal. Attempts are bounded and serialized with
+manual recovery. Unknown process ownership, repeated failures, and missing
+remote terminal output remain blocked with a concrete explanation. Remote
+recovery requires confirmed termination and recorded terminal events; it
+cannot silently accept lost output.
+
+The internal `Fenced` state is not a user-facing status. Brief recovery is
+quiet. Longer recovery shows “Reconnecting…”. A notice appears when recovery
+fails or needs user input, with the cause and a specific next action.

--- a/docs/decisions/0066-pull-request-state-is-one-store.md
+++ b/docs/decisions/0066-pull-request-state-is-one-store.md
@@ -15,7 +15,7 @@ its own cache, and its own clock:
 | Representation | Fetcher | Freshness | Read by |
 |---|---|---|---|
 | `PullRequestDigest` | `gh pr view` ×2 + `gh pr checks` + timeline | 20 s `PrDigestCache` (`gh.rs`) | workspace header, Review tab |
-| `code_workspace.pr` column | side effect of a digest read | as old as the last read | workspace cards, `/code/updates` digests |
+| `code_workspace.pr` column | side effect of a digest read | as old as the last read | workspace cards, `/updates` digests |
 | `code_pull_request` facts | detector, sweeps, delivery reads | ≤ 61 s, no check state | attributed lists, stacks, triggers |
 | Delivery summaries | `gh pr list` / `gh pr view` + REST | 30 s aggregate cache | delivery center, detail sheet, notifications |
 
@@ -94,7 +94,7 @@ it all day must never notice it in their rate limit.
    idle workspace, but no longer skips the state read.
 4. **A change broadcasts once.** The store diffs on write; a changed row
    emits workspace digests for every attributed workspace (the existing
-   `/code/updates` channel) plus one delivery update, and the delivery page
+   `/updates` channel) plus one delivery update, and the delivery page
    and background monitor drop their own poll timers. `GET
    /code/workspaces/{id}/pr` stops calling GitHub in the request path: it
    reads local git plus the row, so opening a workspace stops paying the

--- a/docs/decisions/0069-durable-code-session-queue.md
+++ b/docs/decisions/0069-durable-code-session-queue.md
@@ -50,7 +50,7 @@ by the session worker.**
   runs under the session's model and effort as they are then, not as they
   were at enqueue.
 - The same REST surface as chat, one path segment over: `GET
-  /code/sessions/{id}/queued`, `PATCH`/`DELETE
+  /sessions/{id}/queued`, `PATCH`/`DELETE
   …/queued/{queued_id}`, `PUT …/queue-paused` (a settings key,
   `code.sessions.{id}.queue_paused`), `POST …/queued/send-now`. The queued
   submit receipt returns the row.

--- a/docs/decisions/0074-agent-mcp-drives-code-mode.md
+++ b/docs/decisions/0074-agent-mcp-drives-code-mode.md
@@ -33,7 +33,7 @@ auto-approve the driven session's harness approvals.
 **2. The chat return contract extends with `queued`.**
 `code_run_turn`, `code_wait`, and `code_decide` return the chat shape
 `{status, assistant_text, pending?, events_cursor}` with one added status:
-`queued`. `POST /code/sessions/{id}/turns` waits for the worker to finish or
+`queued`. `POST /sessions/{id}/turns` waits for the worker to finish or
 to park the message (decision 69). A `SubmitTurnResponse::Queued` receipt
 returns immediately with the queue position and the turn id the promoted turn
 will run under. The caller re-checks with `code_wait`. `running` still means

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -159,7 +159,7 @@ Four more things are shared through it:
   not read this file: its REST validators are exercised against
   `generated/fixtures.ts` and the generated types.
 - **Code-mode fixtures.** The repo, workspace, session, turn, approval, and
-  delivery snapshots, the sequenced event frame, and the `/code/updates`
+  delivery snapshots, the sequenced event frame, and the `/updates`
   notices are re-exported from `tidebreak_server::wire` too, reject unknown
   keys, and are written to `crates/tidebreak-server-api/fixtures/code-frames.json`
   by `wire_code_fixtures` (a `CodeEvent` or `CodeUpdateNotice` variant without

--- a/mobile/app/sessions.tsx
+++ b/mobile/app/sessions.tsx
@@ -1,5 +1,6 @@
+import type { SessionDigest as CodeSessionDigest } from "../src/generated/wire";
 import { useRouter } from "expo-router";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -14,6 +15,7 @@ import {
   attentionBadgeLabel,
   harnessLabel,
   lifecycleLabel,
+  sessionRecoveryPresentation,
 } from "../src/lib/updates";
 import { useMachineClient } from "../src/session/useMachineClient";
 import { useHasSnapshot, useListedSessions } from "../src/session/updatesStore";
@@ -103,40 +105,9 @@ export default function SessionsScreen() {
             </Text>
           </View>
         ) : null}
-        {rows.map((row) => {
-          const badge = attentionBadgeLabel(row.attention);
-          return (
-            <Pressable
-              key={row.session}
-              className="rounded-xl border border-border bg-background p-4 gap-1"
-              onPress={() =>
-                router.push({
-                  pathname: "/session/[id]",
-                  params: {
-                    id: row.session,
-                    title: row.title,
-                    workspace: row.workspace,
-                  },
-                })
-              }
-            >
-              <View className="flex-row items-start justify-between gap-2">
-                <Text className="flex-1 text-base font-medium text-foreground">
-                  {row.title || "Untitled session"}
-                </Text>
-                {badge ? (
-                  <View className="rounded-full bg-warning px-2 py-0.5">
-                    <Text className="text-xs text-warning-foreground">{badge}</Text>
-                  </View>
-                ) : null}
-              </View>
-              <Text className="text-sm text-muted-foreground">{row.workspace}</Text>
-              <Text className="text-sm text-muted-foreground">
-                {harnessLabel(row.harness_kind)} · {lifecycleLabel(row.lifecycle)}
-              </Text>
-            </Pressable>
-          );
-        })}
+        {rows.map((row) => (
+          <SessionRow key={row.session} row={row} />
+        ))}
         <Pressable
           className="mt-2 rounded-lg border border-border bg-background px-4 py-3"
           onPress={() => router.push("/approvals")}
@@ -151,5 +122,43 @@ export default function SessionsScreen() {
         </Pressable>
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+function SessionRow({ row }: { row: CodeSessionDigest }) {
+  const router = useRouter();
+  const { recovering, prompt } = sessionRecoveryPresentation(row);
+  const [showRecovery, setShowRecovery] = useState(false);
+  useEffect(() => {
+    setShowRecovery(false);
+    if (!recovering) return;
+    const timer = setTimeout(() => setShowRecovery(true), 1500);
+    return () => clearTimeout(timer);
+  }, [recovering]);
+  const badge = prompt ?? attentionBadgeLabel(row.attention);
+  const status = recovering
+    ? showRecovery ? "Reconnecting…" : null
+    : row.lifecycle === "fenced" ? "Needs you" : lifecycleLabel(row.lifecycle);
+  return (
+    <Pressable
+      className="rounded-xl border border-border bg-background p-4 gap-1"
+      onPress={() => router.push({
+        pathname: "/session/[id]",
+        params: { id: row.session, title: row.title, workspace: row.workspace },
+      })}
+    >
+      <View className="flex-row items-start justify-between gap-2">
+        <Text className="flex-1 text-base font-medium text-foreground">{row.title || "Untitled session"}</Text>
+        {badge ? (
+          <View className="rounded-full bg-warning px-2 py-0.5">
+            <Text className="text-xs text-warning-foreground">{badge}</Text>
+          </View>
+        ) : null}
+      </View>
+      <Text className="text-sm text-muted-foreground">{row.workspace}</Text>
+      <Text className="text-sm text-muted-foreground">
+        {harnessLabel(row.harness_kind)}{status ? ` · ${status}` : ""}
+      </Text>
+    </Pressable>
   );
 }

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2298,15 +2298,7 @@ message: string,
 /**
  * Bounded remedy sentence for the person.
  */
-remediation: string, } | { "type": "attention_changed",
-/**
- * New state.
- */
-state: AttentionState,
-/**
- * Who or what set it.
- */
-source: AttentionSource, } | { "type": "stream_interrupted" } | { "type": "tool_args_delta",
+remediation: string, } | { "type": "stream_interrupted" } | { "type": "tool_args_delta",
 /**
  * The call these args belong to.
  */
@@ -4825,7 +4817,11 @@ can_open_chat?: boolean, session: SessionId, kind: SessionKind,
  * one workspace row. Optional on the wire so a desktop can still read a
  * digest from an older server during an update.
  */
-harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
+harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention,
+/**
+ * Recovery cause, independent of a manual attention pin.
+ */
+fence_reason?: FenceReason, title: string, turn_count: number,
 /**
  * Timestamp trigger delivery uses to rank candidate sessions: the newest
  * turn start, or session creation before the first turn. Optional so a
@@ -5708,7 +5704,7 @@ sessions: Array<SessionDigest>, } | { "type": "digest", workspace: WorkspaceId |
 /**
  * Engine identity for the session represented by this digest.
  */
-harness_kind?: HarnessKind, lifecycle: SessionLifecycle, attention: Attention, title: string, turn_count: number,
+harness_kind?: HarnessKind, lifecycle: SessionLifecycle, fence_reason?: FenceReason, attention: Attention, title: string, turn_count: number,
 /**
  * Timestamp trigger delivery uses to rank candidate sessions.
  */

--- a/mobile/src/lib/transcript.ts
+++ b/mobile/src/lib/transcript.ts
@@ -200,12 +200,6 @@ function applyEvent(
       };
     case "harness_notice":
       return appendStatus(state, `note:${state.lastSeq}`, event.message);
-    case "attention_changed":
-      return appendStatus(
-        state,
-        `att:${state.lastSeq}`,
-        `Attention: ${event.state.type}`,
-      );
     default:
       return state;
   }

--- a/mobile/src/lib/updates.test.ts
+++ b/mobile/src/lib/updates.test.ts
@@ -6,6 +6,7 @@ import type {
 import {
   EMPTY_UPDATES,
   attentionBadgeLabel,
+  sessionRecoveryPresentation,
   listedSessions,
   noticeToAction,
   reduceUpdates,
@@ -114,7 +115,7 @@ describe("reduceUpdates", () => {
 });
 
 describe("attentionBadgeLabel", () => {
-  it("shows needs-you, done, stalled, and fenced; hides working and idle", () => {
+  it("shows needs-you, done, and stalled; hides recovery, working, and idle", () => {
     expect(attentionBadgeLabel(need)).toBe("an approval is waiting");
     expect(attentionBadgeLabel(done)).toBe("Done");
     expect(
@@ -123,9 +124,17 @@ describe("attentionBadgeLabel", () => {
         source: "lifecycle",
       }),
     ).toBe("Stalled");
+    expect(attentionBadgeLabel({ state: { type: "fenced", reason: { type: "orphan_alive" } }, source: "lifecycle" })).toBeNull();
     expect(attentionBadgeLabel(working)).toBeNull();
     expect(
       attentionBadgeLabel({ state: { type: "idle" }, source: "lifecycle" }),
     ).toBeNull();
   });
+});
+
+it("shows a recovery blocker without losing the manual pin", () => {
+  const row = { ...digest(), lifecycle: "fenced" as const, attention: { state: { type: "manual" as const, note: "Review today" }, source: "user" as const }, fence_reason: { type: "probe_ambiguous" as const, detail: "Automatic recovery failed" } };
+  expect(sessionRecoveryPresentation(row)).toEqual({ recovering: false, prompt: "Automatic recovery failed" });
+  expect(row.attention.state.type).toBe("manual");
+  expect(noticeToAction({ type: "digest", ...row })).toMatchObject({ digest: { fence_reason: row.fence_reason } });
 });

--- a/mobile/src/lib/updates.ts
+++ b/mobile/src/lib/updates.ts
@@ -44,6 +44,7 @@ export function noticeToAction(
           : {}),
         lifecycle: notice.lifecycle,
         attention: notice.attention,
+        ...(notice.fence_reason ? { fence_reason: notice.fence_reason } : {}),
         title: notice.title,
         turn_count: notice.turn_count,
         ...(notice.activity !== undefined ? { activity: notice.activity } : {}),
@@ -135,7 +136,7 @@ export function listedSessions(state: UpdatesState): CodeSessionDigest[] {
 }
 
 /**
- * Badge when a human should look: waiting approval/question, stalled/fenced,
+ * Badge when a human should look: waiting approval/question, stalled,
  * or a finished turn that has not been reviewed.
  */
 export function attentionBadgeLabel(
@@ -148,7 +149,7 @@ export function attentionBadgeLabel(
     case "stalled":
       return "Stalled";
     case "fenced":
-      return "Fenced";
+      return null;
     case "done_unreviewed":
       return "Done";
     case "working":
@@ -167,7 +168,7 @@ export function lifecycleLabel(lifecycle: CodeSessionDigest["lifecycle"]): strin
     case "running":
       return "Running";
     case "fenced":
-      return "Fenced";
+      return "Reconnecting…";
     case "ended":
       return "Ended";
   }
@@ -201,4 +202,13 @@ export function isCodeUpdateNotice(value: unknown): value is CodeUpdateNotice {
     type === "harness_install" ||
     type === "delivery"
   );
+}
+
+export function sessionRecoveryPresentation(digest: CodeSessionDigest): { recovering: boolean; prompt: string | null } {
+  if (digest.lifecycle !== "fenced") return { recovering: false, prompt: null };
+  if (digest.attention.state.type === "needs_you") return { recovering: false, prompt: digest.attention.state.prompt };
+  const reason = digest.fence_reason ?? (digest.attention.state.type === "fenced" ? digest.attention.state.reason : undefined);
+  if (digest.fence_reason && (reason?.type === "orphan_alive" || reason?.type === "resume_lost" || reason?.type === "sandbox_lost")) return { recovering: true, prompt: null };
+  if (!digest.fence_reason && digest.attention.state.type === "fenced") return { recovering: false, prompt: "The engine connection stopped. Open this session on desktop to recover it." };
+  return { recovering: false, prompt: reason && "detail" in reason ? reason.detail : "This session needs your attention." };
 }

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -781,6 +781,9 @@ test("macOS CI exercises Seatbelt and the egress broker without signing setup", 
   assert.match(sandbox, /test -x \/usr\/bin\/sandbox-exec/);
   assert.match(sandbox, /\/usr\/bin\/sandbox-exec -p/);
   assert.match(sandbox, /\/usr\/bin\/python3 -c/);
+  assert.match(sandbox, /uses: actions\/setup-python@[a-f0-9]{40} # v6/);
+  assert.match(sandbox, /python-version: "3\.12\.11"/);
+  assert.match(sandbox, /python3 -I -c .*pip.*is_relative_to.*sys\.prefix/);
   for (const suite of ["local", "network", "sbpl"]) {
     assert.ok(
       sandbox.includes(`run: cargo test -p tidebreak-code-execution --locked --lib ${suite}::tests`),

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -518,6 +518,7 @@ test("PR lanes are scope-gated, never label-gated", () => {
     [workflowJob(ci, "desktop"), "rust"],
     [workflowJob(ci, "windows-check"), "rust"],
     [workflowJob(ci, "windows-native"), "windows_native"],
+    [workflowJob(ci, "macos-sandbox"), "workspace"],
     [testPartitions, "workspace"],
     [postgres, "workspace"],
     [workflowJob(ci, "ui"), "ui"],
@@ -772,6 +773,23 @@ test("UI tests and production build each gate the UI lane", () => {
   assert.doesNotMatch(ci, /matrix\.task/);
 });
 
+test("macOS CI exercises Seatbelt and the egress broker without signing setup", () => {
+  const sandbox = workflowJob(workflows["ci.yml"], "macos-sandbox");
+  assert.match(sandbox, /runs-on: macos-latest/);
+  assert.match(sandbox, /needs: changes/);
+  assert.match(sandbox, /TIDEBREAK_DEV_SIGNING_IDENTITY: ""/);
+  assert.match(sandbox, /test -x \/usr\/bin\/sandbox-exec/);
+  assert.match(sandbox, /\/usr\/bin\/sandbox-exec -p/);
+  assert.match(sandbox, /\/usr\/bin\/python3 -c/);
+  for (const suite of ["local", "network", "sbpl"]) {
+    assert.ok(
+      sandbox.includes(`run: cargo test -p tidebreak-code-execution --locked --lib ${suite}::tests`),
+      `macOS CI must run the ${suite} suite`,
+    );
+  }
+  assert.doesNotMatch(sandbox, /continue-on-error|--ignored|\|\| true/);
+});
+
 test("compiler caches use OIDC-scoped S3 access", () => {
   const ci = workflows["ci.yml"];
   const ciJobs = [
@@ -779,6 +797,7 @@ test("compiler caches use OIDC-scoped S3 access", () => {
     "desktop",
     "windows-check",
     "windows-native",
+    "macos-sandbox",
     "test",
     "postgres",
     "self-host-build",

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -782,7 +782,7 @@ test("macOS CI exercises Seatbelt and the egress broker without signing setup", 
   assert.match(sandbox, /\/usr\/bin\/sandbox-exec -p/);
   assert.match(sandbox, /\/usr\/bin\/python3 -c/);
   assert.match(sandbox, /uses: actions\/setup-python@[a-f0-9]{40} # v6/);
-  assert.match(sandbox, /python-version: "3\.12\.11"/);
+  assert.match(sandbox, /python-version: "3\.12\.10"/);
   assert.match(sandbox, /python3 -I -c .*pip.*is_relative_to.*sys\.prefix/);
   for (const suite of ["local", "network", "sbpl"]) {
     assert.ok(


### PR DESCRIPTION
## Changes

Interrupted engine connections recover automatically when Tidebreak can verify that recovery is safe. Brief recovery stays quiet; longer recovery shows “Reconnecting…”. If recovery cannot proceed, the conversation shows the cause and a retry action. Manual attention pins remain intact, and live recovery updates clear the blocked composer without a reload.

Recovery checks process identity, serializes worker replacement with session controls and turn admission, and limits automatic retries. It preserves the transcript, never replays interrupted input, and pauses queued messages for review. Remote recovery requires confirmed termination, saved final events, and the existing checkpoint and spend checks. Continuing without missing remote output requires explicit confirmation.

This batch also removes the unused `AttentionChanged` event and duplicate `/code/sessions*`, `/code/updates`, and `/code/approvals*` routes. It enables portable egress broker tests, adds a macOS sandbox CI lane, and fixes malformed Python fixtures exposed by running the native sandbox suite. The lane uses a pinned Python installation with pip inside its runtime prefix. Python fixtures use the configured supported interpreter instead of assuming Apple’s launcher works with every Xcode layout. Trusted Xcode directory comparisons also resolve configured aliases before checking the allowed locations.

## Compatibility and risk

The internal `Fenced` lifecycle and explicit recovery API remain available. Session digests and live notices add an optional `fence_reason`; no database migration is required. Shipping clients already use the canonical unprefixed routes, and the removed attention event had no production writer. External session and workspace routes retain their paths.

Worker recovery is the main behavioral risk. Regression coverage checks duplicate recovery, failed shutdown and launch, process ownership, paused queues, lost context, manual pins, and remote recovery limits. The Xcode fix resolves the same trusted locations and retains the existing confinement rules. Application dependency versions remain unchanged.

## Validation

- 288 server API tests and 24 wire contract tests pass.
- 13 automatic recovery tests, 17 existing recovery tests, one startup recovery test, and the gated remote admission regression pass.
- The desktop suite passes 2,581 tests. A focused suite passes 20 tests after workspace-less recovery changes; 21 focused tests pass after adding selected-session isolation coverage. Desktop/mobile TypeScript and desktop lint pass.
- Native macOS execution passes 37 local sandbox tests, 10 egress broker tests, and five SBPL tests. Workflow policy passes 51 tests; actionlint is clean.
- Storybook builds. All five changed stories are captured and inspected at desktop/narrow widths across four theme globals, plus four missing-output confirmation captures. The existing preview maps high-contrast globals to ordinary light/dark.
- Strict clippy passes for the server core and remote driver; all 24 remote service tests pass. Rust formatting and diff checks pass. The full hosted cross-platform checks run on this PR.

Closes #3330
Closes #3332
Closes #3337
