### PR TITLE
fix(sandbox): preserve native tool bridge in engine launches

### DIFF
--- a/crates/tidebreak-harness/src/claude/session.rs
+++ b/crates/tidebreak-harness/src/claude/session.rs
@@ -22,7 +22,6 @@ use tokio::sync::{oneshot, Mutex as AsyncMutex};
 use tokio::time::{timeout, timeout_at, Instant};
 use tracing::warn;
 
-use crate::browser_channel::apply_child_env_tokio;
 use crate::child::{turn_outcome, ChildPid};
 use crate::claude::parse::ClaudeStreamParser;
 use crate::launch::{validate_launch_plan_with, BypassPolicy, LaunchPlan};
@@ -625,13 +624,10 @@ impl ClaudeSession {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        apply_child_env_tokio(
+        self.spec.apply_child_env(
             &mut command,
             tidebreak_core::HarnessKind::ClaudeCode,
-            self.spec.env.iter().cloned(),
             &plan.env,
-            self.spec.browser.as_ref(),
-            self.spec.native.as_ref(),
         );
         let mut child = spawn_process_tree(&mut command)?;
         let stdin = child
@@ -1483,6 +1479,7 @@ mod tests {
             sink,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
     }
@@ -1659,6 +1656,7 @@ done
             sink: Arc::new(Discard),
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         });
         let plan = session.compose_plan_for(None, None).unwrap();
@@ -1807,6 +1805,39 @@ done
     /// the next launch composes it. Moving to `Allow` is refused whatever the
     /// child's state, because its flags are decided at launch.
     #[tokio::test]
+    async fn native_tool_bridge_paths_reach_shell_children_without_ambient_overrides() {
+        use tidebreak_core::HarnessKind;
+        let dir = tempfile::tempdir().unwrap();
+        let session = session_with("/bin/true".into(), dir.path(), Arc::new(Discard));
+        let mut spec = session.spec;
+        spec.env.extend([
+            ("TIDEBREAK_TOOL_HELPER".into(), "/untrusted/helper".into()),
+            ("TIDEBREAK_TOOL_SOCKET".into(), "/untrusted/socket".into()),
+            ("TIDEBREAK_UNRELATED_SECRET".into(), "private".into()),
+        ]);
+        for kind in [
+            HarnessKind::ClaudeCode,
+            HarnessKind::Codex,
+            HarnessKind::Opencode,
+            HarnessKind::Grok,
+        ] {
+            let mut absent = tokio::process::Command::new("/bin/sh");
+            absent.args(["-c", "test -z \"$TIDEBREAK_TOOL_HELPER$TIDEBREAK_TOOL_SOCKET$TIDEBREAK_UNRELATED_SECRET\""]);
+            spec.apply_child_env(&mut absent, kind, &[]);
+            assert!(absent.status().await.unwrap().success());
+            spec.tool_bridge = Some(crate::ToolBridgeSpec {
+                helper: "/trusted/helper".into(),
+                socket: "/trusted/socket".into(),
+            });
+            let mut present = tokio::process::Command::new("/bin/sh");
+            present.args(["-c", "test \"$TIDEBREAK_TOOL_HELPER\" = /trusted/helper && test \"$TIDEBREAK_TOOL_SOCKET\" = /trusted/socket && test -z \"$TIDEBREAK_UNRELATED_SECRET\""]);
+            spec.apply_child_env(&mut present, kind, &[]);
+            assert!(present.status().await.unwrap().success());
+            spec.tool_bridge = None;
+        }
+    }
+
+    #[tokio::test]
     async fn a_switch_without_a_child_is_recorded_for_the_next_launch() {
         let dir = tempfile::tempdir().unwrap();
         let session = session_with(
@@ -1866,6 +1897,7 @@ done
             sink: Arc::new(Discard),
             browser: Some(browser),
             native: None,
+            tool_bridge: None,
             apps: None,
         });
         let plan = session.compose_plan_for(None, None).unwrap();
@@ -1925,6 +1957,7 @@ done
             sink: Arc::new(Discard),
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         });
         let plan = session.compose_plan_for(None, None).unwrap();

