### PR TITLE
fix(slack): accept fresh messages after empty queue recovery

### DIFF
--- a/crates/tidebreak-core/src/db/ops/code/queued.rs
+++ b/crates/tidebreak-core/src/db/ops/code/queued.rs
@@ -407,6 +407,40 @@ pub async fn queue_paused(store: &DbStore, owner: &OwnerId, session_id: SessionI
     )
 }
 
+/// Release a recovery pause only when no queued message needs review.
+/// Serialize with intake so a message accepted during recovery stays paused.
+/// Call only when recovery introduced the pause; preserve an existing pause.
+pub async fn resume_empty_recovered_queue(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+) -> Result<()> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_code_session_write_lock(&transaction, session_id).await? {
+        return Err(AgentError::Store(format!(
+            "code session {session_id} not found"
+        )));
+    }
+    let session = entities::session::Entity::find_by_id(session_id.0)
+        .filter(entities::session::Column::Owner.eq(owner.as_str()))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    if session.is_none() {
+        return Err(AgentError::Store(format!(
+            "code session {session_id} not found"
+        )));
+    }
+    if list_on(&transaction, owner, session_id).await?.is_empty() {
+        entities::setting::Entity::delete_by_id(queue_paused_setting(session_id))
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
+    }
+    transaction.commit().await.map_err(store_err)?;
+    Ok(())
+}
+
 /// Pause or release promotion for this session; queued rows stay put while
 /// paused. Refuses a session the owner does not hold, for the same reason
 /// [`queue_paused`] anchors on the session row.

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -4829,6 +4829,35 @@ async fn code_queue_reorders_stay_dense_and_the_cap_holds() {
 }
 
 #[tokio::test]
