### PR TITLE
fix(slack): start repository-free sandbox conversations

### DIFF
--- a/crates/tidebreak-supervised-agent/src/bootstrap.rs
+++ b/crates/tidebreak-supervised-agent/src/bootstrap.rs
@@ -456,6 +456,37 @@ mod tests {
     }
 
     #[test]
+    fn a_scratch_envelope_prepares_the_workspace_without_cloning() {
+        let root = tempfile::tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        let inputs = resolve(RawInputs {
+            task: Some(
+                tidebreak_core::code::RemoteWorkspaceTask::encode_scratch(
+                    "Read the channel and report.",
+                    "scratch/channel",
+                )
+                .unwrap(),
+            ),
+            workspace: Some(workspace.display().to_string()),
+            ..RawInputs::default()
+        })
+        .unwrap();
+        let bootstrap = run(&inputs, &trust_options(root.path()), None).unwrap();
+        assert_eq!(bootstrap.workdir, workspace);
+        assert!(bootstrap.workdir.is_dir());
+        assert!(bootstrap.clones.is_empty());
+        assert!(!bootstrap.workdir.join(".git").exists());
+        assert!(bootstrap
+            .events
+            .iter()
+            .any(|(kind, _)| kind == "workspace_prepared"));
+        assert!(!bootstrap
+            .events
+            .iter()
+            .any(|(kind, _)| kind == "repository_cloned"));
+    }
+
+    #[test]
     fn a_declared_repository_is_cloned_and_its_ref_checked_out() {
         let root = tempfile::tempdir().unwrap();
         let remote = fixture_remote(root.path());

--- a/crates/tidebreak-supervised-agent/src/inputs.rs
+++ b/crates/tidebreak-supervised-agent/src/inputs.rs
@@ -211,7 +211,7 @@ pub fn resolve(raw: RawInputs) -> Result<Inputs, InputError> {
     let (task, workspace_branch, scratch_marker) = match envelope.as_ref() {
         Some(envelope) => (
             envelope.task.clone(),
-            Some(envelope.branch.clone()),
+            (!envelope.scratch).then(|| envelope.branch.clone()),
             envelope.scratch.then(|| envelope.branch.clone()),
         ),
         None => (raw_task, None, None),
@@ -450,6 +450,20 @@ mod tests {
         let inputs = resolve(raw).unwrap();
         assert_eq!(inputs.task, task);
         assert_eq!(inputs.workspace_branch.as_deref(), Some("thet/remote-work"));
+    }
+
+    #[test]
+    fn a_scratch_envelope_runs_without_a_repository_or_checkout_branch() {
+        let task = "Report both repositories.\nDo not change files.\n";
+        let mut raw = minimal();
+        raw.task = Some(
+            tidebreak_core::code::RemoteWorkspaceTask::encode_scratch(task, "scratch/one").unwrap(),
+        );
+        let inputs = resolve(raw).unwrap();
+        assert_eq!(inputs.task, task);
+        assert_eq!(inputs.workspace_branch, None);
+        assert_eq!(inputs.scratch_marker.as_deref(), Some("scratch/one"));
+        assert!(inputs.repositories.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
A Slack conversation without a repository reaches Gateway's sandbox, then the supervised agent exits with `MODEL_GATEWAY_SANDBOX_TASK is unusable: a workspace task requires a repository`. The parser assigns a Git checkout branch even when the task envelope explicitly declares scratch mode.

Keep the scratch marker and original task, but only assign a checkout branch for repository tasks. Repository-free conversations then reach the existing scratch-directory bootstrap without cloning. Repository tasks still require a repository.

Validation: reproduced the live failure with two regression tests before the fix. All 126 supervised-agent library tests pass after the fix, including parsing and scratch-directory bootstrap. Formatting and diff checks pass. Scoped all-target Clippy with the core default features passes; the minimal-feature invocation encountered existing unused-code errors in tidebreak-core.