### PR TITLE
fix(slack): expose authorized channel workspaces on the web

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/access.rs
+++ b/crates/tidebreak-core/src/db/ops/code/access.rs
@@ -317,6 +317,7 @@ pub async fn replace_external_session_contributors(
     id: SessionId,
     channel_kind: &str,
     identities: &[String],
+    visibility: Option<SessionVisibility>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<Option<Vec<SessionAccess>>> {
     if !owns_session(store, owner, id).await? {
@@ -358,6 +359,18 @@ pub async fn replace_external_session_contributors(
             .await
             .map_err(store_err)?;
         kept.push(access_from_row(model.try_into_model().map_err(store_err)?)?);
+    }
+    if let Some(visibility) = visibility {
+        entities::session::Entity::update_many()
+            .col_expr(
+                entities::session::Column::Visibility,
+                Expr::value(visibility.as_str()),
+            )
+            .filter(entities::session::Column::Id.eq(id.0))
+            .filter(entities::session::Column::Owner.eq(owner.as_str()))
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
     }
     transaction.commit().await.map_err(store_err)?;
     Ok(Some(kept))

--- a/crates/tidebreak-core/src/db/ops/code/workspace.rs
+++ b/crates/tidebreak-core/src/db/ops/code/workspace.rs
@@ -88,6 +88,36 @@ pub async fn list_workspaces(
         .collect()
 }
 
+/// Workspaces owned by the caller or containing a session they may read.
+/// Shared workspace metadata does not grant access to sibling sessions or files.
+pub async fn list_readable_workspaces(
+    store: &DbStore,
+    owner: &OwnerId,
+    repo_id: Option<RepoId>,
+) -> Result<Vec<CodeWorkspace>> {
+    let shared: Vec<uuid::Uuid> = super::list_accessible_sessions(store, owner)
+        .await?
+        .into_iter()
+        .filter_map(|session| session.workspace_id.map(|id| id.0))
+        .collect();
+    let mut query = entities::code_workspace::Entity::find().filter(
+        sea_orm::Condition::any()
+            .add(entities::code_workspace::Column::Owner.eq(owner.as_str()))
+            .add(entities::code_workspace::Column::Id.is_in(shared)),
+    );
+    if let Some(repo_id) = repo_id {
+        query = query.filter(entities::code_workspace::Column::RepoId.eq(repo_id.0));
+    }
+    query
+        .order_by_desc(entities::code_workspace::Column::CreatedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(workspace_from_row)
+        .collect()
+}
+
 /// Every workspace on the machine, across owners.
 ///
 /// A system path, not a request path: boot recovery sweeps private scratch

--- a/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.dom.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  render,
+  screen,
+  within,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { codeWorkspace } from "@/stories/fixtures";
+import { useCodeCatalogStore } from "./CodeCatalogStore";
+import { CodeArchivePage } from "./CodeArchivePage";
+
+const { client } = vi.hoisted(() => ({
+  client: {
+    searchCodeWorkspace: vi
+      .fn()
+      .mockResolvedValue({ history_matches: [], truncated: false }),
+    restoreCodeWorkspace: vi.fn().mockResolvedValue({}),
+  },
+}));
+vi.mock("@/AppContext", () => ({ useApp: () => ({ client }) }));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@/RouteFrame", () => ({
+  RouteFrame: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("./CodeSidebar", () => ({ CodeSidebar: () => null }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useCodeCatalogStore.setState({
+    loaded: true,
+    error: null,
+    repos: [],
+    refresh: vi.fn().mockResolvedValue(undefined),
+    workspaces: [
+      {
+        ...codeWorkspace,
+        id: "shared",
+        title: "Shared archive",
+        repo_id: "repo",
+        status: "archived",
+        read_only: true,
+      },
+      {
+        ...codeWorkspace,
+        id: "owned",
+        title: "Owned archive",
+        repo_id: "repo",
+        status: "archived",
+        read_only: false,
+      },
+    ],
+  });
+});
+afterEach(cleanup);
+
+it("keeps shared archives browsable without offering owner restore", () => {
+  render(<CodeArchivePage />);
+  const shared = screen
+    .getByText("Shared archive")
+    .closest('[role="listitem"]') as HTMLElement;
+  const owned = screen
+    .getByText("Owned archive")
+    .closest('[role="listitem"]') as HTMLElement;
+  expect(
+    within(shared).queryByRole("button", { name: "Restore" }),
+  ).not.toBeInTheDocument();
+  expect(
+    within(shared).getByRole("button", { name: "Open Shared archive" }),
+  ).toBeVisible();
+  expect(within(owned).getByRole("button", { name: "Restore" })).toBeVisible();
+});
+
+it("searches owned archive history even when a shared row appears first for the repo", async () => {
+  render(<CodeArchivePage />);
+  await userEvent
+    .setup()
+    .type(
+      screen.getByPlaceholderText("Search workspaces and conversations…"),
+      "archive",
+    );
+  await waitFor(() =>
+    expect(client.searchCodeWorkspace).toHaveBeenCalledWith("owned", {
+      query: "archive",
+      history: true,
+      limit: 200,
+    }),
+  );
+  expect(
+    client.searchCodeWorkspace.mock.calls.every(([id]) => id === "owned"),
+  ).toBe(true);
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeArchivePage.tsx
@@ -102,7 +102,7 @@ function CodeArchiveBody() {
   const historyAnchors = useMemo(() => {
     const seenRepos = new Set<string>();
     return archiveCandidates.filter((workspace) => {
-      if (seenRepos.has(workspace.repo_id)) return false;
+      if (workspace.read_only || seenRepos.has(workspace.repo_id)) return false;
       seenRepos.add(workspace.repo_id);
       return true;
     });
@@ -230,7 +230,11 @@ function CodeArchiveBody() {
   }, [archiveCandidates, historyMatchesByWorkspace, repos, trimmedSearch]);
 
   const restore = async (workspaceId: string) => {
-    if (restoring) return;
+    if (
+      restoring ||
+      workspaces.find((workspace) => workspace.id === workspaceId)?.read_only
+    )
+      return;
     setRestoring(workspaceId);
     try {
       const restored = await client.restoreCodeWorkspace(workspaceId);
@@ -475,15 +479,21 @@ function CodeArchiveBody() {
                         PR
                       </Button>
                     )}
-                    <Button
-                      type="button"
-                      size="xs"
-                      disabled={Boolean(restoring)}
-                      onClick={() => void restore(workspace.id)}
-                    >
-                      {restoring === workspace.id ? <Spinner /> : <RotateCcw />}
-                      Restore
-                    </Button>
+                    {!workspace.read_only && (
+                      <Button
+                        type="button"
+                        size="xs"
+                        disabled={Boolean(restoring)}
+                        onClick={() => void restore(workspace.id)}
+                      >
+                        {restoring === workspace.id ? (
+                          <Spinner />
+                        ) : (
+                          <RotateCcw />
+                        )}
+                        Restore
+                      </Button>
+                    )}
                     <Button
                       type="button"
                       size="icon-xs"

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.dom.test.tsx
@@ -1025,3 +1025,32 @@ function seedMixedSources() {
     });
   }
 }
+
+it("discovers a shared workspace without owner-only status or bulk actions", async () => {
+  const [owned] = await client.listCodeWorkspaces();
+  client.listCodeWorkspaces.mockResolvedValueOnce([
+    { ...owned, read_only: true } as typeof owned,
+  ]);
+  const getCodeWorkspacePr = vi.fn();
+  const sharedApp = {
+    ...app,
+    client: { ...client, getCodeWorkspacePr } as never,
+  };
+  const { router } = await renderWithRouter(
+    <AppContextProvider value={sharedApp}>
+      <CodeSidebar />
+    </AppContextProvider>,
+    { initialUrl: "/code" },
+  );
+  const card = await screen.findByRole("button", { name: /^Fix login/ });
+  fireEvent.click(card, { metaKey: true });
+  await waitFor(() =>
+    expect(router.state.location.pathname).toBe("/code/w/ws-1"),
+  );
+  expect(useCodeUiStore.getState().selectedWorkspaceIds).toEqual([]);
+  fireEvent.contextMenu(card);
+  expect(
+    screen.queryByRole("menuitem", { name: /Archive/ }),
+  ).not.toBeInTheDocument();
+  expect(getCodeWorkspacePr).not.toHaveBeenCalled();
+});

--- a/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSidebar.tsx
@@ -166,7 +166,9 @@ export function CodeSidebar() {
   );
   const selectableIds = groups.flatMap((group) =>
     group.workspaces
-      .filter((workspace) => workspace.status !== "creating")
+      .filter(
+        (workspace) => workspace.status !== "creating" && !workspace.read_only,
+      )
       .map((workspace) => workspace.id),
   );
   const selectedWorkspaces = workspaces.filter(
@@ -689,7 +691,10 @@ function SidebarEmptyAction({
 
 function LiveWorkspaceCard(props: ComponentProps<typeof WorkspaceCard>) {
   const { client } = useApp();
-  if (typeof client.getCodeWorkspacePr !== "function") {
+  if (
+    props.workspace.read_only ||
+    typeof client.getCodeWorkspacePr !== "function"
+  ) {
     return <WorkspaceCard {...props} />;
   }
   return <ObservedWorkspaceCard {...props} client={client} />;

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerTarget.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerTarget.test.ts
@@ -102,4 +102,25 @@ describe("codeTriggerTargetForRepository", () => {
       }),
     ).toBeNull();
   });
+  it("excludes shared read-only sessions from the owner's trigger target", () => {
+    const conversationsByWorkspace: DigestsByWorkspace = {
+      "ws-trigger": {
+        "sess-shared": codeDigest({
+          workspace: "ws-trigger",
+          session: "sess-shared",
+          harness_kind: "codex",
+          title: "Shared Slack task",
+          trigger_target_at: "2026-08-29T11:00:00Z",
+        }),
+      },
+    };
+    expect(
+      codeTriggerTargetForRepository({
+        repoId: "repo-trigger",
+        workspaces: [workspace({ read_only: true })],
+        conversationsByWorkspace,
+        doctor: harnessDoctor,
+      }),
+    ).toBeNull();
+  });
 });

--- a/crates/tidebreak-desktop/ui/src/code/CodeTriggerTarget.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeTriggerTarget.ts
@@ -10,7 +10,7 @@ import type { DigestsByWorkspace } from "./CodeUpdatesStore";
 
 type TargetWorkspace = Pick<
   CodeWorkspaceSnapshot,
-  "id" | "repo_id" | "status" | "pr"
+  "id" | "repo_id" | "status" | "pr" | "read_only"
 >;
 
 /**
@@ -37,6 +37,7 @@ export function codeTriggerTargetForRepository({
     workspaces
       .filter(
         (workspace) =>
+          !workspace.read_only &&
           workspace.repo_id === repoId &&
           workspace.status === "active" &&
           workspace.pr !== undefined,

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.dom.test.tsx
@@ -996,3 +996,22 @@ describe("WorkspaceCard", () => {
     ).toBeInTheDocument();
   });
 });
+
+it("opens a shared workspace without selection or mutation actions", async () => {
+  const { onOpen, onCommand, onSelectPointer } = renderCard({
+    workspace: { read_only: true },
+    detailDefaultOpen: true,
+  });
+  const card = screen.getByRole("button", { name: /Fix login.*app/ });
+  fireEvent.click(card, { metaKey: true });
+  expect(onOpen).toHaveBeenCalledOnce();
+  expect(onSelectPointer).not.toHaveBeenCalled();
+  fireEvent.contextMenu(card);
+  expect(
+    screen.queryByRole("menuitem", { name: /Archive/ }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: /Archive/ }),
+  ).not.toBeInTheDocument();
+  expect(onCommand).not.toHaveBeenCalled();
+});

--- a/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
+++ b/crates/tidebreak-desktop/ui/src/code/WorkspaceCard.tsx
@@ -221,6 +221,12 @@ export function WorkspaceCard({
     pr?: PullRequestDigest,
   ) => void;
 }) {
+  if (workspace.read_only) {
+    commands = [];
+    onSelectPointer = undefined;
+    onMenuOpen = undefined;
+    onWorkflowAction = undefined;
+  }
   const title = digest?.title ?? workspace.title;
   const pr = prResource?.data
     ? prResource.data.pr

--- a/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/DeliveryCenter.stories.tsx
@@ -141,7 +141,19 @@ function storyClient(scenario: DeliveryScenario): ApiClient {
       ? deliveryWorkspaces.filter(
           (workspace) => workspace.status !== "released",
         )
-      : deliveryWorkspaces;
+      : scenario === "archive"
+        ? [
+            {
+              ...deliveryWorkspaces.find(
+                (workspace) => workspace.status === "released",
+              )!,
+              id: "ws-shared-archive",
+              title: "Shared Slack investigation",
+              read_only: true,
+            },
+            ...deliveryWorkspaces,
+          ]
+        : deliveryWorkspaces;
   const refreshedMergedPullRequest = {
     ...deliveryPullRequests[0]!,
     state: "merged" as const,

--- a/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
+++ b/crates/tidebreak-desktop/ui/src/stories/WorkspaceCard.stories.tsx
@@ -1265,3 +1265,19 @@ function RecoverableWorktreeFailure() {
 export const WorktreeOpenFailure: Story = {
   render: () => <RecoverableWorktreeFailure />,
 };
+
+export const SharedReadOnly: Story = {
+  args: {
+    workspace: { ...codeWorkspace, read_only: true },
+    digest: readyToMergeDigest,
+    detailDefaultOpen: true,
+    onWorkflowAction: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(
+      body.queryByRole("button", { name: "Merge" }),
+    ).not.toBeInTheDocument();
+    await expect(args.onCommand).not.toHaveBeenCalled();
+  },
+};

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -995,6 +995,10 @@ pub async fn external_recover_steer(
 #[serde(deny_unknown_fields)]
 pub struct ExternalAccessBody {
     pub contributors: Vec<ExternalContributor>,
+    /// The adapter verifies the visibility of every channel bound to the session.
+    /// Older adapters omit this field and preserve the existing visibility.
+    #[serde(default)]
+    pub visibility: Option<tidebreak_core::SessionVisibility>,
 }
 
 #[derive(serde::Deserialize)]
@@ -1025,6 +1029,7 @@ pub async fn external_session_access(
         id,
         &grant.channel_kind,
         &identities,
+        body.visibility,
         chrono::Utc::now(),
     )
     .await?

--- a/crates/tidebreak-server-api/src/routes/code/workspaces.rs
+++ b/crates/tidebreak-server-api/src/routes/code/workspaces.rs
@@ -104,11 +104,16 @@ pub async fn list_workspaces(
     code: ScopedCode,
     Query(query): Query<ListWorkspacesQuery>,
 ) -> Result<Json<Vec<CodeWorkspaceSnapshot>>, ServerError> {
-    let workspaces = code.list_workspaces(query.repo_id).await?;
+    let workspaces = code.list_readable_workspaces(query.repo_id).await?;
     Ok(Json(
         workspaces
             .into_iter()
-            .map(CodeWorkspaceSnapshot::from)
+            .map(|workspace| {
+                let read_only = workspace.owner != *code.owner();
+                let mut snapshot = CodeWorkspaceSnapshot::from(workspace);
+                snapshot.read_only = Some(read_only);
+                snapshot
+            })
             .collect(),
     ))
 }

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -3638,6 +3638,79 @@ async fn a_service_principal_starts_a_workspace_handshake_and_an_admin_approves_
     assert!(subjects.contains(&"external:slack:U9"));
     assert!(subjects.contains(&"external:slack:U8"));
 
+    let session_path = format!("/sessions/{session_id}");
+    let access_path = format!("/external/code/sessions/{session_id}/access");
+    let (status, _) = call_json(&router, "GET", &session_path, BOB_TOKEN, None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let (status, _) = call_json(
+        &router,
+        "PUT",
+        &access_path,
+        &grant_token,
+        Some(serde_json::json!({"contributors": [], "visibility": "deployment"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (status, shared) = call_json(&router, "GET", &session_path, BOB_TOKEN, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(shared["access"], "view");
+    assert_eq!(shared["is_owner"], false);
+    let (status, _) = call_json(
+        &router,
+        "POST",
+        &format!("{session_path}/turns"),
+        BOB_TOKEN,
+        Some(serde_json::json!({"message": "not a contributor"})),
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "deployment visibility never grants writes"
+    );
+
+    // Old adapters preserve visibility; malformed replacements commit nothing.
+    let (status, _) = call_json(
+        &router,
+        "PUT",
+        &access_path,
+        &grant_token,
+        Some(serde_json::json!({"contributors": [{"external_identity": "U9"}]})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (status, _) = call_json(&router, "GET", &session_path, BOB_TOKEN, None).await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _) = call_json(
+        &router, "PUT", &access_path, &grant_token,
+        Some(serde_json::json!({"contributors": [{"external_identity": "x".repeat(600)}], "visibility": "private"})),
+    ).await;
+    assert!(!status.is_success());
+    let (status, _) = call_json(&router, "GET", &session_path, BOB_TOKEN, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        tidebreak_core::db::code::list_session_access(&runtime.db, &service, session_id)
+            .await
+            .unwrap()[0]
+            .subject,
+        "external:slack:U9"
+    );
+
+    let (status, _) = call_json(
+        &router,
+        "PUT",
+        &access_path,
+        &grant_token,
+        Some(serde_json::json!({"contributors": [], "visibility": "private"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (status, _) = call_json(&router, "GET", &session_path, BOB_TOKEN, None).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "public-to-private must revoke web reads"
+    );
+
     let (status, _) = call_json(
         &router,
         "POST",
@@ -3681,6 +3754,20 @@ async fn a_person_grant_refuses_a_body_actor() {
     .await;
     assert_eq!(status, StatusCode::CREATED);
     let session_id = bound_session_id(&runtime, &owner, "T1/C-actor/1.1").await;
+    let (status, _) = call_json(
+        &router,
+        "PUT",
+        &format!("/external/code/sessions/{session_id}/access"),
+        &pair.token,
+        Some(serde_json::json!({"contributors": [], "visibility": "deployment"})),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "personal grants cannot publish a session"
+    );
+
     let (status, _) = call_json(
         &router,
         "POST",

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -3647,7 +3647,7 @@ async fn a_service_principal_starts_a_workspace_handshake_and_an_admin_approves_
         "PUT",
         &access_path,
         &grant_token,
-        Some(serde_json::json!({"contributors": [], "visibility": "deployment"})),
+        Some(serde_json::json!({"contributors": [{"external_identity": "U9"}], "visibility": "deployment"})),
     )
     .await;
     assert_eq!(status, StatusCode::NO_CONTENT);

--- a/crates/tidebreak-server-api/src/tests/code_owner_scope.rs
+++ b/crates/tidebreak-server-api/src/tests/code_owner_scope.rs
@@ -1122,6 +1122,29 @@ async fn shared_session_workspace_reads_preserve_ownership_and_revocation() {
         .await
         .unwrap();
     assert_eq!(shared["read_only"], true);
+    for list_path in [
+        "/code/workspaces".to_owned(),
+        format!(
+            "/code/workspaces?repo_id={}",
+            repo_body["id"].as_str().unwrap()
+        ),
+    ] {
+        let discovered: Vec<serde_json::Value> = client
+            .get(format!("http://{addr}{list_path}"))
+            .bearer_auth(BOB_TOKEN)
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0]["id"], workspace_id);
+        assert_eq!(discovered[0]["read_only"], true);
+    }
+
     let listed: Vec<serde_json::Value> = client
         .get(format!("http://{addr}{path}/sessions"))
         .bearer_auth(BOB_TOKEN)
@@ -1205,6 +1228,21 @@ async fn shared_session_workspace_reads_preserve_ownership_and_revocation() {
         .await
         .unwrap();
     assert!(revoke.status().is_success(), "{}", revoke.status());
+    let discovered: Vec<serde_json::Value> = client
+        .get(format!("http://{addr}/code/workspaces"))
+        .bearer_auth(BOB_TOKEN)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        discovered.is_empty(),
+        "revoked workspaces must disappear from discovery"
+    );
     for suffix in ["", "/sessions", "/tree"] {
         assert_eq!(
             get_status(&client, addr, BOB_TOKEN, &format!("{path}{suffix}")).await,

--- a/crates/tidebreak-server/src/code/scoped.rs
+++ b/crates/tidebreak-server/src/code/scoped.rs
@@ -376,6 +376,19 @@ impl ScopedCode {
         self.runtime.list_workspaces(&self.owner, repo_id).await
     }
 
+    /// Discover shared workspaces without widening owner-only mutation paths.
+    pub async fn list_readable_workspaces(
+        &self,
+        repo_id: Option<RepoId>,
+    ) -> Result<Vec<CodeWorkspace>, ServerError> {
+        Ok(tidebreak_core::db::code::list_readable_workspaces(
+            &self.runtime.db,
+            &self.owner,
+            repo_id,
+        )
+        .await?)
+    }
+
     pub async fn get_workspace(&self, id: WorkspaceId) -> Result<CodeWorkspace, ServerError> {
         self.runtime.get_workspace(&self.owner, id).await
     }

--- a/docs/slack-sessions.md
+++ b/docs/slack-sessions.md
@@ -32,6 +32,24 @@ the same conversation, and the conversation can wait on those children
 and read their results. Grant-bound children follow the configured external
 placement. Remaining adapter and orchestration work is recorded below.
 
+## Opening channel sessions on the web
+
+The adapter sets session visibility through the workspace grant's bound
+`PUT /external/code/sessions/{id}/access` route. The optional `visibility`
+field accepts `deployment` or `private`. Contributor replacement and the
+visibility change commit together. Older adapters omit the field and preserve
+the session's visibility.
+
+Only channels that the adapter verifies as public and not externally shared
+may use deployment visibility. Private channels and unknown channel metadata
+stay private. Deployment visibility lets signed-in people read the session;
+it does not grant permission to send instructions or edit the workspace.
+
+The workspace list includes workspaces that contain a session the caller may
+read. Shared entries carry `read_only: true`. Their cards open the transcript
+without offering workspace commands or requesting owner-only Git status.
+Revoking the session's access removes the workspace from that reader's list.
+
 ## What is true today
 
 - Desktop, CLI, mobile, and `tidebreak agent-mcp` speak one attach


### PR DESCRIPTION
Public Slack channel sessions remain private to their service owner, so a signed-in reader can receive 404 from Open in Tidebreak. Authorized shared workspaces also disappear from the sidebar because its workspace list only returns owned workspaces.

Allow the bound workspace-grant access endpoint to replace contributors and visibility atomically. The adapter can mark verified public channels deployment-readable; omitted visibility preserves compatibility with older adapters. Personal grants cannot change it. Return authorized shared workspaces in the web list with read_only=true. Shared entries hide mutation and selection actions, skip owner-only Git status and archive history requests, and cannot serve as repository trigger targets.

Deploy this server before brightwave-inc/model-gateway#2021. Older servers reject the adapter's visibility field.

Validation: three focused server API regressions pass, covering shared workspace discovery and revocation, public-to-private reads, denied writes, atomic rollback, legacy requests, and personal-grant rejection. The initial focused UI suite passes 58 tests; five archive and trigger-target tests also pass. Scoped all-target Rust Clippy, TypeScript, UI lint, formatting, and diff checks pass. Added Code/Workspace card/Shared read only and a shared row in ArchivePopulated. The Storybook build passes, including the updated archive fixture. Screenshot review is unavailable because browser access is blocked by administrator policy; no visual pass is claimed.