### PR TITLE
feat(slack): recover unconfirmed steering deliveries

### DIFF
--- a/crates/tidebreak-core/src/code/mod.rs
+++ b/crates/tidebreak-core/src/code/mod.rs
@@ -2217,6 +2217,48 @@ impl ExternalSteerAdmission {
     }
 }
 
+/// The explicit recovery chosen for an instruction whose delivery is unknown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalSteerRecoveryAction {
+    /// Remove the held message without undoing any native execution.
+    Discard,
+    /// Queue another copy after accepting that the original may already have run.
+    Retry,
+}
+
+impl ExternalSteerRecoveryAction {
+    /// Stable database token.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Discard => "discard",
+            Self::Retry => "retry",
+        }
+    }
+
+    /// Parse a stored recovery action.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "discard" => Some(Self::Discard),
+            "retry" => Some(Self::Retry),
+            _ => None,
+        }
+    }
+}
+
+/// An immutable recovery decision, separate from the original native admission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalSteerRecovery {
+    /// The action explicitly chosen for the unconfirmed instruction.
+    pub action: ExternalSteerRecoveryAction,
+    /// A fresh ordinary queue row created by retry; never the original receipt ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_turn_id: Option<TurnId>,
+    /// When the recovery transaction committed its decision.
+    pub recovered_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// A bounded reason attached to a queued steering admission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/tidebreak-core/src/db/entities.rs
+++ b/crates/tidebreak-core/src/db/entities.rs
@@ -1756,6 +1756,9 @@ pub mod code_external_event {
         pub outcome: Option<String>,
         pub outcome_reason: Option<String>,
         pub outcome_at: Option<DateTimeUtc>,
+        pub recovery_action: Option<String>,
+        pub recovery_retry_turn_id: Option<Uuid>,
+        pub recovered_at: Option<DateTimeUtc>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tidebreak-core/src/db/migration.rs
+++ b/crates/tidebreak-core/src/db/migration.rs
@@ -27,6 +27,7 @@ mod baseline;
 mod channel_repository_confirm;
 mod code_conversation_request;
 mod external_steer_admission;
+mod external_steer_recovery;
 mod external_thread_context;
 mod grant_kind;
 mod idens;
@@ -111,6 +112,7 @@ impl MigratorTrait for Migrator {
             Box::new(native_tool_receipt::NativeToolClaimTime),
             Box::new(workspace_setup_error::WorkspaceSetupError),
             Box::new(external_steer_admission::ExternalSteerAdmission),
+            Box::new(external_steer_recovery::ExternalSteerRecovery),
         ]
     }
 }