+async fn recovery_resumes_only_an_empty_queue_owned_by_the_caller() {
+    use crate::db::code::resume_empty_recovered_queue;
+    let (_dir, store, session_id, _turn) = seeded_session().await;
+    let owner = OwnerId::local();
+    set_queue_paused(&store, &owner, session_id, true)
+        .await
+        .unwrap();
+    let other = OwnerId::new("intruder").unwrap();
+    assert!(resume_empty_recovered_queue(&store, &other, session_id)
+        .await
+        .is_err());
+    assert!(queue_paused(&store, &owner, session_id).await.unwrap());
+    let row = enqueue_queued_turn(&store, &owner, &queued_message(session_id, "review first"))
+        .await
+        .unwrap();
+    resume_empty_recovered_queue(&store, &owner, session_id)
+        .await
+        .unwrap();
+    assert!(queue_paused(&store, &owner, session_id).await.unwrap());
+    delete_queued_turn(&store, &owner, session_id, row.id)
+        .await
+        .unwrap();
+    resume_empty_recovered_queue(&store, &owner, session_id)
+        .await
+        .unwrap();
+    assert!(!queue_paused(&store, &owner, session_id).await.unwrap());
+}
+
+#[tokio::test]
 async fn code_queue_pause_round_trips_and_an_ended_session_clears_its_rows() {
     let (_dir, store, session_id, _turn) = seeded_session().await;
     let owner = OwnerId::local();

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1553,6 +1553,113 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn slack_message_after_reap_starts_without_replaying_queued_work() {
+        for (pending, manual_pause) in [(false, false), (true, false), (false, true)] {
+            let dir = tempfile::tempdir().unwrap();
+            let (runtime, fake, owner, _) = runtime_with_remote(dir.path()).await;
+            let grant = tidebreak_core::CodeGrantId::new();
+            let (resolution, _) = runtime
+                .external_get_or_create(
+                    &owner,
+                    None,
+                    grant,
+                    "slack",
+                    "T1/C1/recovery",
+                    None,
+                    None,
+                    HarnessKind::ClaudeCode,
+                    session_settings(),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
+                panic!("expected creation");
+            };
+            let message = |event: &str| crate::code::runtime::ExternalMessage {
+                text: event.into(),
+                event_id: event.into(),
+                channel_ts: "1.0".into(),
+                actor: tidebreak_core::TurnActor::default(),
+                context: None,
+                steer: false,
+                expected_turn_id: None,
+                correlation_uuid: None,
+            };
+            runtime
+                .external_submit_message(&owner, grant, binding.session_id, message("start"))
+                .await
+                .unwrap();
+            if pending {
+                runtime
+                    .external_submit_message(
+                        &owner,
+                        grant,
+                        binding.session_id,
+                        message("old queued work"),
+                    )
+                    .await
+                    .unwrap();
+            }
+            let mut session = runtime
+                .get_session(&owner, binding.session_id)
+                .await
+                .unwrap();
+            crate::code::recovery::fence_session(
+                &runtime.db,
+                runtime.bus.as_ref(),
+                &mut session,
+                FenceReason::SandboxLost {
+                    detail: "idle timeout".into(),
+                },
+            )
+            .await
+            .unwrap();
+            if manual_pause {
+                runtime
+                    .set_queue_paused(&owner, session.id, true)
+                    .await
+                    .unwrap();
+            }
+            runtime.reap(&owner, session.id).await.unwrap();
+            assert_eq!(
+                fake.spawns.lock().unwrap().len(),
+                1,
+                "clearing a fault must not start work"
+            );
+            let result = runtime
+                .external_submit_message(&owner, grant, session.id, message("fresh retry"))
+                .await
+                .unwrap();
+            if pending || manual_pause {
+                assert!(matches!(result, ExternalMessageOutcome::Queued(_)));
+                assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+                assert!(
+                    runtime
+                        .list_queued_turns(&owner, session.id)
+                        .await
+                        .unwrap()
+                        .1
+                );
+            } else {
+                assert!(
+                    matches!(result, ExternalMessageOutcome::NewTurn(_)),
+                    "fresh input must start after clearing an empty queue: {result:?}"
+                );
+                assert_eq!(fake.spawns.lock().unwrap().len(), 2);
+                assert!(
+                    !runtime
+                        .list_queued_turns(&owner, session.id)
+                        .await
+                        .unwrap()
+                        .1
+                );
+            }
+        }
+    }
+
     /// Stop on a remote session sends an interrupt to the sandbox instead of
     /// looking for a host worker.
     #[tokio::test]

--- a/crates/tidebreak-server/src/code/runtime/auto_recovery.rs
+++ b/crates/tidebreak-server/src/code/runtime/auto_recovery.rs
@@ -228,6 +228,8 @@ impl CodeRuntime {
             return self.publish_recovery_blocker(session).await;
         };
 
+        let already_paused =
+            tidebreak_core::db::code::queue_paused(&self.db, &session.owner, session.id).await?;
         // A resumed worker normally drains its queue immediately. Recovery
         // never grants permission to run queued or interrupted work.
         tidebreak_core::db::code::set_queue_paused(&self.db, &session.owner, session.id, true)
@@ -245,6 +247,14 @@ impl CodeRuntime {
         };
         match result {
             Ok(recovered) => {
+                if !already_paused {
+                    tidebreak_core::db::code::resume_empty_recovered_queue(
+                        &self.db,
+                        &recovered.owner,
+                        recovered.id,
+                    )
+                    .await?;
+                }
                 // Preserve a manual pin. Otherwise show queued work that needs
                 // review, or let the composer accept a fresh message.
                 let queued = tidebreak_core::db::code::list_queued_turns(
@@ -835,6 +845,18 @@ mod remote_and_admission_tests {
             );
             assert_eq!(latest.stop_reason.as_deref(), Some(stop));
             assert_eq!(launches.load(Ordering::SeqCst), 0);
+            if recovered {
+                assert!(
+                    !tidebreak_core::db::code::queue_paused(
+                        &runtime.db,
+                        &session.owner,
+                        session.id,
+                    )
+                    .await
+                    .unwrap(),
+                    "an empty recovered queue must accept fresh Slack input"
+                );
+            }
             if !recovered {
                 assert!(matches!(
                     current.attention.state,

--- a/crates/tidebreak-server/src/code/runtime/turns.rs
+++ b/crates/tidebreak-server/src/code/runtime/turns.rs
@@ -847,8 +847,12 @@ impl CodeRuntime {
             .lock()
             .expect("recovery attempts")
             .remove(&id);
+        let already_paused = tidebreak_core::db::code::queue_paused(&self.db, owner, id).await?;
         tidebreak_core::db::code::set_queue_paused(&self.db, owner, id, true).await?;
         let result = self.reap_inner(owner, id).await;
+        if result.is_ok() && !already_paused {
+            tidebreak_core::db::code::resume_empty_recovered_queue(&self.db, owner, id).await?;
+        }
         if let Err(error) = &result {
             self.retain_failed_recovery(&session, error.message())
                 .await?;


### PR DESCRIPTION
Clearing a session fault leaves its queue paused. Slack records every incoming message in that queue, so the next message is accepted but never starts a sandbox.

After successful explicit or automatic recovery, release the pause only when recovery introduced it and the queue is empty. Check the queue under the same database lock used by message intake. Keep manually paused queues and queued work paused for review; clearing a fault does not start or replay work.

Validation: the Slack recovery regression passes for an empty queue, existing queued work, and a manual pause. All 13 automatic recovery tests pass. The storage regression verifies owner scope and preservation of queued work. Scoped Clippy, formatting, and `git diff --check` pass.

Live reproduction: the deployed Clear fault button succeeds, but the next message stays queued without creating a sandbox. A fresh test thread starts normally. This PR addresses that recovery gap; post-deployment validation remains required.