--- a/crates/tidebreak-harness/src/codex/session.rs
+++ b/crates/tidebreak-harness/src/codex/session.rs
@@ -15,7 +15,6 @@ use tokio::sync::{oneshot, Mutex as AsyncMutex, Notify};
 use tokio::time::{timeout, Instant};
 use tracing::warn;
 
-use crate::browser_channel::apply_child_env_tokio;
 use crate::child::ChildPid;
 use crate::codex::parse::CodexStreamParser;
 use crate::launch::{validate_launch_plan, LaunchPlan};
@@ -964,14 +963,8 @@ impl CodexSession {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        apply_child_env_tokio(
-            &mut command,
-            tidebreak_core::HarnessKind::Codex,
-            self.spec.env.iter().cloned(),
-            &plan.env,
-            self.spec.browser.as_ref(),
-            self.spec.native.as_ref(),
-        );
+        self.spec
+            .apply_child_env(&mut command, tidebreak_core::HarnessKind::Codex, &plan.env);
         let mut child = spawn_process_tree(&mut command)?;
         let stdin = child
             .take_stdin()

--- a/crates/tidebreak-harness/src/codex/session/tests.rs
+++ b/crates/tidebreak-harness/src/codex/session/tests.rs
@@ -318,6 +318,7 @@ fn unit_session(sink: Arc<dyn crate::HarnessEventSink>) -> CodexSession {
         sink,
         browser: None,
         native: None,
+        tool_bridge: None,
         apps: None,
     })
 }
@@ -629,6 +630,7 @@ fn spec_for(
         sink: Arc::new(SilentSink),
         browser: None,
         native: None,
+        tool_bridge: None,
         apps: None,
     }
 }

--- a/crates/tidebreak-harness/src/grok/acp.rs
+++ b/crates/tidebreak-harness/src/grok/acp.rs
@@ -252,14 +252,8 @@ impl GrokSession {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        apply_child_env_tokio(
-            &mut command,
-            HarnessKind::Grok,
-            self.spec.env.iter().cloned(),
-            &plan.env,
-            self.spec.browser.as_ref(),
-            self.spec.native.as_ref(),
-        );
+        self.spec
+            .apply_child_env(&mut command, HarnessKind::Grok, &plan.env);
         let mut child = spawn_process_tree(&mut command)?;
         let stdin = child
             .take_stdin()

--- a/crates/tidebreak-harness/src/grok/acp_tests.rs
+++ b/crates/tidebreak-harness/src/grok/acp_tests.rs
@@ -254,6 +254,7 @@ fn session(dir: &Path, mode: PermissionMode, duplicate: bool) -> (Arc<GrokSessio
         sink: sink.clone(),
         browser: None,
         native: None,
+        tool_bridge: None,
         apps: None,
     };
     (Arc::new(GrokSession::new(spec, "1.0.13".into())), sink)

--- a/crates/tidebreak-harness/src/grok/session.rs
+++ b/crates/tidebreak-harness/src/grok/session.rs
@@ -16,6 +16,7 @@ use tokio::sync::watch;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::warn;
 
+#[cfg(test)]
 use crate::browser_channel::apply_child_env_tokio;
 use crate::child::{turn_outcome, ChildPid};
 use crate::grok::parse::GrokStreamParser;
@@ -699,14 +700,8 @@ impl GrokSession {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        apply_child_env_tokio(
-            &mut command,
-            tidebreak_core::HarnessKind::Grok,
-            self.spec.env.iter().cloned(),
-            &plan.env,
-            self.spec.browser.as_ref(),
-            self.spec.native.as_ref(),
-        );
+        self.spec
+            .apply_child_env(&mut command, tidebreak_core::HarnessKind::Grok, &plan.env);
         let mut child = spawn_process_tree(&mut command)?;
         // The engine writes its session directory as it starts, so from here
         // on the id is something to resume rather than something to create.
@@ -896,6 +891,7 @@ mod tests {
                 sink: std::sync::Arc::new(Discard),
                 browser: None,
                 native: None,
+                tool_bridge: None,
                 apps: None,
             },
             "1.0.5".into(),
@@ -1552,6 +1548,7 @@ exit 0
                     sink,
                     browser: None,
                     native: None,
+                    tool_bridge: None,
                     apps: None,
                 },
                 "1.0.5".into(),

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -798,6 +798,23 @@ impl BrowserChannelSpec {
     }
 }
 