--- a/crates/tidebreak-core/src/db/migration/external_steer_recovery.rs
+++ b/crates/tidebreak-core/src/db/migration/external_steer_recovery.rs
@@ -1,0 +1,55 @@
+//! Explicit recovery decisions remain separate from native steering admission.
+use sea_orm_migration::prelude::*;
+
+use super::idens::CodeExternalEvent;
+
+pub(super) struct ExternalSteerRecovery;
+
+impl MigrationName for ExternalSteerRecovery {
+    fn name(&self) -> &str {
+        "m20260911_000002_external_steer_recovery"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for ExternalSteerRecovery {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for column in [
+            CodeExternalEvent::RecoveryAction,
+            CodeExternalEvent::RecoveryRetryTurnId,
+            CodeExternalEvent::RecoveredAt,
+        ] {
+            let name = column.to_string();
+            if manager.has_column("code_external_event", &name).await? {
+                continue;
+            }
+            let mut definition = ColumnDef::new(column);
+            match name.as_str() {
+                "recovery_action" => {
+                    definition.text();
+                }
+                "recovery_retry_turn_id" => {
+                    definition.uuid();
+                }
+                "recovered_at" => {
+                    definition.timestamp_with_time_zone();
+                }
+                _ => unreachable!("all recovery columns are handled"),
+            }
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(CodeExternalEvent::Table)
+                        .add_column_if_not_exists(definition)
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Retain recovery records so rolling back cannot create another retry.
+        Ok(())
+    }
+}

--- a/crates/tidebreak-core/src/db/migration/idens.rs
+++ b/crates/tidebreak-core/src/db/migration/idens.rs
@@ -1181,6 +1181,9 @@ pub(crate) enum CodeExternalEvent {
     Outcome,
     OutcomeReason,
     OutcomeAt,
+    RecoveryAction,
+    RecoveryRetryTurnId,
+    RecoveredAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/tidebreak-core/src/db/migration/tests.rs
+++ b/crates/tidebreak-core/src/db/migration/tests.rs
@@ -103,6 +103,7 @@ async fn a_fresh_database_records_the_whole_chain() {
             "m20260910_000026_native_tool_claim_time",
             "m20260910_000027_workspace_setup_error",
             "m20260911_000001_external_steer_admission",
+            "m20260911_000002_external_steer_recovery",
         ]
     );
     assert!(db
@@ -2155,4 +2156,28 @@ async fn the_condition_widening_keeps_trigger_and_fire_rows() {
         )
         .await
         .is_err());
+}
+
+#[tokio::test]
+async fn steer_recovery_migration_preserves_admission() {
+    let db = Database::connect("sqlite::memory:").await.unwrap();
+    Migrator::up(
+        &db,
+        Some(steps_before("m20260911_000002_external_steer_recovery")),
+    )
+    .await
+    .unwrap();
+    db.execute_unprepared("PRAGMA foreign_keys = OFF")
+        .await
+        .unwrap();
+    db.execute_unprepared("INSERT INTO code_external_event (id, owner, session_id, event_id, channel_ts, turn_id, created_at, steer_requested, outcome) VALUES ('00000000-0000-0000-0000-000000000001', 'local', '00000000-0000-0000-0000-000000000002', 'upgrade', '1.1', '00000000-0000-0000-0000-000000000003', '2026-09-11 00:00:00+00:00', 1, 'steered')").await.unwrap();
+    Migrator::up(&db, None).await.unwrap();
+    let row = db.query_one_raw(Statement::from_string(DbBackend::Sqlite, "SELECT outcome, recovery_action, recovery_retry_turn_id, recovered_at FROM code_external_event WHERE event_id = 'upgrade'".to_owned())).await.unwrap().unwrap();
+    assert_eq!(row.try_get::<String>("", "outcome").unwrap(), "steered");
+    for field in ["recovery_action", "recovery_retry_turn_id", "recovered_at"] {
+        assert!(row.try_get::<Option<String>>("", field).unwrap().is_none());
+    }
+    let fresh = Database::connect("sqlite::memory:").await.unwrap();
+    Migrator::up(&fresh, None).await.unwrap();
+    assert_eq!(schema_of(&db).await, schema_of(&fresh).await);
 }

--- a/crates/tidebreak-core/src/db/ops/code/external_event.rs
+++ b/crates/tidebreak-core/src/db/ops/code/external_event.rs
@@ -951,7 +951,7 @@ pub async fn recover_external_steer(
         return Err(ExternalSteerRecoveryError::AdmissionResolved);
     }
     let now = database_now(&transaction).await?;
-    let retry_turn_id = if action == ExternalSteerRecoveryAction::Retry {
+    let original = if action == ExternalSteerRecoveryAction::Retry {
         let session = entities::session::Entity::find_by_id(session_id.0)
             .one(&transaction)
             .await
@@ -967,6 +967,18 @@ pub async fn recover_external_steer(
             .await
             .map_err(store_err)?
             .ok_or(ExternalSteerRecoveryError::OriginalMissing)?;
+        Some(original)
+    } else {
+        None
+    };
+    entities::code_queued_turn::Entity::delete_many()
+        .filter(entities::code_queued_turn::Column::Id.eq(event.turn_id))
+        .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    let retry_turn_id = if let Some(original) = original {
         let tail = entities::code_queued_turn::Entity::find()
             .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
             .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
@@ -1000,13 +1012,6 @@ pub async fn recover_external_steer(
     } else {
         None
     };
-    entities::code_queued_turn::Entity::delete_many()
-        .filter(entities::code_queued_turn::Column::Id.eq(event.turn_id))
-        .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
-        .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
-        .exec(&transaction)
-        .await
-        .map_err(store_err)?;
     entities::code_external_event::ActiveModel {
         id: Set(event.id),
         recovery_action: Set(Some(action.as_str().into())),

--- a/crates/tidebreak-core/src/db/ops/code/external_event.rs
+++ b/crates/tidebreak-core/src/db/ops/code/external_event.rs
@@ -355,6 +355,9 @@ pub async fn record_external_message_with_steer(
         outcome: Set(None),
         outcome_reason: Set(None),
         outcome_at: Set(None),
+        recovery_action: Set(None),
+        recovery_retry_turn_id: Set(None),
+        recovered_at: Set(None),
     }
     .insert(&transaction)
     .await;
@@ -844,4 +847,180 @@ pub async fn external_steer_target_by_correlation(
         native_turn,
         runtime_id,
     }))
+}
+
+/// A recovery request could not safely change an unconfirmed admission.
+#[derive(Debug, thiserror::Error)]
+pub enum ExternalSteerRecoveryError {
+    #[error("steering admission not found")]
+    NotFound,
+    #[error("The native admission already resolved. Refresh its status before recovering.")]
+    AdmissionResolved,
+    #[error("This admission already has a different recovery decision.")]
+    ConflictingAction,
+    #[error(
+        "Accept that the original instruction may already have run before queuing another copy."
+    )]
+    DuplicateRiskNotAccepted,
+    #[error("The original held message is no longer available to retry.")]
+    OriginalMissing,
+    #[error("The session ended and cannot accept another copy.")]
+    SessionEnded,
+    #[error(transparent)]
+    Store(#[from] AgentError),
+}
+
+fn recovery_from_event(
+    event: &entities::code_external_event::Model,
+) -> Result<Option<crate::code::ExternalSteerRecovery>> {
+    use crate::code::{ExternalSteerRecovery, ExternalSteerRecoveryAction};
+    let Some(action) = event.recovery_action.as_deref() else {
+        return Ok(None);
+    };
+    let action = ExternalSteerRecoveryAction::from_str(action)
+        .ok_or_else(|| AgentError::Store("invalid stored steering recovery action".into()))?;
+    let recovered_at = event
+        .recovered_at
+        .ok_or_else(|| AgentError::Store("steering recovery has no timestamp".into()))?;
+    if (action == ExternalSteerRecoveryAction::Retry) != event.recovery_retry_turn_id.is_some() {
+        return Err(AgentError::Store(
+            "steering recovery has an invalid retry identity".into(),
+        ));
+    }
+    Ok(Some(ExternalSteerRecovery {
+        action,
+        retry_turn_id: event.recovery_retry_turn_id.map(TurnId),
+        recovered_at,
+    }))
+}
+
+/// Read the immutable recovery decision under the event's owner and session.
+pub async fn external_steer_recovery(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event_id: &str,
+) -> Result<Option<crate::code::ExternalSteerRecovery>> {
+    let Some(event) = find_event_on(&store.conn, owner, session_id, event_id).await? else {
+        return Ok(None);
+    };
+    recovery_from_event(&event)
+}
+
+/// Recover one unresolved admission without claiming anything about native execution.
+/// The original receipt is the idempotency key; its decision never changes.
+pub async fn recover_external_steer(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+    event_id: &str,
+    action: crate::code::ExternalSteerRecoveryAction,
+    accept_duplicate_risk: bool,
+) -> std::result::Result<crate::code::ExternalSteerRecovery, ExternalSteerRecoveryError> {
+    use crate::code::{ExternalSteerRecovery, ExternalSteerRecoveryAction, SessionLifecycle};
+    if action == ExternalSteerRecoveryAction::Retry && !accept_duplicate_risk {
+        return Err(ExternalSteerRecoveryError::DuplicateRiskNotAccepted);
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    // The same owner-scoped session lock serializes recovery with native settlement.
+    let locked = entities::session::Entity::update_many()
+        .col_expr(
+            entities::session::Column::UnrecognizedEventCount,
+            sea_orm::sea_query::Expr::col(entities::session::Column::UnrecognizedEventCount),
+        )
+        .filter(entities::session::Column::Id.eq(session_id.0))
+        .filter(entities::session::Column::Owner.eq(owner.as_str()))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if locked.rows_affected != 1 {
+        return Err(ExternalSteerRecoveryError::NotFound);
+    }
+    let event = find_event_on(&transaction, owner, session_id, event_id)
+        .await?
+        .filter(|event| event.steer_requested)
+        .ok_or(ExternalSteerRecoveryError::NotFound)?;
+    if let Some(recovery) = recovery_from_event(&event)? {
+        if recovery.action != action {
+            return Err(ExternalSteerRecoveryError::ConflictingAction);
+        }
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(recovery);
+    }
+    if event.outcome.is_some() {
+        return Err(ExternalSteerRecoveryError::AdmissionResolved);
+    }
+    let now = database_now(&transaction).await?;
+    let retry_turn_id = if action == ExternalSteerRecoveryAction::Retry {
+        let session = entities::session::Entity::find_by_id(session_id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or(ExternalSteerRecoveryError::NotFound)?;
+        if session.lifecycle == SessionLifecycle::Ended.as_str() {
+            return Err(ExternalSteerRecoveryError::SessionEnded);
+        }
+        let original = entities::code_queued_turn::Entity::find_by_id(event.turn_id)
+            .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+            .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or(ExternalSteerRecoveryError::OriginalMissing)?;
+        let tail = entities::code_queued_turn::Entity::find()
+            .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+            .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+            .order_by_desc(entities::code_queued_turn::Column::Position)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        let position = tail
+            .map_or(Some(0), |row| row.position.checked_add(1))
+            .ok_or_else(|| AgentError::Store("the queue position limit was reached".into()))?;
+        let id = TurnId::new();
+        entities::code_queued_turn::ActiveModel {
+            id: Set(id.0),
+            owner: Set(owner.as_str().to_owned()),
+            session_id: Set(session_id.0),
+            message: Set(original.message),
+            attachments_json: Set(original.attachments_json),
+            file_attachments_json: Set(original.file_attachments_json),
+            invoked_skills_json: Set(original.invoked_skills_json),
+            voice_input_used: Set(original.voice_input_used),
+            fingerprint: Set(None),
+            actor: Set(original.actor),
+            position: Set(position),
+            created_at: Set(now),
+            updated_at: Set(now),
+        }
+        .insert(&transaction)
+        .await
+        .map_err(store_err)?;
+        Some(id)
+    } else {
+        None
+    };
+    entities::code_queued_turn::Entity::delete_many()
+        .filter(entities::code_queued_turn::Column::Id.eq(event.turn_id))
+        .filter(entities::code_queued_turn::Column::Owner.eq(owner.as_str()))
+        .filter(entities::code_queued_turn::Column::SessionId.eq(session_id.0))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    entities::code_external_event::ActiveModel {
+        id: Set(event.id),
+        recovery_action: Set(Some(action.as_str().into())),
+        recovery_retry_turn_id: Set(retry_turn_id.map(|id| id.0)),
+        recovered_at: Set(Some(now)),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(ExternalSteerRecovery {
+        action,
+        retry_turn_id,
+        recovered_at: now,
+    })
 }

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -8848,7 +8848,7 @@ async fn steer_recovery_delete_failure_rolls_back_without_poisoning_receipt() {
     assert_eq!(
         rows.len(),
         1,
-        "the replacement insert rolls back with the failed delete"
+        "a failed delete leaves only the original row"
     );
     assert_eq!(rows[0].id, original.id);
     assert!(

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -8500,3 +8500,327 @@ async fn sandbox_steer_refusal_and_deleted_input_do_not_create_transcript_text()
         .events
         .is_empty());
 }
+
+#[tokio::test]
+async fn steer_recovery_retry_is_immutable_and_survives_late_ack() {
+    use crate::code::{ExternalSteerAdmission, ExternalSteerRecoveryAction as Action};
+    use crate::db::code::{recover_external_steer, ExternalSteerRecoveryError as Error};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "recovery-retry").await;
+    let (original, expected, _) = record_pending_steer(&store, &owner, session, "retry").await;
+    assert!(matches!(
+        recover_external_steer(&store, &owner, session, "retry", Action::Retry, false).await,
+        Err(Error::DuplicateRiskNotAccepted)
+    ));
+    let result = recover_external_steer(&store, &owner, session, "retry", Action::Retry, true)
+        .await
+        .unwrap();
+    let retry = result.retry_turn_id.unwrap();
+    assert_ne!(retry, original.id);
+    let rows = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, retry);
+    assert_eq!(rows[0].message, original.message);
+    assert_eq!(rows[0].actor, original.actor);
+    assert_eq!(rows[0].attachments, original.attachments);
+    let replay = recover_external_steer(&store, &owner, session, "retry", Action::Retry, true)
+        .await
+        .unwrap();
+    assert_eq!(result, replay);
+    assert!(matches!(
+        recover_external_steer(&store, &owner, session, "retry", Action::Discard, false).await,
+        Err(Error::ConflictingAction)
+    ));
+    update_queued_turn(&store, &owner, session, retry, Some("edited retry"), None)
+        .await
+        .unwrap();
+    assert!(crate::db::code::settle_external_steer_admission(
+        &store,
+        &owner,
+        session,
+        "retry",
+        expected,
+        ExternalSteerAdmission::Steered,
+        None
+    )
+    .await
+    .unwrap());
+    let row = queued_turn_head(&store, &owner, session)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.id, retry);
+    assert_eq!(row.message, "edited retry");
+    assert!(
+        promote_queued_turn(&store, &owner, &row, &turn_for(&row, 1))
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        recover_external_steer(&store, &owner, session, "retry", Action::Retry, true)
+            .await
+            .unwrap(),
+        result
+    );
+    assert!(list_queued_turns(&store, &owner, session)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn steer_recovery_discard_is_scoped_and_releases_tail() {
+    use crate::code::ExternalSteerRecoveryAction as Action;
+    use crate::db::code::{
+        external_steer_recovery, recover_external_steer, ExternalSteerRecoveryError as Error,
+    };
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let other = OwnerId::new("foreign").unwrap();
+    let session = seed_external_session(&store, &owner, "recovery-discard").await;
+    let unrelated = seed_external_session(&store, &owner, "recovery-unrelated").await;
+    record_pending_steer(&store, &owner, session, "discard").await;
+    let tail = enqueue_queued_turn(&store, &owner, &queued_message(session, "later"))
+        .await
+        .unwrap();
+    for (who, id) in [(&other, session), (&owner, unrelated)] {
+        assert!(matches!(
+            recover_external_steer(&store, who, id, "discard", Action::Discard, false).await,
+            Err(Error::NotFound)
+        ));
+        assert!(external_steer_recovery(&store, who, id, "discard")
+            .await
+            .unwrap()
+            .is_none());
+    }
+    let result = recover_external_steer(&store, &owner, session, "discard", Action::Discard, false)
+        .await
+        .unwrap();
+    assert!(result.retry_turn_id.is_none());
+    assert_eq!(
+        queued_turn_head(&store, &owner, session)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        tail.id
+    );
+    assert_eq!(
+        recover_external_steer(&store, &owner, session, "discard", Action::Discard, false)
+            .await
+            .unwrap(),
+        result
+    );
+    let (missing, _, _) = record_pending_steer(&store, &owner, session, "missing").await;
+    delete_queued_turn(&store, &owner, session, missing.id)
+        .await
+        .unwrap();
+    assert!(matches!(
+        recover_external_steer(&store, &owner, session, "missing", Action::Retry, true).await,
+        Err(Error::OriginalMissing)
+    ));
+    recover_external_steer(&store, &owner, session, "missing", Action::Discard, false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn steer_recovery_ack_first_rejects_and_concurrent_ack_is_safe() {
+    use crate::code::{ExternalSteerAdmission, ExternalSteerRecoveryAction as Action};
+    use crate::db::code::{
+        recover_external_steer, settle_external_steer_admission,
+        ExternalSteerRecoveryError as Error,
+    };
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "recovery-race").await;
+    let (_, expected, _) = record_pending_steer(&store, &owner, session, "ack-first").await;
+    settle_external_steer_admission(
+        &store,
+        &owner,
+        session,
+        "ack-first",
+        expected,
+        ExternalSteerAdmission::Steered,
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        recover_external_steer(&store, &owner, session, "ack-first", Action::Retry, true).await,
+        Err(Error::AdmissionResolved)
+    ));
+    let (_, expected, _) = record_pending_steer(&store, &owner, session, "race").await;
+    let (ack, recovery) = tokio::join!(
+        settle_external_steer_admission(
+            &store,
+            &owner,
+            session,
+            "race",
+            expected,
+            ExternalSteerAdmission::Steered,
+            None
+        ),
+        recover_external_steer(&store, &owner, session, "race", Action::Retry, true)
+    );
+    assert!(ack.unwrap());
+    let rows = list_queued_turns(&store, &owner, session).await.unwrap();
+    match recovery {
+        Ok(result) => {
+            assert_eq!(rows.len(), 1);
+            assert_eq!(Some(rows[0].id), result.retry_turn_id);
+        }
+        Err(Error::AdmissionResolved) => assert!(rows.is_empty()),
+        other => panic!("unexpected race result: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn steer_recovery_receipt_failure_rolls_back_retry_and_delete() {
+    use crate::code::ExternalSteerRecoveryAction as Action;
+    use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "recovery-rollback").await;
+    let (original, _, _) = record_pending_steer(&store, &owner, session, "rollback").await;
+    store.conn.execute_raw(Statement::from_string(DatabaseBackend::Sqlite,
+        "CREATE TRIGGER fail_recovery BEFORE UPDATE OF recovery_action ON code_external_event BEGIN SELECT RAISE(ABORT, 'injected recovery failure'); END;".to_owned())).await.unwrap();
+    assert!(crate::db::code::recover_external_steer(
+        &store,
+        &owner,
+        session,
+        "rollback",
+        Action::Retry,
+        true
+    )
+    .await
+    .is_err());
+    let rows = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, original.id);
+    assert!(
+        crate::db::code::external_steer_recovery(&store, &owner, session, "rollback")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn steer_recovery_ended_session_refuses_retry_but_allows_discard() {
+    use crate::code::{ExternalSteerRecoveryAction as Action, SessionLifecycle};
+    use crate::db::code::{recover_external_steer, ExternalSteerRecoveryError as Error};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "recovery-ended").await;
+    record_pending_steer(&store, &owner, session, "ended").await;
+    let mut stored = crate::db::code::get_session(&store, &owner, session)
+        .await
+        .unwrap()
+        .unwrap();
+    stored.lifecycle = SessionLifecycle::Ended;
+    assert!(save_session(&store, &stored).await.unwrap());
+    assert!(matches!(
+        recover_external_steer(&store, &owner, session, "ended", Action::Retry, true).await,
+        Err(Error::SessionEnded)
+    ));
+    recover_external_steer(&store, &owner, session, "ended", Action::Discard, false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn steer_recovery_late_sandbox_ack_preserves_edited_retry() {
+    use crate::code::{ExternalSteerAdmission, ExternalSteerRecoveryAction as Action};
+    use crate::db::code::{recover_external_steer, settle_sandbox_external_steer_admission};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "recovery-native-late").await;
+    let target = pending_sandbox_steer(&store, &owner, session, "native-late").await;
+    let result =
+        recover_external_steer(&store, &owner, session, "native-late", Action::Retry, true)
+            .await
+            .unwrap();
+    let retry = result.retry_turn_id.unwrap();
+    update_queued_turn(
+        &store,
+        &owner,
+        session,
+        retry,
+        Some("edited after recovery"),
+        None,
+    )
+    .await
+    .unwrap();
+    for _ in 0..2 {
+        let (settled, event) = settle_sandbox_external_steer_admission(
+            &store,
+            &owner,
+            session,
+            &target,
+            ExternalSteerAdmission::Steered,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(settled);
+        assert!(
+            event.is_none(),
+            "late acknowledgment cannot journal the new copy as original text"
+        );
+    }
+    let rows = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, retry);
+    assert_eq!(rows[0].message, "edited after recovery");
+}
+
+#[tokio::test]
+async fn steer_recovery_late_machine_ack_preserves_edited_retry() {
+    use crate::code::ExternalSteerRecoveryAction as Action;
+    use crate::db::code::{recover_external_steer, settle_machine_external_steer_ack};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "recovery-machine-late").await;
+    let (row, expected, correlation) =
+        record_pending_steer(&store, &owner, session, "machine-late").await;
+    let mut running = get_session(&store, &owner, session).await.unwrap().unwrap();
+    running.lifecycle = SessionLifecycle::Running;
+    assert!(save_session(&store, &running).await.unwrap());
+    let mut turn = turn_for(&row, 1);
+    turn.id = expected;
+    turn.status = TurnStatus::Running;
+    insert_turn(&store, &owner, &turn).await.unwrap();
+    let decision =
+        recover_external_steer(&store, &owner, session, "machine-late", Action::Retry, true)
+            .await
+            .unwrap();
+    let retry = decision.retry_turn_id.unwrap();
+    update_queued_turn(
+        &store,
+        &owner,
+        session,
+        retry,
+        Some("edited machine retry"),
+        None,
+    )
+    .await
+    .unwrap();
+    for _ in 0..2 {
+        assert!(settle_machine_external_steer_ack(
+            &store,
+            &owner,
+            session,
+            running.spawn_epoch,
+            expected,
+            correlation
+        )
+        .await
+        .unwrap());
+    }
+    let rows = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, retry);
+    assert_eq!(rows[0].message, "edited machine retry");
+}

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -8824,3 +8824,69 @@ async fn steer_recovery_late_machine_ack_preserves_edited_retry() {
     assert_eq!(rows[0].id, retry);
     assert_eq!(rows[0].message, "edited machine retry");
 }
+
+#[tokio::test]
+async fn steer_recovery_delete_failure_rolls_back_without_poisoning_receipt() {
+    use crate::code::ExternalSteerRecoveryAction as Action;
+    use crate::db::code::{external_steer_recovery, recover_external_steer};
+    let (_dir, store) = temp_store().await;
+    let owner = OwnerId::local();
+    let session = seed_external_session(&store, &owner, "recovery-delete-rollback").await;
+    let (original, _, _) = record_pending_steer(&store, &owner, session, "delete-rollback").await;
+    store.conn.execute_unprepared("CREATE TRIGGER fail_recovery_delete BEFORE DELETE ON code_queued_turn BEGIN SELECT RAISE(ABORT, 'injected delete failure'); END;").await.unwrap();
+    assert!(recover_external_steer(
+        &store,
+        &owner,
+        session,
+        "delete-rollback",
+        Action::Retry,
+        true
+    )
+    .await
+    .is_err());
+    let rows = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "the replacement insert rolls back with the failed delete"
+    );
+    assert_eq!(rows[0].id, original.id);
+    assert!(
+        external_steer_recovery(&store, &owner, session, "delete-rollback")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    store
+        .conn
+        .execute_unprepared("DROP TRIGGER fail_recovery_delete")
+        .await
+        .unwrap();
+    let decision = recover_external_steer(
+        &store,
+        &owner,
+        session,
+        "delete-rollback",
+        Action::Retry,
+        true,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        recover_external_steer(
+            &store,
+            &owner,
+            session,
+            "delete-rollback",
+            Action::Retry,
+            true
+        )
+        .await
+        .unwrap(),
+        decision
+    );
+    let rows = list_queued_turns(&store, &owner, session).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(Some(rows[0].id), decision.retry_turn_id);
+    assert_ne!(rows[0].id, original.id);
+}

--- a/crates/tidebreak-server-api/src/lib.rs
+++ b/crates/tidebreak-server-api/src/lib.rs
@@ -516,6 +516,10 @@ pub fn app(state: AppState) -> Router {
             get(routes::code::external_steer_receipt),
         )
         .route(
+            "/external/code/sessions/{id}/messages/{event_id}/recovery",
+            post(routes::code::external_recover_steer),
+        )
+        .route(
             "/external/code/sessions/{id}/conversation-requests",
             get(routes::code::external_conversation_requests),
         )

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -908,6 +908,8 @@ pub struct ExternalSteerReceiptResponse {
     pub expected_turn_id: tidebreak_core::TurnId,
     pub correlation_uuid: Option<uuid::Uuid>,
     pub reason: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<tidebreak_core::code::ExternalSteerRecovery>,
 }
 
 /// Read admission without submitting another message or contacting the harness.
@@ -950,7 +952,43 @@ pub async fn external_steer_receipt(
         expected_turn_id,
         correlation_uuid,
         reason,
+        recovery: tidebreak_core::db::code::external_steer_recovery(
+            &runtime.db,
+            &grant.owner,
+            id,
+            &event_id,
+        )
+        .await?,
     }))
+}
+
+/// An explicit decision about an instruction whose native delivery is unknown.
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExternalSteerRecoveryBody {
+    pub action: tidebreak_core::code::ExternalSteerRecoveryAction,
+    #[serde(default)]
+    pub accept_duplicate_risk: bool,
+}
+
+/// Record recovery once. Retrying uses a fresh ordinary queue row.
+pub async fn external_recover_steer(
+    State(state): State<AppState>,
+    ExternalGrantAuth(grant): ExternalGrantAuth,
+    Path((id, event_id)): Path<(SessionId, String)>,
+    Json(body): Json<ExternalSteerRecoveryBody>,
+) -> Result<Json<tidebreak_core::code::ExternalSteerRecovery>, ServerError> {
+    let runtime = require_bound(&state, &grant, id).await?;
+    let recovery = runtime
+        .recover_external_steer(
+            &grant.owner,
+            id,
+            &event_id,
+            body.action,
+            body.accept_duplicate_risk,
+        )
+        .await?;
+    Ok(Json(recovery))
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/tidebreak-server-api/src/routes/code/mod.rs
+++ b/crates/tidebreak-server-api/src/routes/code/mod.rs
@@ -67,8 +67,8 @@ pub(crate) use delivery::{
 pub(crate) use external::{
     external_approval, external_approval_decision, external_attach_binding, external_bindings,
     external_events, external_get_or_create, external_interrupt, external_messages,
-    external_plan_decision, external_question_decision, external_reap, external_rotate,
-    external_session_access, external_steer_receipt,
+    external_plan_decision, external_question_decision, external_reap, external_recover_steer,
+    external_rotate, external_session_access, external_steer_receipt,
 };
 pub(crate) use git::{
     commit_workspace, create_pull_request, get_workspace_pr, get_workspace_pr_comments,

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -5091,3 +5091,198 @@ async fn steering_receipt_reads_are_scoped_and_never_resend() {
         reqwest::StatusCode::UNAUTHORIZED
     );
 }
+
+#[tokio::test]
+async fn steering_recovery_requires_binding_and_preserves_receipt() {
+    let (router, fake, runtime, repo_id, _dir) = external_app().await;
+    let addr = serve(router).await;
+    let client = reqwest::Client::new();
+    let owner = OwnerId::local();
+    let (grant, pair) = runtime
+        .mint_adapter_grant(&owner, "slack", "U1", "T1")
+        .await
+        .unwrap();
+    let (_, foreign) = runtime
+        .mint_adapter_grant(&owner, "slack", "U2", "T1")
+        .await
+        .unwrap();
+    client
+        .post(format!("http://{addr}/external/code/sessions"))
+        .bearer_auth(&pair.token)
+        .json(&serde_json::json!({"external_key":"T1/C1/recovery", "repo_id":repo_id}))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    let session = bound_session_id(&runtime, &owner, "T1/C1/recovery").await;
+    runtime
+        .set_queue_paused(&owner, session, true)
+        .await
+        .unwrap();
+    let target = tidebreak_core::TurnId::new();
+    tidebreak_core::db::code::record_external_message_with_steer(
+        &runtime.db,
+        &owner,
+        session,
+        "Ev-recovery",
+        "1.1",
+        "follow up",
+        &Default::default(),
+        None,
+        tidebreak_core::db::code::ExternalSteerAdmissionInput {
+            request_steer: true,
+            expected_turn_id: Some(target),
+            correlation_uuid: Some(uuid::Uuid::new_v4()),
+        },
+    )
+    .await
+    .unwrap();
+    let base = format!("http://{addr}/external/code/sessions/{session}/messages/Ev-recovery");
+    let url = format!("{base}/recovery");
+    let retry = serde_json::json!({"action":"retry", "accept_duplicate_risk":true});
+    assert_eq!(
+        client
+            .post(&url)
+            .json(&retry)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(
+        client
+            .post(&url)
+            .bearer_auth(&foreign.token)
+            .json(&retry)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        client
+            .post(&url)
+            .bearer_auth(&pair.token)
+            .json(&serde_json::json!({"action":"retry"}))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        client
+            .post(&url)
+            .bearer_auth(&pair.token)
+            .json(&serde_json::json!({"action":"invalid"}))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+    let first: serde_json::Value = client
+        .post(&url)
+        .bearer_auth(&pair.token)
+        .json(&retry)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let replay: serde_json::Value = client
+        .post(&url)
+        .bearer_auth(&pair.token)
+        .json(&retry)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(first, replay);
+    assert_eq!(first["action"], "retry");
+    assert!(first["retry_turn_id"].is_string());
+    assert!(first["recovered_at"].is_string());
+    assert_eq!(
+        client
+            .post(&url)
+            .bearer_auth(&pair.token)
+            .json(&serde_json::json!({"action":"discard"}))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::CONFLICT
+    );
+    let receipt: serde_json::Value = client
+        .get(format!("{base}/admission"))
+        .bearer_auth(&pair.token)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(receipt["outcome"], "pending");
+    assert_eq!(receipt["recovery"], first);
+    tidebreak_core::db::code::settle_external_steer_admission(
+        &runtime.db,
+        &owner,
+        session,
+        "Ev-recovery",
+        target,
+        tidebreak_core::code::ExternalSteerAdmission::Steered,
+        None,
+    )
+    .await
+    .unwrap();
+    let settled: serde_json::Value = client
+        .get(format!("{base}/admission"))
+        .bearer_auth(&pair.token)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(settled["outcome"], "steered");
+    assert_eq!(settled["recovery"], first);
+    let rows = tidebreak_core::db::code::list_queued_turns(&runtime.db, &owner, session)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].id.to_string(),
+        first["retry_turn_id"].as_str().unwrap()
+    );
+    assert!(fake.spawns.lock().unwrap().is_empty());
+    assert!(fake.sends.lock().unwrap().is_empty());
+    runtime
+        .revoke_adapter_grant(&owner, grant.id, "test revocation")
+        .await
+        .unwrap();
+    assert_eq!(
+        client
+            .post(&url)
+            .bearer_auth(&pair.token)
+            .json(&retry)
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::UNAUTHORIZED
+    );
+}

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -512,6 +512,96 @@ impl CodeRuntime {
         Ok(tidebreak_core::db::code::delete_queued_turn(&self.db, owner, id, queued_id).await?)
     }
 
+    /// Recover an unconfirmed external instruction and wake the remaining queue.
+    pub async fn recover_external_steer(
+        &self,
+        owner: &OwnerId,
+        id: SessionId,
+        event_id: &str,
+        action: tidebreak_core::code::ExternalSteerRecoveryAction,
+        accept_duplicate_risk: bool,
+    ) -> Result<tidebreak_core::code::ExternalSteerRecovery, ServerError> {
+        use tidebreak_core::db::code::ExternalSteerRecoveryError;
+        let _recovery_guard = self.session_recovery_lock(id).lock_owned().await;
+        self.get_session(owner, id).await?;
+        let recovery = tidebreak_core::db::code::recover_external_steer(
+            &self.db,
+            owner,
+            id,
+            event_id,
+            action,
+            accept_duplicate_risk,
+        )
+        .await
+        .map_err(|error| match error {
+            ExternalSteerRecoveryError::NotFound => {
+                ServerError::not_found("steering admission not found")
+            }
+            ExternalSteerRecoveryError::DuplicateRiskNotAccepted => {
+                ServerError::bad_request(error.to_string())
+            }
+            ExternalSteerRecoveryError::Store(error) => error.into(),
+            other => ServerError::conflict_kind("steering_recovery_conflict", other.to_string()),
+        })?;
+        self.resume_recovered_queue(owner, id).await?;
+        Ok(recovery)
+    }
+
+    /// Start an idle machine worker when explicit recovery releases its queue.
+    async fn resume_recovered_queue(
+        &self,
+        owner: &OwnerId,
+        id: SessionId,
+    ) -> Result<(), ServerError> {
+        let session = self.get_session(owner, id).await?;
+        if session.lifecycle == SessionLifecycle::Ended
+            || tidebreak_core::db::code::queued_turn_head(&self.db, owner, id)
+                .await?
+                .is_none()
+        {
+            return Ok(());
+        }
+        if session.execution_location == tidebreak_core::ExecutionLocation::Sandbox {
+            let remote = self.remote_sessions().ok_or_else(|| {
+                ServerError::conflict_kind(
+                    "remote_disabled",
+                    "Recovery is saved, but this deployment has no sandbox runtime configured.",
+                )
+            })?;
+            remote.wake_sweep();
+            return Ok(());
+        }
+        if let Ok(handle) = self.require_worker(id) {
+            if !handle.commands.is_closed() {
+                wake_queue(&handle);
+                return Ok(());
+            }
+            self.take_worker_for_epoch(id, handle.spawn_epoch);
+        }
+        if !matches!(
+            session.lifecycle,
+            SessionLifecycle::Created | SessionLifecycle::Idle
+        ) || session.child_pid.is_some()
+        {
+            return Err(ServerError::conflict_kind("session_needs_recovery",
+                "The decision is saved, but the prior worker must be recovered before queued work can start."));
+        }
+        if let Some(workspace) = self.session_workspace(&session).await? {
+            if workspace.status != CodeWorkspaceStatus::Active {
+                return Err(ServerError::conflict_kind(
+                    "workspace_not_ready",
+                    format!(
+                        "Recovery is saved, but the workspace is {}.",
+                        workspace.status.as_str()
+                    ),
+                ));
+            }
+        }
+        self.attach_and_spawn_worker(session).await?;
+        self.wake_session_queue(id);
+        Ok(())
+    }
+
     /// Pause or release the session's queue. A release wakes the worker so a
     /// waiting head starts without a new send.
     pub async fn set_queue_paused(

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -818,4 +818,147 @@ mod tests {
             .await
             .is_empty());
     }
+
+    #[tokio::test]
+    async fn steering_recovery_starts_missing_idle_worker_and_runs_one_retry() {
+        use tidebreak_core::code::ExternalSteerRecoveryAction as Action;
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime = scripted_runtime(tmp.path()).await;
+        let owner = OwnerId::local();
+        let mut session = workspaceless_session(&owner, HarnessKind::ClaudeCode);
+        session.lifecycle = SessionLifecycle::Idle;
+        insert_session(&runtime.db, &session).await.unwrap();
+        tidebreak_core::db::code::record_external_message_with_steer(
+            &runtime.db,
+            &owner,
+            session.id,
+            "recover-idle",
+            "1.1",
+            "recovered instruction",
+            &Default::default(),
+            None,
+            tidebreak_core::db::code::ExternalSteerAdmissionInput {
+                request_steer: true,
+                expected_turn_id: Some(TurnId::new()),
+                correlation_uuid: Some(uuid::Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!runtime.has_worker(session.id));
+        let (first, replay) = tokio::join!(
+            runtime.recover_external_steer(&owner, session.id, "recover-idle", Action::Retry, true),
+            runtime.recover_external_steer(&owner, session.id, "recover-idle", Action::Retry, true)
+        );
+        let first = first.unwrap();
+        assert_eq!(first, replay.unwrap());
+        assert!(runtime.has_worker(session.id));
+        let turns = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let turns = tidebreak_core::db::code::list_turns(&runtime.db, &owner, session.id)
+                    .await
+                    .unwrap();
+                if !turns.is_empty() {
+                    break turns;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("the recovered queue starts without another message");
+        assert_eq!(turns.len(), 1);
+        assert_eq!(Some(turns[0].id), first.retry_turn_id);
+        assert_eq!(turns[0].user_input, "recovered instruction");
+        assert_eq!(
+            runtime
+                .get_session(&owner, session.id)
+                .await
+                .unwrap()
+                .spawn_epoch,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn steering_recovery_preserves_pause_and_never_reopens_ended_session() {
+        use tidebreak_core::code::ExternalSteerRecoveryAction as Action;
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime = scripted_runtime(tmp.path()).await;
+        let owner = OwnerId::local();
+        let mut session = workspaceless_session(&owner, HarnessKind::ClaudeCode);
+        session.lifecycle = SessionLifecycle::Idle;
+        insert_session(&runtime.db, &session).await.unwrap();
+        runtime
+            .set_queue_paused(&owner, session.id, true)
+            .await
+            .unwrap();
+        tidebreak_core::db::code::record_external_message_with_steer(
+            &runtime.db,
+            &owner,
+            session.id,
+            "recover-paused",
+            "1.1",
+            "paused instruction",
+            &Default::default(),
+            None,
+            tidebreak_core::db::code::ExternalSteerAdmissionInput {
+                request_steer: true,
+                expected_turn_id: Some(TurnId::new()),
+                correlation_uuid: Some(uuid::Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        let decision = runtime
+            .recover_external_steer(&owner, session.id, "recover-paused", Action::Retry, true)
+            .await
+            .unwrap();
+        assert!(runtime.has_worker(session.id));
+        assert!(
+            tidebreak_core::db::code::queue_paused(&runtime.db, &owner, session.id)
+                .await
+                .unwrap()
+        );
+        assert!(
+            tidebreak_core::db::code::list_turns(&runtime.db, &owner, session.id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        runtime
+            .set_queue_paused(&owner, session.id, false)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if !tidebreak_core::db::code::list_turns(&runtime.db, &owner, session.id)
+                    .await
+                    .unwrap()
+                    .is_empty()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("unpausing starts the recovered instruction");
+        runtime.end_session_row(&owner, session.id).await.unwrap();
+        assert_eq!(
+            runtime
+                .recover_external_steer(&owner, session.id, "recover-paused", Action::Retry, true)
+                .await
+                .unwrap(),
+            decision
+        );
+        assert!(!runtime.has_worker(session.id));
+        assert_eq!(
+            runtime
+                .get_session(&owner, session.id)
+                .await
+                .unwrap()
+                .lifecycle,
+            SessionLifecycle::Ended
+        );
+    }
 }

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -866,6 +866,29 @@ the stored sandbox, runtime UUID, native turn, Tidebreak turn, and correlation.
 A replacement process cannot consume a frame addressed to its predecessor. A late local acknowledgment can
 settle the original receipt while its worker still owns the turn.
 
+To retire an unconfirmed admission, call
+`POST /external/code/sessions/{id}/messages/{event_id}/recovery` with the bound
+adapter token. Send `{"action":"discard"}` to remove its held queue row.
+Discard does not undo work that the harness may already have performed. Send
+`{"action":"retry","accept_duplicate_risk":true}` to queue another copy of the
+original message. Require explicit acceptance that the original may already
+have run before sending a retry request.
+
+Recovery returns `action`, `recovered_at`, and `retry_turn_id` for a retry.
+The admission GET also includes this object as `recovery`. Repeating the same
+action returns the original decision and retry ID; choosing a different action
+returns a conflict. Retry creates a fresh ordinary queue row. Recovery wakes
+queue processing and preserves an explicit queue pause. An idle machine session
+with no worker starts one so the recovered queue can run without another message.
+If its prior worker still needs recovery, the endpoint reports that the decision
+is saved but queued work cannot start.
+
+Recovery remains separate from native admission. If native confirmation arrives
+first, recovery refuses the request. If recovery commits first, late confirmation
+can still settle the original receipt without deleting the retry. Clients can
+retire recovery polling when `recovery` appears, even if `outcome` remains
+`pending`. An ended session allows discard but refuses retry.
+
 Keep automatic adapter steering disabled until the adapter exposes pending
 admissions and their recovery controls. Native acceptance followed by process
 loss can remain unknown; transport idempotency cannot settle that case.


### PR DESCRIPTION
## What changed

An unconfirmed Slack instruction can hold the session queue indefinitely. Add an authenticated recovery endpoint that records an explicit discard or retry decision. Retry requires acceptance that the original may already have run and creates one fresh ordinary queue row. Repeating the action returns the original decision and retry ID.

Native delivery remains separate from recovery. Late machine and sandbox acknowledgments cannot consume the retry or journal its edited text as the original instruction. Recovery wakes sandbox processing or starts a missing idle machine worker. It preserves queue pauses and ended sessions, and shares the session lock used by automatic recovery and turn admission.

## Validation

- Eight focused core and migration recovery tests pass.
- Two runtime recovery tests pass, covering concurrent replay, missing workers, queue pause, and ended sessions.
- All 13 automatic recovery tests pass.
- The authenticated recovery API test passes, covering unrelated and revoked grants, duplicate-risk acceptance, conflicts, immutable replay, and late native settlement.
- Scoped Clippy passes with warnings denied across all targets of core, server-core, and server.
- Full `cargo fmt --check` and `git diff --check` pass.
- The 23 migration tests pass before the rebase; the new migration preservation test also passes after it.

## Compatibility and risk

Adds nullable recovery columns and optional recovery metadata to the admission response. The endpoint requires the existing session-bound adapter grant. Discard does not undo native work; retry can duplicate an instruction whose earlier execution remains unknown. Automatic steering stays disabled by default. Live Slack acceptance and the paired recovery controls still need validation alongside the companion Gateway change.

## Tracking

Related to #3188 and brightwave-inc/model-gateway#1852. Companion controls: brightwave-inc/model-gateway#2017.