+/// Trusted executable and socket for supervised native tool calls.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolBridgeSpec {
+    /// Absolute path to the runtime executable that dispatches tool calls.
+    pub helper: std::path::PathBuf,
+    /// Session-private socket served by the supervised runtime.
+    pub socket: std::path::PathBuf,
+}
+
+impl ToolBridgeSpec {
+    /// Inject runtime-owned paths after ambient environment filtering.
+    pub fn inject_env_tokio(&self, command: &mut tokio::process::Command) {
+        command.env("TIDEBREAK_TOOL_HELPER", &self.helper);
+        command.env("TIDEBREAK_TOOL_SOCKET", &self.socket);
+    }
+}
+
 /// Session-private native computer-use capability-file path.
 ///
 /// The desktop native runtime writes a short-lived JSON capability file at
@@ -922,6 +939,8 @@ pub struct SessionSpec {
     /// has produced a session-private capability file. `None` preserves the
     /// existing behavior: no native tools are advertised or injected.
     pub native: Option<NativeChannelSpec>,
+    /// Native tool bridge created by the supervised runtime.
+    pub tool_bridge: Option<ToolBridgeSpec>,
     /// Connected-apps channel wiring: the loopback MCP bridge over every
     /// server Tidebreak has mounted. `None` advertises no connected apps.
     pub apps: Option<AppsChannelSpec>,
@@ -1299,6 +1318,28 @@ pub fn is_absolute_executable(path: &Path) -> bool {
     #[cfg(not(unix))]
     {
         true
+    }
+}
+
+impl SessionSpec {
+    /// Compose the engine environment and then attach the trusted tool bridge.
+    pub fn apply_child_env(
+        &self,
+        command: &mut tokio::process::Command,
+        kind: HarnessKind,
+        plan_env: &[(String, String)],
+    ) {
+        browser_channel::apply_child_env_tokio(
+            command,
+            kind,
+            self.env.iter().cloned(),
+            plan_env,
+            self.browser.as_ref(),
+            self.native.as_ref(),
+        );
+        if let Some(bridge) = &self.tool_bridge {
+            bridge.inject_env_tokio(command);
+        }
     }
 }
 

--- a/crates/tidebreak-harness/src/opencode/session.rs
+++ b/crates/tidebreak-harness/src/opencode/session.rs
@@ -14,6 +14,7 @@ use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
 use tokio::time::timeout;
 use tracing::warn;
 
+#[cfg(test)]
 use crate::browser_channel::apply_child_env_tokio;
 use crate::child::ChildPid;
 use crate::launch::{validate_launch_plan, LaunchPlan};
@@ -573,13 +574,10 @@ impl OpencodeSession {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        apply_child_env_tokio(
+        self.spec.apply_child_env(
             &mut command,
             tidebreak_core::HarnessKind::Opencode,
-            self.spec.env.iter().cloned(),
             &plan.env,
-            self.spec.browser.as_ref(),
-            self.spec.native.as_ref(),
         );
         let mut child = spawn_process_tree(&mut command)?;
         let stdout = child
@@ -1146,6 +1144,7 @@ mod tests {
             sink: std::sync::Arc::new(Discard),
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
     }

--- a/crates/tidebreak-server/src/code/recovery.rs
+++ b/crates/tidebreak-server/src/code/recovery.rs
@@ -1288,6 +1288,7 @@ mod tests {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -1658,6 +1659,7 @@ mod tests {
                 sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
                 browser: None,
                 native: None,
+                tool_bridge: None,
                 apps: None,
             })
             .await

--- a/crates/tidebreak-server/src/code/runtime/workers.rs
+++ b/crates/tidebreak-server/src/code/runtime/workers.rs
@@ -412,6 +412,7 @@ impl CodeRuntime {
             sink: sink.clone() as Arc<dyn HarnessEventSink>,
             browser,
             native,
+            tool_bridge: None,
             apps,
         };
         let mut attached = attached;

--- a/crates/tidebreak-server/src/code/session_worker/tests.rs
+++ b/crates/tidebreak-server/src/code/session_worker/tests.rs
@@ -263,6 +263,7 @@ async fn a_stale_local_worker_leaves_sandbox_queue_rows_for_the_remote_driver() 
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -380,6 +381,7 @@ async fn an_engine_observed_decision_settles_its_own_approval_row() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -524,6 +526,7 @@ async fn a_send_over_an_internal_turn_waiting_on_a_client_is_refused() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -636,6 +639,7 @@ async fn a_parked_turn_waits_durably_and_resumes_on_the_awaited_decision() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -792,6 +796,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
                 sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
                 browser: None,
                 native: None,
+                tool_bridge: None,
                 apps: None,
             })
             .await
@@ -864,6 +869,7 @@ async fn client_and_agent_run_parks_resume_after_a_worker_restart() {
                 sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
                 browser: None,
                 native: None,
+                tool_bridge: None,
                 apps: None,
             })
             .await
@@ -983,6 +989,7 @@ async fn a_decision_on_the_running_leg_resumes_the_park() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -1104,6 +1111,7 @@ async fn an_interrupt_closes_a_parked_turn() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -1207,6 +1215,7 @@ async fn a_confirmed_setting_reservation_wins_over_an_already_queued_idle_turn()
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -1324,6 +1333,7 @@ async fn a_queued_turn_uses_a_later_setting_committed_before_promotion() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await
@@ -2000,6 +2010,7 @@ async fn an_update_quiesce_refuses_new_turns_until_resumed() {
             sink: sink.clone() as Arc<dyn tidebreak_harness::HarnessEventSink>,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         })
         .await

--- a/crates/tidebreak-server/src/scripted_harness.rs
+++ b/crates/tidebreak-server/src/scripted_harness.rs
@@ -1030,6 +1030,7 @@ mod tests {
             sink,
             browser: None,
             native: None,
+            tool_bridge: None,
             apps: None,
         }
     }

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -204,6 +204,8 @@ pub struct HarnessEngineSpec {
     pub allowed_read_roots: Vec<PathBuf>,
     /// Outbound-trust variables every engine child carries.
     pub trust_env: Vec<(OsString, OsString)>,
+    /// Runtime-owned native tool dispatcher, independent of ambient variables.
+    pub tool_bridge: Option<tidebreak_harness::ToolBridgeSpec>,
     /// The environment's inference contract, when the pod has one.
     pub gateway_inference: Option<GatewayInference>,
 }
@@ -325,6 +327,7 @@ impl HarnessEngine {
                 sink: self.sink.clone(),
                 browser: None,
                 native: None,
+                tool_bridge: self.spec.tool_bridge.clone(),
                 apps: self.spec.apps.clone(),
             })
             .await
@@ -702,6 +705,7 @@ mod tests {
     #[derive(Default)]
     struct CapturedSpec {
         apps: Option<tidebreak_harness::AppsChannelSpec>,
+        tool_bridge: Option<tidebreak_harness::ToolBridgeSpec>,
         session_id: Option<tidebreak_core::SessionId>,
         permission_mode: Option<PermissionMode>,
         worktree: Option<PathBuf>,
@@ -768,6 +772,7 @@ mod tests {
                 return Err(error);
             }
             *self.captured.lock().unwrap() = CapturedSpec {
+                tool_bridge: spec.tool_bridge.clone(),
                 apps: spec.apps,
                 session_id: Some(spec.session_id),
                 permission_mode: Some(spec.permission_mode),
@@ -814,6 +819,7 @@ mod tests {
             reasoning_effort: Some(ReasoningEffort::High),
             worktree: PathBuf::from("/workspace/repo"),
             allowed_read_roots: vec![PathBuf::from("/workspace")],
+            tool_bridge: None,
             trust_env: vec![(
                 OsString::from("SSL_CERT_FILE"),
                 OsString::from("/tmp/bundle.pem"),
@@ -1159,6 +1165,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn native_tool_bridge_survives_child_environment_filtering() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
+            events: vec![completed_event()],
+            outcome: Ok(TurnOutcome::Clean),
+            waits_for_interrupt: false,
+        }]));
+        let captured = adapter.captured.clone();
+        let mut engine = engine_over(adapter, probe(true));
+        let bridge = tidebreak_harness::ToolBridgeSpec {
+            helper: PathBuf::from("/usr/local/bin/tidebreak-supervised-agent"),
+            socket: PathBuf::from("/workspace/.tidebreak/tool.sock"),
+        };
+        engine.spec.tool_bridge = Some(bridge.clone());
+        engine
+            .start_turn(request("use native tools"))
+            .await
+            .unwrap();
+        assert_eq!(captured.lock().unwrap().tool_bridge, Some(bridge));
+    }
+
+    #[tokio::test]
     async fn a_placeholder_credential_wires_the_engine_at_the_gateway() {
         let adapter = Arc::new(FakeAdapter::scripted(vec![ScriptedTurn {
             events: vec![completed_event()],
@@ -1352,6 +1379,7 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"p
             reasoning_effort: None,
             worktree: dir.path().to_owned(),
             allowed_read_roots: Vec::new(),
+            tool_bridge: None,
             trust_env: Vec::new(),
             gateway_inference: Some(GatewayInference {
                 placeholder_credential: SANDBOX_PLACEHOLDER_TOKEN.into(),

--- a/crates/tidebreak-supervised-agent/src/main.rs
+++ b/crates/tidebreak-supervised-agent/src/main.rs
@@ -149,7 +149,7 @@ async fn run_inputs(
         vec![workspace]
     };
 
-    let mut trust_env: Vec<(OsString, OsString)> = bootstrap
+    let trust_env: Vec<(OsString, OsString)> = bootstrap
         .trust
         .environment()
         .iter()
@@ -158,21 +158,7 @@ async fn run_inputs(
 
     let tool_bridge = if inputs.embedded_engine.is_some() {
         match tidebreak_supervised_agent::tool_bridge::LocalToolBridge::start(&workdir) {
-            Ok(bridge) => {
-                let helper = match std::env::current_exe() {
-                    Ok(path) => path,
-                    Err(error) => {
-                        eprintln!("could not locate native tool helper: {error}");
-                        return EXIT_CONTROL_FATAL;
-                    }
-                };
-                trust_env.push((
-                    "TIDEBREAK_TOOL_SOCKET".into(),
-                    bridge.socket_path().into_os_string(),
-                ));
-                trust_env.push(("TIDEBREAK_TOOL_HELPER".into(), helper.into_os_string()));
-                Some(bridge)
-            }
+            Ok(bridge) => Some(bridge),
             Err(error) => {
                 eprintln!("could not start native tool bridge: {error}");
                 return EXIT_CONTROL_FATAL;
@@ -189,6 +175,19 @@ async fn run_inputs(
             return EXIT_MISSING_INPUT;
         }
     };
+    let tool_bridge_spec = match &tool_bridge {
+        Some(bridge) => match std::env::current_exe() {
+            Ok(helper) => Some(tidebreak_harness::ToolBridgeSpec {
+                helper,
+                socket: bridge.socket_path(),
+            }),
+            Err(error) => {
+                eprintln!("could not locate native tool helper: {error}");
+                return EXIT_CONTROL_FATAL;
+            }
+        },
+        None => None,
+    };
     let engine = HarnessEngine::new(HarnessEngineSpec {
         apps,
         session_id,
@@ -199,6 +198,7 @@ async fn run_inputs(
         worktree: workdir.clone(),
         allowed_read_roots,
         trust_env,
+        tool_bridge: tool_bridge_spec,
         gateway_inference,
     });
 


### PR DESCRIPTION
Slack sandbox prompts advertise native repository and conversation tools, but engine launches stripped `TIDEBREAK_TOOL_HELPER` and `TIDEBREAK_TOOL_SOCKET` from the supervisor's environment. Agents could read the tool schemas but could not call the helper.

Pass the runtime-created executable and socket through a typed tool-bridge field. Every harness launch injects those trusted paths after its existing environment filter. Ambient Tidebreak variables remain filtered, and ordinary desktop sessions carry no supervised bridge.

Validation: a real shell-child regression exercises all four harness environment paths, verifies the helper and socket are present, and rejects ambient overrides and unrelated Tidebreak variables. The supervisor launch regression and all 127 supervised-agent tests pass. Scoped server/supervisor test compilation, all-target Clippy for the harness, supervisor and server core, cargo fmt, and git diff --check pass. Live Slack acceptance follows release and deployment.