### PR TITLE
fix(slack): recover scratch sessions and report usable harness models

### DIFF
--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -382,14 +382,17 @@ fn state_token<'a>(
 
 /// A follow-up cannot authorize another budget after a spend stop. A failed
 /// checkout without a saved checkpoint cannot silently restart from the base.
-pub fn recovery_block(row: &CodeSessionIncarnation) -> Option<(&'static str, &'static str)> {
+pub fn recovery_block(
+    row: &CodeSessionIncarnation,
+    has_repository: bool,
+) -> Option<(&'static str, &'static str)> {
     row.sandbox_id.as_ref()?;
     match row.stop_reason.as_deref() {
         Some("ceiling_exceeded" | "spend_ceiling_exceeded") => Some((
             "sandbox_spend_exhausted",
             "This sandbox reached its spend ceiling. Queued follow-ups cannot start another sandbox with a fresh budget. Review its work and budget before explicitly starting a new session.",
         )),
-        Some("failed" | "expired") if row.last_wip_ref.is_none() => Some((
+        Some("failed" | "expired") if has_repository && row.last_wip_ref.is_none() => Some((
             "sandbox_checkpoint_missing",
             "This sandbox stopped without a saved checkpoint. Its work cannot be restored, so queued follow-ups will not restart from the repository base. Review the failure before explicitly starting a new session.",
         )),
@@ -734,7 +737,9 @@ impl RemoteDriver<'_> {
             if predecessor.sandbox_id.is_some() && !predecessor.terminal_events_journaled {
                 return Ok(RemoteTurnOutcome::FlushPending);
             }
-            if let Some((code, message)) = recovery_block(predecessor) {
+            if let Some((code, message)) =
+                recovery_block(predecessor, session.workspace_id.is_some())
+            {
                 refusal_notice(db, bus, session, message.to_owned(), message).await?;
                 return Ok(RemoteTurnOutcome::RecoveryBlocked {
                     code,
@@ -755,6 +760,9 @@ impl RemoteDriver<'_> {
             }
         }
         if current.is_some() {
+            if session.workspace_id.is_none() {
+                spawn_task.push_str("This conversation continues in a fresh sandbox. Temporary files from the previous sandbox are unavailable. Use saved conversation history and retrieve needed attachments again. Do not claim that previous temporary files were restored.\n\n");
+            }
             let history =
                 tidebreak_core::db::code::sandbox_resume_context(db, &owner, session.id).await?;
             if !history.is_empty() {
@@ -782,9 +790,8 @@ impl RemoteDriver<'_> {
             // Supervised answers live in the journal; a turn's narrative is
             // optional and often absent for external harnesses.
             let recent =
-                tidebreak_core::db::code::list_events(db, &owner, session.id, 0, 32).await?;
+                tidebreak_core::db::code::list_recent_events(db, &owner, session.id, 32).await?;
             let answers = recent
-                .events
                 .iter()
                 .filter_map(|entry| match &entry.event {
                     tidebreak_core::code::Event::AssistantMessage { text, .. } => {
@@ -793,7 +800,7 @@ impl RemoteDriver<'_> {
                     _ => None,
                 })
                 .collect::<Vec<_>>();
-            for (seq, text) in answers.iter().rev().take(4).rev() {
+            for (seq, text) in answers.iter().take(4).rev() {
                 let excerpt = text.chars().take(512).collect::<String>();
                 spawn_task.push_str(
                     &serde_json::json!({ "historical_assistant_event": seq, "excerpt": excerpt })
@@ -3158,6 +3165,103 @@ mod tests {
                 .await
                 .unwrap()
                 .is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn scratch_recovery_needs_no_git_checkpoint_but_preserves_spend_limits() {
+        for reason in [
+            "failed",
+            "expired",
+            "ceiling_exceeded",
+            "spend_ceiling_exceeded",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let (db, bus, _, _, _) = seed(dir.path()).await;
+            let mut session = super::super::fixtures::session_value();
+            session.workspace_id = None;
+            tidebreak_core::db::code::insert_session(&db, &session)
+                .await
+                .unwrap();
+            let mut prior = start_turn_row(
+                &db,
+                &bus,
+                &mut session,
+                1,
+                "Remember the prior request",
+                None,
+            )
+            .await
+            .unwrap();
+            prior.status = TurnStatus::Completed;
+            tidebreak_core::db::code::set_turn_narrative(
+                &db,
+                &session.owner,
+                prior.id,
+                "The prior result is saved",
+            )
+            .await
+            .unwrap();
+            prior.ended_at = Some(chrono::Utc::now());
+            save_turn(&db, &session.owner, &prior).await.unwrap();
+            for index in 0..40 {
+                tidebreak_core::db::code::append_event(
+                    &db,
+                    &session.owner,
+                    session.id,
+                    session.spawn_epoch,
+                    &tidebreak_core::Event::AssistantMessage {
+                        text: format!("Journal answer {index}"),
+                        parent_call_id: None,
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            let incarnation = super::super::fixtures::seeded_incarnation(&db, &session).await;
+            stop_incarnation(&db, &session.owner, incarnation, Some(reason))
+                .await
+                .unwrap();
+            mark_incarnation_terminal_events_journaled(&db, &session.owner, incarnation)
+                .await
+                .unwrap();
+            let fake = FakeProvisioner::default();
+            let settings = settings();
+            let driver = driver!(&db, &bus, &fake, &settings);
+            let outcome = driver
+                .submit_turn(&mut session, None, None, Some("scratch"), "Continue here")
+                .await
+                .unwrap();
+            if reason.contains("ceiling") {
+                assert!(matches!(
+                    outcome,
+                    RemoteTurnOutcome::RecoveryBlocked {
+                        code: "sandbox_spend_exhausted",
+                        ..
+                    }
+                ));
+                assert!(fake.spawns.lock().unwrap().is_empty());
+            } else {
+                assert!(matches!(outcome, RemoteTurnOutcome::Reincarnated { .. }));
+                let spawns = fake.spawns.lock().unwrap();
+                assert_eq!(spawns.len(), 1);
+                assert!(spawns[0].task.contains("Remember the prior request"));
+                assert!(spawns[0].task.contains("The prior result is saved"));
+                assert!(spawns[0].task.contains("Journal answer 39"));
+                assert!(!spawns[0].task.contains("Journal answer 0"));
+                assert!(
+                    spawns[0].task.find("Journal answer 36")
+                        < spawns[0].task.find("Journal answer 39")
+                );
+                assert!(spawns[0].repository.is_none());
+                assert!(spawns[0].repository_ref.is_none());
+                assert!(spawns[0]
+                    .task
+                    .contains("Temporary files from the previous sandbox are unavailable"));
+                assert!(spawns[0]
+                    .task
+                    .ends_with("Current user request:\nContinue here"));
+            }
         }
     }
 

--- a/crates/tidebreak-code-remote/src/ingest.rs
+++ b/crates/tidebreak-code-remote/src/ingest.rs
@@ -119,6 +119,20 @@ fn project_event(binding: &IngestBinding, kind: &str, payload: &Value) -> Projec
                 resume_ref: None,
             });
         }
+        "model_reported" => {
+            if let Some(model) = payload_str(payload, "model")
+                .map(str::trim)
+                .filter(|model| {
+                    !model.is_empty()
+                        && model.encode_utf16().count() <= 160
+                        && !model.chars().any(char::is_control)
+                })
+            {
+                out.journal.push(Event::ModelReported {
+                    model: model.to_owned(),
+                });
+            }
+        }
         "turn_started" => {
             if let Some(turn_id) = binding.turn_id {
                 out.journal.push(Event::TurnStarted { turn_id });
@@ -399,10 +413,81 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn observed_model_is_durable_scoped_and_does_not_change_the_selection() {
+        let dir = tempfile::tempdir().unwrap();
+        let (db, bus, session, _, _) = seed(dir.path()).await;
+        let incarnation = seeded_incarnation(&db, &session).await;
+        let b = binding(&session, incarnation);
+        let batch = read(
+            SandboxState::Running,
+            1,
+            vec![event(
+                1,
+                "model_reported",
+                json!({"model":"effective-model"}),
+            )],
+        );
+        ingest_events(&db, &bus, &b, &batch).await.unwrap();
+        ingest_events(&db, &bus, &b, &batch).await.unwrap();
+        // Unrelated later events must not hide the model on reconnect.
+        for _ in 0..150 {
+            tidebreak_core::db::code::append_event(
+                &db,
+                &b.owner,
+                b.session_id,
+                b.spawn_epoch,
+                &Event::AssistantDelta {
+                    text: "activity".into(),
+                },
+            )
+            .await
+            .unwrap();
+        }
+        assert_eq!(
+            tidebreak_core::db::code::latest_reported_model(&db, &b.owner, b.session_id)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("effective-model")
+        );
+        assert!(tidebreak_core::db::code::latest_reported_model(
+            &db,
+            &OwnerId::new("user:other").unwrap(),
+            b.session_id
+        )
+        .await
+        .unwrap()
+        .is_none());
+        let saved = get_session(&db, &b.owner, b.session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(saved.model, session.model);
+        let page = list_events(&db, &b.owner, b.session_id, 0, 200)
+            .await
+            .unwrap();
+        assert_eq!(
+            page.events
+                .iter()
+                .filter(|row| matches!(row.event, Event::ModelReported { .. }))
+                .count(),
+            1
+        );
+    }
+
     #[test]
     fn the_projection_maps_the_supervisor_vocabulary() {
         let session = session_value();
         let b = binding(&session, CodeIncarnationId::new());
+
+        for model in ["", "invalid\nmodel", "invalid\tmodel"] {
+            assert!(
+                project_event(&b, "model_reported", &json!({ "model": model }))
+                    .journal
+                    .is_empty()
+            );
+        }
 
         let started = project_event(&b, "turn_started", &json!({ "turn": 3 }));
         assert!(matches!(started.journal[0], Event::TurnStarted { .. }));

--- a/crates/tidebreak-core/fixtures/code-journal-events.json
+++ b/crates/tidebreak-core/fixtures/code-journal-events.json
@@ -162,5 +162,9 @@
   {
     "type": "compaction_finished",
     "compacted": true
+  },
+  {
+    "type": "model_reported",
+    "model": "effective-model"
   }
 ]

--- a/crates/tidebreak-core/src/chat_journal.rs
+++ b/crates/tidebreak-core/src/chat_journal.rs
@@ -280,6 +280,7 @@ pub fn chat_event(event: Event) -> Result<Option<AgentEvent>> {
         // chat lane never produces (a completion with no stop reason, a
         // steer with no message row, a failure with no kind).
         Event::SessionStarted { .. }
+        | Event::ModelReported { .. }
         | Event::TurnResumed { .. }
         | Event::AssistantMessage { .. }
         | Event::ToolCompleted { output: None, .. }

--- a/crates/tidebreak-core/src/code/event.rs
+++ b/crates/tidebreak-core/src/code/event.rs
@@ -580,6 +580,11 @@ pub enum Event {
         #[ts(optional)]
         resume_ref: Option<String>,
     },
+    /// The parent engine reports the model it uses, independent of the requested selection.
+    ModelReported {
+        /// Model identifier reported by the engine.
+        model: String,
+    },
     /// A user→engine turn has begun.
     TurnStarted {
         /// The turn being processed.
@@ -984,6 +989,7 @@ mod tests {
             Event::CompactionStarted => 22,
             Event::CompactionFinished { .. } => 23,
             Event::CredentialRefused { .. } => 24,
+            Event::ModelReported { .. } => 25,
         }
     }
 
@@ -1129,6 +1135,9 @@ mod tests {
             },
             Event::CompactionStarted,
             Event::CompactionFinished { compacted: true },
+            Event::ModelReported {
+                model: "effective-model".into(),
+            },
         ]
     }
 

--- a/crates/tidebreak-core/src/db/ops/code/journal.rs
+++ b/crates/tidebreak-core/src/db/ops/code/journal.rs
@@ -524,6 +524,38 @@ fn turn_is_reconstructable(turn_id: TurnId, events: &[SequencedEvent]) -> bool {
     true
 }
 
+/// The latest model the parent engine reports, without changing the requested model.
+pub async fn latest_reported_model(
+    store: &DbStore,
+    owner: &OwnerId,
+    session_id: SessionId,
+) -> Result<Option<String>> {
+    use sea_orm::{sea_query::Expr, DatabaseBackend};
+    let kind = match store.conn.get_database_backend() {
+        DatabaseBackend::Postgres => "event->>'type' = 'model_reported'",
+        _ => "json_extract(event, '$.type') = 'model_reported'",
+    };
+    let row = entities::event::Entity::find()
+        .filter(entities::event::Column::Owner.eq(owner.as_str()))
+        .filter(entities::event::Column::SessionId.eq(session_id.0))
+        .filter(Expr::cust(kind))
+        .order_by_desc(entities::event::Column::Seq)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(row.and_then(|row| {
+        row.event
+            .get("model")
+            .and_then(serde_json::Value::as_str)
+            .filter(|model| {
+                !model.trim().is_empty()
+                    && model.encode_utf16().count() <= 160
+                    && !model.chars().any(char::is_control)
+            })
+            .map(str::to_owned)
+    }))
+}
+
 /// Newest journal events for one session, newest first. Digests use this
 /// bounded tail to identify an unresolved top-level tool without replaying a
 /// long conversation on every updates-socket connection.

--- a/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
+++ b/crates/tidebreak-desktop/ui/src/code/CodeSessionReducer.ts
@@ -820,6 +820,7 @@ export function reduceCodeSessionEvent(
 
   switch (event.type) {
     case "session_started":
+    case "model_reported":
       // Session metadata already comes from the durable session snapshot.
       return { state, effects };
 

--- a/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.test.ts
@@ -1199,6 +1199,10 @@ describe("parseCodeEvent", () => {
       usage,
     });
     expect(
+      parseCodeEvent({ type: "model_reported", model: "claude-effective" }),
+    ).toEqual({ type: "model_reported", model: "claude-effective" });
+    expect(parseCodeEvent({ type: "model_reported", model: "\n" })).toBeNull();
+    expect(
       parseCodeEvent({
         type: "credential_refused",
         reason: "connection_ended",

--- a/crates/tidebreak-desktop/ui/src/code/parsers.ts
+++ b/crates/tidebreak-desktop/ui/src/code/parsers.ts
@@ -3799,6 +3799,18 @@ export function parseCodeEvent(value: unknown): CodeEvent | null {
           ? { resume_ref: value.resume_ref }
           : {}),
       };
+    case "model_reported":
+      if (
+        !onlyKeys<Extract<WireCodeEvent, { type: "model_reported" }>>(value, [
+          "type",
+          "model",
+        ]) ||
+        !nonEmptyLine(value.model) ||
+        value.model.length > 160
+      ) {
+        return null;
+      }
+      return { type: "model_reported", model: value.model };
     case "turn_started":
       if (
         !onlyKeys<Extract<WireCodeEvent, { type: "turn_started" }>>(value, [

--- a/crates/tidebreak-desktop/ui/src/generated/wire.ts
+++ b/crates/tidebreak-desktop/ui/src/generated/wire.ts
@@ -2107,7 +2107,11 @@ harness_version: string,
 /**
  * Engine-native resume token, when the stream reported one.
  */
-resume_ref?: string, } | { "type": "turn_started",
+resume_ref?: string, } | { "type": "model_reported",
+/**
+ * Model identifier reported by the engine.
+ */
+model: string, } | { "type": "turn_started",
 /**
  * The turn being processed.
  */

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-allow.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "e65cc2a8-e5db-4f07-8e58-219691c423b5"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "tool_started",
     "call_id": "toolu_01AccXU5wrjo1GDyiNaAGDXM",
     "name": "Write",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-deny-with-feedback.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "aa8bfc30-886d-4792-93f4-ce64c1cc00a5"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "tool_started",
     "call_id": "toolu_01Pwo7nMXPQZWnBMyeTuL8ts",
     "name": "Write",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-request.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/approval-request.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "e65cc2a8-e5db-4f07-8e58-219691c423b5"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "tool_started",
     "call_id": "toolu_01AccXU5wrjo1GDyiNaAGDXM",
     "name": "Write",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/image-input.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/image-input.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "f89fe270-751c-4956-8113-2c940d84a79b"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "assistant_delta",
     "text": "a red square"
   },

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/interrupt.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/interrupt.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "1ab03711-0488-40db-945a-21a95e9a8884"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "assistant_delta",
     "text": "This"
   },

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/permission-denied.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "135a02d7-ace6-479b-9a31-c3b305b7a50e"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "tool_started",
     "call_id": "toolu_01NHAnSCW3oCoKt9Y5yijZtC",
     "name": "Write",

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/plain-text.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "f89fe270-751c-4956-8113-2c940d84a79b"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "assistant_delta",
     "text": "hello from fixture"
   },

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/resume.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "f89fe270-751c-4956-8113-2c940d84a79b"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "assistant_delta",
     "text": "I repl"
   },

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/subagent-task.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/subagent-task.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "9f4a2c10-5a51-4a2e-9f6d-3f2c7f7a1b22"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "assistant_message",
     "text": "Delegating the search to a subagent."
   },

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/tool-use.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "341c3eb3-768b-4115-9e5c-712a4b6a75af"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "assistant_delta",
     "text": "This"
   },

--- a/crates/tidebreak-harness/fixtures/claude-code/2.1.233/two-turn.expected.json
+++ b/crates/tidebreak-harness/fixtures/claude-code/2.1.233/two-turn.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "f89fe270-751c-4956-8113-2c940d84a79b"
   },
   {
+    "type": "model_reported",
+    "model": "claude-sonnet-5"
+  },
+  {
     "type": "assistant_delta",
     "text": "one"
   },

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-approve.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "01a006c6-ac48-7982-82d8-b355ca4e102d"
   },
   {
+    "type": "model_reported",
+    "model": "gpt-5.6-luna"
+  },
+  {
     "type": "turn_started"
   },
   {

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/approval-deny.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "01a006c6-f970-7c32-87f2-1511e1be0f44"
   },
   {
+    "type": "model_reported",
+    "model": "gpt-5.6-luna"
+  },
+  {
     "type": "turn_started"
   },
   {

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/collab-agents.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/collab-agents.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "01a039e7-0dba-7020-b640-3ff5235158ac"
   },
   {
+    "type": "model_reported",
+    "model": "gpt-5.6-luna"
+  },
+  {
     "type": "turn_started"
   },
   {

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/interrupt.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/interrupt.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "01a006c7-84da-77e1-92e7-08a4f6ed2103"
   },
   {
+    "type": "model_reported",
+    "model": "gpt-5.6-luna"
+  },
+  {
     "type": "turn_started"
   },
   {

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/plain-text.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/plain-text.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "01a006c6-2f0c-7581-bb06-1057bf661e4f"
   },
   {
+    "type": "model_reported",
+    "model": "gpt-5.6-luna"
+  },
+  {
     "type": "turn_started"
   },
   {

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/resume.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "01a006c7-47f3-7ad3-8d77-65d5caba8441"
   },
   {
+    "type": "model_reported",
+    "model": "gpt-5.6-luna"
+  },
+  {
     "type": "turn_started"
   },
   {

--- a/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
+++ b/crates/tidebreak-harness/fixtures/codex/0.147.0/tool-use.expected.json
@@ -6,6 +6,10 @@
     "resume_ref": "01a006c6-6577-79f1-a3d9-e25433506368"
   },
   {
+    "type": "model_reported",
+    "model": "gpt-5.6-luna"
+  },
+  {
     "type": "turn_started"
   },
   {

--- a/crates/tidebreak-harness/src/claude/parse.rs
+++ b/crates/tidebreak-harness/src/claude/parse.rs
@@ -38,6 +38,7 @@ pub struct ClaudeStreamParser {
     /// assemble.
     open_blocks: HashMap<BlockKey, OpenToolCall>,
     emitted_session: bool,
+    reported_model: Option<String>,
 }
 
 /// Which content block a stream event belongs to.
@@ -140,21 +141,29 @@ impl ClaudeStreamParser {
         let subtype = value.get("subtype").and_then(Value::as_str).unwrap_or("");
         match subtype {
             "init" => {
+                if parent_call_id(value).is_some() {
+                    return Vec::new();
+                }
                 if let Some(session_id) = value.get("session_id").and_then(Value::as_str) {
                     self.resume_ref = Some(session_id.to_owned());
                 }
                 if let Some(version) = value.get("claude_code_version").and_then(Value::as_str) {
                     self.version = Some(version.to_owned());
                 }
+                let mut events = self.report_model(value.get("model"));
                 if self.emitted_session {
-                    return Vec::new();
+                    return events;
                 }
                 self.emitted_session = true;
-                vec![HarnessEvent::SessionStarted {
-                    harness_kind: HarnessKind::ClaudeCode,
-                    harness_version: self.version.clone().unwrap_or_else(|| "unknown".into()),
-                    resume_ref: self.resume_ref.clone(),
-                }]
+                events.insert(
+                    0,
+                    HarnessEvent::SessionStarted {
+                        harness_kind: HarnessKind::ClaudeCode,
+                        harness_version: self.version.clone().unwrap_or_else(|| "unknown".into()),
+                        resume_ref: self.resume_ref.clone(),
+                    },
+                );
+                events
             }
             "permission_denied" => {
                 let message = value
@@ -265,6 +274,9 @@ impl ClaudeStreamParser {
         // Every line a subagent produces carries the parent `Task` call's id
         // at the top level (decision 52); the parent's own lines say null.
         let parent = parent_call_id(value);
+        if parent.is_none() {
+            events.extend(self.report_model(value.pointer("/message/model")));
+        }
         let content = value
             .pointer("/message/content")
             .and_then(Value::as_array)
@@ -292,6 +304,27 @@ impl ClaudeStreamParser {
             }
         }
         events
+    }
+
+    fn report_model(&mut self, value: Option<&Value>) -> Vec<HarnessEvent> {
+        let Some(model) = value
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|model| {
+                !model.is_empty()
+                    && model.encode_utf16().count() <= 160
+                    && !model.chars().any(char::is_control)
+            })
+        else {
+            return Vec::new();
+        };
+        if self.reported_model.as_deref() == Some(model) {
+            return Vec::new();
+        }
+        self.reported_model = Some(model.to_owned());
+        vec![HarnessEvent::ModelReported {
+            model: model.to_owned(),
+        }]
     }
 
     fn parse_user(&mut self, value: &Value) -> Vec<HarnessEvent> {
@@ -734,6 +767,30 @@ fn bound(text: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reports_the_parent_model_without_borrowing_a_child_model() {
+        let out = ClaudeStreamParser::parse_ndjson(
+            r#"
+{"type":"system","subtype":"init","session_id":"parent","model":"claude-default"}
+{"type":"system","subtype":"init","session_id":"child","parent_tool_use_id":"child-task","model":"child-init-model"}
+{"type":"assistant","parent_tool_use_id":"child","message":{"model":"child-model","content":[]}}
+{"type":"assistant","message":{"model":"claude-default","content":[]}}
+{"type":"assistant","message":{"model":"claude-effective","content":[]}}
+{"type":"assistant","message":{"model":"invalid\nmodel","content":[]}}
+"#,
+        );
+        let models: Vec<_> = out
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                HarnessEvent::ModelReported { model } => Some(model.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(models, ["claude-default", "claude-effective"]);
+        assert_eq!(out.resume_ref.as_deref(), Some("parent"));
+    }
 
     /// `usage.iterations` is one entry per API call. Summing the turn totals
     /// counts the transcript once per call, so a three-call turn reads as

--- a/crates/tidebreak-harness/src/codex/parse.rs
+++ b/crates/tidebreak-harness/src/codex/parse.rs
@@ -43,6 +43,7 @@ pub struct CodexStreamParser {
     /// to `None` because their spawn ran on the parent thread.
     subagent_parents: HashMap<String, Option<String>>,
     emitted_session: bool,
+    reported_model: Option<String>,
     /// Child frames are accepted only while their parent turn is open.
     parent_turn_active: bool,
     /// Thread-wide counters at the start of the active turn.
@@ -761,7 +762,28 @@ impl CodexStreamParser {
         let method = self.outbound_methods.remove(&id).unwrap_or_default();
         let result = value.get("result").cloned().unwrap_or(Value::Null);
         match method.as_str() {
-            "thread/start" | "thread/resume" => self.emit_session_started(&result),
+            "thread/start" | "thread/resume" => {
+                let mut events = self.emit_session_started(&result);
+                // The response carries the resolved model; thread/started may arrive first.
+                if let Some(model) = result
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|model| {
+                        !model.is_empty()
+                            && model.encode_utf16().count() <= 160
+                            && !model.chars().any(char::is_control)
+                    })
+                {
+                    if self.reported_model.as_deref() != Some(model) {
+                        self.reported_model = Some(model.to_owned());
+                        events.push(HarnessEvent::ModelReported {
+                            model: model.to_owned(),
+                        });
+                    }
+                }
+                events
+            }
             "turn/start" => {
                 if let Some(turn_id) = result.pointer("/turn/id").and_then(Value::as_str) {
                     self.last_turn_id = Some(turn_id.to_owned());
@@ -1686,6 +1708,26 @@ mod tests {
             Some(HarnessEvent::TurnCompleted { .. })
         ));
         assert_eq!(out.resume_ref.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn reports_the_resolved_model_even_when_the_start_notification_arrives_first() {
+        let out = CodexStreamParser::parse_ndjson(
+            r#"
+{"dir":"in","msg":{"method":"thread/started","params":{"thread":{"id":"parent","cliVersion":"0.147.0"}}}}
+{"dir":"out","msg":{"id":1,"method":"thread/start","params":{}}}
+{"dir":"in","msg":{"id":1,"result":{"thread":{"id":"parent"},"model":"gpt-effective"}}}
+"#,
+        );
+        assert!(out.events.iter().any(|event| matches!(event,
+            HarnessEvent::ModelReported { model } if model == "gpt-effective")));
+        assert_eq!(
+            out.events
+                .iter()
+                .filter(|event| matches!(event, HarnessEvent::SessionStarted { .. }))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/tidebreak-harness/src/lib.rs
+++ b/crates/tidebreak-harness/src/lib.rs
@@ -158,6 +158,11 @@ pub enum HarnessEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         resume_ref: Option<String>,
     },
+    /// The parent engine reports the model it uses, independent of the requested selection.
+    ModelReported {
+        /// Model identifier reported by the engine.
+        model: String,
+    },
     /// A user turn has begun on the engine side.
     TurnStarted,
     /// A chunk of assistant text.

--- a/crates/tidebreak-server-api/fixtures/code-frames.json
+++ b/crates/tidebreak-server-api/fixtures/code-frames.json
@@ -1143,6 +1143,17 @@
   },
   {
     "kind": "event_frame",
+    "name": "event: model_reported",
+    "value": {
+      "event": {
+        "model": "selected-model",
+        "type": "model_reported"
+      },
+      "seq": 67
+    }
+  },
+  {
+    "kind": "event_frame",
     "name": "event: harness_notice",
     "value": {
       "event": {

--- a/crates/tidebreak-server-api/src/routes/code/external.rs
+++ b/crates/tidebreak-server-api/src/routes/code/external.rs
@@ -1043,6 +1043,19 @@ async fn external_session_model_display_name(
     grant: &CodeExternalGrant,
     session: &tidebreak_core::Session,
 ) -> Option<String> {
+    if !session.harness_kind.is_in_process() {
+        if let Some(runtime) = state.code.as_ref() {
+            if let Ok(Some(model)) = tidebreak_core::db::code::latest_reported_model(
+                &runtime.db,
+                &grant.owner,
+                session.id,
+            )
+            .await
+            {
+                return Some(model);
+            }
+        }
+    }
     let selection = session.model.as_deref()?;
     if !session.harness_kind.is_in_process() {
         return Some(selection.to_owned());

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -530,14 +530,7 @@ impl crate::obo_gateway::GitCredentialLender for LendingFake {
 #[tokio::test]
 async fn a_sessions_git_borrows_the_persons_credential_from_the_loopback_route() {
     let lender = Arc::new(LendingFake::new());
-    let gateway = Arc::new(
-        crate::obo_gateway::OboGateway::new(
-            "https://gateway.example",
-            "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed".to_owned(),
-        )
-        .unwrap(),
-    );
-    let relay = Arc::new(crate::code::harness_llm::HarnessLlmRelay::new(gateway));
+    let relay = Arc::new(crate::code::harness_llm::HarnessLlmRelay::keys_only());
     let (router, _fake, runtime, repo_id, _token, _dir) = external_app_built({
         let lender = lender.clone();
         let relay = relay.clone();
@@ -2816,15 +2809,7 @@ async fn a_refused_borrow_answers_the_helper_and_journals_the_reason() {
         ),
     ] {
         let lender = Arc::new(RefusingFake(refusal));
-        let gateway = Arc::new(
-            crate::obo_gateway::OboGateway::new(
-                "https://gateway.example",
-                "tidebreak:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed"
-                    .to_owned(),
-            )
-            .unwrap(),
-        );
-        let relay = Arc::new(crate::code::harness_llm::HarnessLlmRelay::new(gateway));
+        let relay = Arc::new(crate::code::harness_llm::HarnessLlmRelay::keys_only());
         let (router, _fake, runtime, repo_id, _token, _dir) = external_app_built({
             let lender = lender.clone();
             let relay = relay.clone();

--- a/crates/tidebreak-server-api/src/tests/code_external.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external.rs
@@ -902,6 +902,235 @@ async fn web_follow_ups_and_recovery_keep_a_slack_session_in_its_sandbox() {
         .any(|message| message.interrupt));
 }
 
+/// Exercise the adapter's HTTP and replay routes after the real driver observes
+/// a stopped lease, including Clear fault and the next Slack message.
+#[tokio::test]
+async fn slack_recovery_http_delivers_scratch_answers_and_preserves_repository_and_spend_gates() {
+    for (repository, state, goodbye, may_continue) in [
+        (false, SandboxState::Failed, false, true),
+        (false, SandboxState::Failed, true, true),
+        (false, SandboxState::CeilingExceeded, false, false),
+        (true, SandboxState::Failed, false, false),
+    ] {
+        let (router, fake, runtime, repo, token, _dir) = external_app_with_token().await;
+        let addr = serve(router).await;
+        let client = reqwest::Client::new();
+        let owner = OwnerId::local();
+        let (_, pair) = runtime
+            .mint_adapter_grant(&owner, "slack", "U-recovery", "T1")
+            .await
+            .unwrap();
+        let create = client
+            .post(format!("http://{addr}/external/code/sessions"))
+            .bearer_auth(&pair.token)
+            .json(&serde_json::json!({
+                "external_key": "T1/C-recovery/1.1", "harness": "claude_code",
+                "repo_id": if repository { Some(repo) } else { None },
+            }))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+        let created: serde_json::Value = create.json().await.unwrap();
+        let id: tidebreak_core::SessionId =
+            serde_json::from_value(created["session_id"].clone()).unwrap();
+        let path = format!("http://{addr}/external/code/sessions/{id}");
+        let message = |event: &str| {
+            serde_json::json!({
+                "event_id": event, "text": event, "channel_ts": "2.1",
+            })
+        };
+        client
+            .post(format!("{path}/messages"))
+            .bearer_auth(&pair.token)
+            .json(&message("original task"))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+        assert_eq!(fake.spawns.lock().unwrap().len(), 1);
+        let event = |seq, kind: &str, payload| SandboxEvent {
+            seq,
+            kind: kind.into(),
+            payload,
+            created_at: String::new(),
+        };
+        let mut events = vec![
+            event(1, "turn_started", serde_json::json!({"turn": 1})),
+            event(
+                2,
+                "assistant_record",
+                serde_json::json!({"body": "Saved first answer"}),
+            ),
+            event(
+                3,
+                "turn_completed",
+                serde_json::json!({"turn": 1, "exit_code": 0}),
+            ),
+        ];
+        if goodbye {
+            events.push(event(
+                4,
+                "supervisor_stopped",
+                serde_json::json!({"reason": "idle_ceiling"}),
+            ));
+        }
+        fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+            sandbox_id: "sb-ext".into(),
+            state,
+            latest_event_seq: events.last().unwrap().seq,
+            events,
+        });
+        let mut session = runtime.get_session(&owner, id).await.unwrap();
+        runtime
+            .remote_sessions()
+            .unwrap()
+            .driver(&runtime.db, runtime.bus.as_ref())
+            .pump(&mut session, 0)
+            .await
+            .unwrap();
+        if !goodbye {
+            assert_eq!(session.lifecycle, tidebreak_core::SessionLifecycle::Fenced);
+            let clear = client
+                .post(format!("{path}/reap"))
+                .bearer_auth(&pair.token)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                clear.status(),
+                reqwest::StatusCode::OK,
+                "{}",
+                clear.text().await.unwrap()
+            );
+        }
+        let retry = client
+            .post(format!("{path}/messages"))
+            .bearer_auth(&pair.token)
+            .json(&message("fresh retry"))
+            .send()
+            .await
+            .unwrap();
+        let retry_status = retry.status();
+        let retry: serde_json::Value = retry.json().await.unwrap();
+        assert!(retry_status.is_success(), "{retry}");
+        if !may_continue {
+            assert_eq!(
+                fake.spawns.lock().unwrap().len(),
+                1,
+                "a stopped repository or spend limit cannot buy another sandbox"
+            );
+            assert!(runtime.list_queued_turns(&owner, id).await.unwrap().1);
+            let events = tidebreak_core::db::code::list_events(&runtime.db, &owner, id, 0, 100)
+                .await
+                .unwrap();
+            let refusal = if repository {
+                "without a saved checkpoint"
+            } else {
+                "reached its spend ceiling"
+            };
+            assert!(events.events.iter().any(|row| matches!(
+                &row.event, tidebreak_core::Event::HarnessNotice { message, .. } if message.contains(refusal)
+            )), "the refusal must explain the retained queue");
+            continue;
+        }
+        assert_eq!(fake.spawns.lock().unwrap().len(), 2, "{retry}");
+        assert!(runtime
+            .list_queued_turns(&owner, id)
+            .await
+            .unwrap()
+            .0
+            .is_empty());
+        assert!(fake.spawns.lock().unwrap()[1]
+            .task
+            .contains("Saved first answer"));
+        let duplicate: serde_json::Value = client
+            .post(format!("{path}/messages"))
+            .bearer_auth(&pair.token)
+            .json(&message("fresh retry"))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(
+            duplicate, retry,
+            "Slack retries must return the existing receipt"
+        );
+        assert_eq!(fake.spawns.lock().unwrap().len(), 2);
+
+        fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+            sandbox_id: "sb-ext".into(),
+            state: SandboxState::Running,
+            latest_event_seq: 3,
+            events: vec![
+                event(1, "turn_started", serde_json::json!({"turn": 1})),
+                event(
+                    2,
+                    "assistant_record",
+                    serde_json::json!({"body": "HTTP-RECOVERY-OK"}),
+                ),
+                event(
+                    3,
+                    "turn_completed",
+                    serde_json::json!({"turn": 1, "exit_code": 0}),
+                ),
+            ],
+        });
+        let mut session = runtime.get_session(&owner, id).await.unwrap();
+        runtime
+            .remote_sessions()
+            .unwrap()
+            .driver(&runtime.db, runtime.bus.as_ref())
+            .pump(&mut session, 0)
+            .await
+            .unwrap();
+        assert_eq!(session.lifecycle, tidebreak_core::SessionLifecycle::Idle);
+        assert!(!runtime.has_worker(id));
+        let web: serde_json::Value = client
+            .get(format!("http://{addr}/sessions/{id}"))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(web["id"], id.to_string());
+        assert_eq!(web["execution_location"], "sandbox");
+        assert!(web["workspace_id"].is_null());
+
+        let mut request = format!("ws://{addr}/external/code/sessions/{id}/events")
+            .into_client_request()
+            .unwrap();
+        request.headers_mut().insert(
+            "Authorization",
+            format!("Bearer {}", pair.token).parse().unwrap(),
+        );
+        let (mut socket, _) = connect_async(request).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let frame = socket.next().await.unwrap().unwrap();
+                if frame
+                    .to_text()
+                    .is_ok_and(|text| text.contains("HTTP-RECOVERY-OK"))
+                {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("Slack event replay must deliver the recovered answer");
+    }
+}
+
 /// A configured runtime places an external session in the sandbox and leaves
 /// a desktop session on the same app on the machine, with a host worktree.
 #[tokio::test]

--- a/crates/tidebreak-server-api/src/tests/code_external_model.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external_model.rs
@@ -96,16 +96,26 @@ async fn model_gateway(empty_catalog: bool) -> (String, GatewayCalls) {
         )
         .route(
             "/compat/anthropic/v1/models",
-            get(|headers: HeaderMap| async move {
+            get(|State(calls): State<GatewayCalls>, headers: HeaderMap| async move {
                 assert!(headers[header::AUTHORIZATION].to_str().unwrap().ends_with(DELEGATED));
-                Json(serde_json::json!({"data": [{"id":"compat-anthropic-alias"}]}))
+                let data = if calls.empty_catalog.load(Ordering::SeqCst) {
+                    vec![]
+                } else {
+                    vec![serde_json::json!({"id":"compat-anthropic-alias"})]
+                };
+                Json(serde_json::json!({"data": data}))
             }),
         )
         .route(
             "/compat/openai/v1/models",
-            get(|headers: HeaderMap| async move {
+            get(|State(calls): State<GatewayCalls>, headers: HeaderMap| async move {
                 assert!(headers[header::AUTHORIZATION].to_str().unwrap().ends_with(DELEGATED));
-                Json(serde_json::json!({"data": [{"id":"compat-openai-alias"}]}))
+                let data = if calls.empty_catalog.load(Ordering::SeqCst) {
+                    vec![]
+                } else {
+                    vec![serde_json::json!({"id":"compat-openai-alias"})]
+                };
+                Json(serde_json::json!({"data": data}))
             }),
         )
         .route(
@@ -802,4 +812,72 @@ async fn channel_sandbox_catalog_uses_grant_without_local_cli_and_rejects_other_
     )
     .await
     .is_err());
+}
+
+#[tokio::test]
+async fn sandbox_defaults_resolve_the_grants_model_for_http_and_direct_child_creation() {
+    let fixture = fixture_with_channel_runtime(false, true).await;
+    let (status, created) = post_external(
+        &fixture,
+        "/external/code/sessions",
+        serde_json::json!({
+            "external_key":"T1/C1/default-model", "channel_id":"C1"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+    assert_eq!(created["model"], "compat-openai-alias");
+    let (resolution, _) = fixture
+        .runtime
+        .external_get_or_create(
+            &fixture.grant.owner,
+            None,
+            fixture.grant.id,
+            "slack",
+            "child/default-model",
+            None,
+            None,
+            tidebreak_core::HarnessKind::Codex,
+            crate::code::runtime::NewSessionSettings::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
+        panic!("a direct child creation must create a session");
+    };
+    let session = fixture
+        .runtime
+        .get_session(&fixture.grant.owner, binding.session_id)
+        .await
+        .unwrap();
+    assert_eq!(session.model.as_deref(), Some("compat-openai-alias"));
+    assert!(fixture
+        .calls
+        .exchanges
+        .lock()
+        .unwrap()
+        .iter()
+        .all(|token| token == DELEGATED));
+}
+
+#[tokio::test]
+async fn sandbox_without_granted_models_refuses_before_creating_a_session() {
+    let fixture = fixture_with_channel_runtime(true, true).await;
+    let (status, response) = post_external(
+        &fixture,
+        "/external/code/sessions",
+        serde_json::json!({
+            "external_key":"T1/C1/no-model", "channel_id":"C1"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{response}");
+    assert!(fixture
+        .runtime
+        .list_sessions(&fixture.grant.owner)
+        .await
+        .unwrap()
+        .is_empty());
 }

--- a/crates/tidebreak-server-api/src/tests/code_external_model.rs
+++ b/crates/tidebreak-server-api/src/tests/code_external_model.rs
@@ -710,6 +710,58 @@ async fn external_snapshot_labels_the_saved_model_after_channel_default_changes(
 }
 
 #[tokio::test]
+async fn external_snapshot_reports_the_observed_model_without_changing_the_selection() {
+    use futures::StreamExt;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    let fixture = fixture_with_channel_runtime(false, true).await;
+    let (status, created) = post_external(
+        &fixture,
+        "/external/code/sessions",
+        serde_json::json!({
+            "external_key":"T1/C1/observed", "channel_id":"C1"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+    let session_id: SessionId = serde_json::from_value(created["session_id"].clone()).unwrap();
+    let session = fixture
+        .runtime
+        .get_session(&fixture.grant.owner, session_id)
+        .await
+        .unwrap();
+    assert_eq!(session.harness_kind, tidebreak_core::HarnessKind::Codex);
+    tidebreak_core::db::code::append_event(
+        &fixture.runtime.db,
+        &fixture.grant.owner,
+        session_id,
+        session.spawn_epoch,
+        &tidebreak_core::Event::ModelReported {
+            model: "gpt-effective".into(),
+        },
+    )
+    .await
+    .unwrap();
+    let address = super::code::serve(fixture.router.clone()).await;
+    let mut request = format!("ws://{address}/external/code/sessions/{session_id}/events")
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        header::AUTHORIZATION,
+        format!("Bearer {}", fixture.bearer).parse().unwrap(),
+    );
+    let (mut socket, _) = tokio_tungstenite::connect_async(request).await.unwrap();
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(5), socket.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let frame: serde_json::Value = serde_json::from_str(frame.to_text().unwrap()).unwrap();
+    assert_eq!(frame["snapshot"]["model_display_name"], "gpt-effective");
+    assert_eq!(frame["snapshot"]["model"], created["model"]);
+    socket.close(None).await.unwrap();
+}
+
+#[tokio::test]
 async fn channel_sandbox_catalog_uses_grant_without_local_cli_and_rejects_other_engines() {
     use axum::extract::FromRequestParts;
     let fixture = fixture_with_channel_runtime(false, true).await;

--- a/crates/tidebreak-server-api/src/wire_code_fixtures.rs
+++ b/crates/tidebreak-server-api/src/wire_code_fixtures.rs
@@ -940,6 +940,15 @@ fn event_frames() -> Vec<Fixture> {
             ),
         ),
         (
+            "event: model_reported",
+            frame(
+                67,
+                Event::ModelReported {
+                    model: "selected-model".to_owned(),
+                },
+            ),
+        ),
+        (
             "event: harness_notice",
             frame(
                 54,

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -495,12 +495,16 @@ mod tests {
             arguments: &SpawnArguments,
         ) -> Result<SandboxLease, RemoteSandboxError> {
             wait_for_provision_gate(&self.spawn_gate).await;
-            self.spawns.lock().unwrap().push(arguments.clone());
+            let sandbox_id = {
+                let mut spawns = self.spawns.lock().unwrap();
+                spawns.push(arguments.clone());
+                format!("sb-{}", spawns.len())
+            };
             if let Some(error) = self.spawn_errors.lock().unwrap().pop_front() {
                 return Err(error);
             }
             Ok(SandboxLease {
-                sandbox_id: "sb-1".to_owned(),
+                sandbox_id,
                 state: SandboxState::Pending,
                 latest_event_seq: 0,
                 expires_in_seconds: 7200,
@@ -1607,16 +1611,45 @@ mod tests {
                 .get_session(&owner, binding.session_id)
                 .await
                 .unwrap();
-            crate::code::recovery::fence_session(
-                &runtime.db,
-                runtime.bus.as_ref(),
-                &mut session,
-                FenceReason::SandboxLost {
-                    detail: "idle timeout".into(),
-                },
-            )
-            .await
-            .unwrap();
+            // Reproduce the real idle-expiry path. The prior implementation
+            // reaped an active lease, which hid the stopped-checkpoint refusal.
+            fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                sandbox_id: "sb-1".into(),
+                state: SandboxState::Failed,
+                latest_event_seq: 4,
+                events: vec![
+                    event(1, "turn_started", serde_json::json!({ "turn": 1 })),
+                    event(
+                        2,
+                        "assistant_record",
+                        serde_json::json!({ "body": "Previous answer" }),
+                    ),
+                    event(
+                        3,
+                        "turn_completed",
+                        serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                    ),
+                    event(4, "failed", serde_json::json!({ "reason": "idle_ceiling" })),
+                ],
+            });
+            runtime
+                .remote_sessions()
+                .unwrap()
+                .driver(&runtime.db, runtime.bus.as_ref())
+                .pump(&mut session, 0)
+                .await
+                .unwrap();
+            assert_eq!(session.lifecycle, SessionLifecycle::Fenced);
+            runtime.recover().await.unwrap();
+            assert_eq!(
+                runtime
+                    .get_session(&owner, session.id)
+                    .await
+                    .unwrap()
+                    .lifecycle,
+                SessionLifecycle::Fenced,
+                "automatic recovery cannot accept missing output"
+            );
             if manual_pause {
                 runtime
                     .set_queue_paused(&owner, session.id, true)
@@ -1648,7 +1681,86 @@ mod tests {
                     matches!(result, ExternalMessageOutcome::NewTurn(_)),
                     "fresh input must start after clearing an empty queue: {result:?}"
                 );
-                assert_eq!(fake.spawns.lock().unwrap().len(), 2);
+                {
+                    let spawns = fake.spawns.lock().unwrap();
+                    assert_eq!(spawns.len(), 2);
+                    assert!(spawns[1].repository.is_none());
+                    assert!(spawns[1].task.contains("Previous answer"));
+                    assert!(spawns[1]
+                        .task
+                        .contains("Temporary files from the previous sandbox are unavailable"));
+                }
+                let replay = runtime
+                    .external_submit_message(&owner, grant, session.id, message("fresh retry"))
+                    .await
+                    .unwrap();
+                let (
+                    ExternalMessageOutcome::NewTurn(first),
+                    ExternalMessageOutcome::NewTurn(replay),
+                ) = (result, replay)
+                else {
+                    panic!("expected the same accepted turn");
+                };
+                assert_eq!(first.id, replay.id);
+                assert_eq!(
+                    fake.spawns.lock().unwrap().len(),
+                    2,
+                    "duplicate Slack input must not respawn"
+                );
+
+                // Recreate the server over its durable database before ingesting
+                // the answer. The replacement sandbox starts its own sequence.
+                let resumed = CodeRuntime::new(
+                    runtime.db.clone(),
+                    dir.path().to_path_buf(),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .with_remote_sessions(RemoteSessions::new(fake.clone(), settings()));
+                resumed.recover().await.unwrap();
+                fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                    sandbox_id: "sb-2".into(),
+                    state: SandboxState::Running,
+                    latest_event_seq: 3,
+                    events: vec![
+                        event(1, "turn_started", serde_json::json!({ "turn": 1 })),
+                        event(
+                            2,
+                            "assistant_record",
+                            serde_json::json!({ "body": "RECOVERY-OK" }),
+                        ),
+                        event(
+                            3,
+                            "turn_completed",
+                            serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                        ),
+                    ],
+                });
+                let mut session = resumed.get_session(&owner, session.id).await.unwrap();
+                resumed
+                    .remote_sessions()
+                    .unwrap()
+                    .driver(&resumed.db, resumed.bus.as_ref())
+                    .pump(&mut session, 0)
+                    .await
+                    .unwrap();
+                let completed = latest_turn(&resumed.db, &owner, session.id)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(completed.id, first.id);
+                assert_eq!(completed.status, TurnStatus::Completed);
+                let events =
+                    tidebreak_core::db::code::list_events(&resumed.db, &owner, session.id, 0, 100)
+                        .await
+                        .unwrap();
+                assert_eq!(events.events.iter().filter(|row| matches!(
+                    &row.event, tidebreak_core::Event::AssistantMessage { text, .. } if text == "RECOVERY-OK"
+                )).count(), 1, "the recovered answer must be available to Slack and web replay");
                 assert!(
                     !runtime
                         .list_queued_turns(&owner, session.id)

--- a/crates/tidebreak-server/src/code/runtime/auto_recovery.rs
+++ b/crates/tidebreak-server/src/code/runtime/auto_recovery.rs
@@ -156,9 +156,10 @@ impl CodeRuntime {
                         if row.state == IncarnationState::Stopped
                             && row.terminal_events_journaled =>
                     {
-                        if let Some((_, message)) =
-                            crate::code::remote::driver::recovery_block(&row)
-                        {
+                        if let Some((_, message)) = crate::code::remote::driver::recovery_block(
+                            &row,
+                            session.workspace_id.is_some(),
+                        ) {
                             session.fence_reason = Some(FenceReason::IncarnationUnresolved {
                                 detail: message.into(),
                             });
@@ -780,9 +781,11 @@ mod remote_and_admission_tests {
     };
 
     #[tokio::test]
-    async fn automatic_remote_recovery_preserves_output_checkpoint_and_spend_gates() {
+    async fn automatic_scratch_recovery_preserves_output_and_spend_gates() {
         for (stop, checkpoint, terminal, recovered) in [
-            ("failed", None, true, false),
+            ("failed", None, true, true),
+            ("expired", None, true, true),
+            ("failed", None, false, false),
             ("ceiling_exceeded", Some("refs/heads/wip"), true, false),
             ("expired", Some("refs/heads/wip"), false, false),
             ("expired", Some("refs/heads/wip"), true, true),

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -377,7 +377,10 @@ impl CodeRuntime {
         {
             let listings = match delegated.as_ref() {
                 Some(gateway) => Some(gateway.compat_listings(owner).await?),
-                None => match self.harness_llm() {
+                None => match self
+                    .harness_llm()
+                    .filter(|relay| relay.forwards_inference())
+                {
                     Some(relay) => Some(relay.listings(owner).await?),
                     None => None,
                 },

--- a/crates/tidebreak-server/src/code/runtime/remote.rs
+++ b/crates/tidebreak-server/src/code/runtime/remote.rs
@@ -371,6 +371,26 @@ impl CodeRuntime {
                 identity,
             ));
         }
+        let mut settings = settings;
+        if location == ExecutionLocation::Sandbox
+            && matches!(harness, HarnessKind::ClaudeCode | HarnessKind::Codex)
+        {
+            let listings = match delegated.as_ref() {
+                Some(gateway) => Some(gateway.compat_listings(owner).await?),
+                None => match self.harness_llm() {
+                    Some(relay) => Some(relay.listings(owner).await?),
+                    None => None,
+                },
+            };
+            if let Some((anthropic, openai)) = listings {
+                settings.model = Some(select_external_sandbox_model(
+                    harness,
+                    settings.model.as_deref(),
+                    anthropic,
+                    openai,
+                )?);
+            }
+        }
         let workspace_grant =
             tidebreak_core::db::code::get_external_grant(&self.db, owner, grant_id)
                 .await?
@@ -1559,5 +1579,92 @@ mod steer_target_tests {
         assert_eq!(native_steer_turn(4, 4).unwrap(), 1);
         assert_eq!(native_steer_turn(5, 4).unwrap(), 2);
         assert!(native_steer_turn(3, 4).is_err());
+    }
+}
+
+/// Match Gateway's sandbox bootstrap: keep an explicit granted model, otherwise
+/// select the first granted route for the engine's protocol before starting work.
+fn select_external_sandbox_model(
+    harness: HarnessKind,
+    selection: Option<&str>,
+    anthropic: tidebreak_core::Result<Vec<crate::obo_gateway::GatewayCompatModel>>,
+    openai: tidebreak_core::Result<Vec<crate::obo_gateway::GatewayCompatModel>>,
+) -> Result<String, ServerError> {
+    let models: Vec<String> = match harness {
+        HarnessKind::ClaudeCode => anthropic?.into_iter().map(|row| row.id).collect(),
+        HarnessKind::Codex => openai?.into_iter().map(|row| row.id).collect(),
+        HarnessKind::Internal | HarnessKind::Opencode | HarnessKind::Grok => Vec::new(),
+    };
+    match selection {
+        Some(selected) => models.into_iter().find(|model| model == selected),
+        None => models.into_iter().next(),
+    }
+    .ok_or_else(|| {
+        ServerError::conflict_kind(
+            "model_provider_unavailable",
+            "This Slack connection cannot use the selected harness model. Choose an available model in channel settings.",
+        )
+    })
+}
+
+#[cfg(test)]
+mod external_sandbox_model_tests {
+    use super::*;
+    use crate::obo_gateway::GatewayCompatModel;
+
+    fn models(ids: &[&str]) -> tidebreak_core::Result<Vec<GatewayCompatModel>> {
+        Ok(ids
+            .iter()
+            .map(|id| GatewayCompatModel {
+                id: (*id).to_owned(),
+                display_name: None,
+                family_default: false,
+            })
+            .collect())
+    }
+
+    #[test]
+    fn defaults_and_explicit_models_use_the_engines_granted_protocol() {
+        for (harness, expected) in [
+            (HarnessKind::ClaudeCode, "claude-granted"),
+            (HarnessKind::Codex, "gpt-granted"),
+        ] {
+            assert_eq!(
+                select_external_sandbox_model(
+                    harness,
+                    None,
+                    models(&["claude-granted"]),
+                    models(&["gpt-granted", "gpt-selected"])
+                )
+                .unwrap(),
+                expected
+            );
+        }
+        assert_eq!(
+            select_external_sandbox_model(
+                HarnessKind::Codex,
+                Some("gpt-selected"),
+                Err(tidebreak_core::AgentError::msg(
+                    "unused protocol is unavailable"
+                )),
+                models(&["gpt-granted", "gpt-selected"])
+            )
+            .unwrap(),
+            "gpt-selected"
+        );
+        assert!(select_external_sandbox_model(
+            HarnessKind::Codex,
+            Some("native-ungranted"),
+            models(&[]),
+            models(&["gpt-granted"])
+        )
+        .is_err());
+        assert!(select_external_sandbox_model(
+            HarnessKind::Codex,
+            None,
+            models(&["claude-granted"]),
+            models(&[])
+        )
+        .is_err());
     }
 }

--- a/crates/tidebreak-server/src/code/session_tools.rs
+++ b/crates/tidebreak-server/src/code/session_tools.rs
@@ -172,7 +172,8 @@ impl Tool for SessionTool {
                     "repository":{"type":"string","description":"GitHub owner/name"},
                     "task":{"type":"string","maxLength":16000},
                     "request_key":{"type":"string","maxLength":128,"description":"Stable key for this task, reused on retries."},
-                    "harness":{"type":"string","description":"Optional installed harness; defaults to claude_code."}
+                    "harness":{"type":"string","description":"Optional installed harness; defaults to claude_code."},
+                    "model":{"type":"string","maxLength":160,"description":"Optional model available to this connection. Without one, a managed sandbox uses its first granted model for the selected harness protocol."}
                 }),
                 json!(["repository", "task", "request_key"]),
             ),
@@ -434,7 +435,10 @@ impl SessionTool {
         };
         let settings = NewSessionSettings {
             permission_mode,
-            model: None,
+            model: args
+                .get("model")
+                .map(|_| text(args, "model", 160).map(str::to_owned))
+                .transpose()?,
             reasoning_effort: None,
             fast_mode: false,
             permission_mode_ceiling: None,
@@ -992,9 +996,13 @@ mod tests {
             .unwrap();
             for name in ["one", "two"] {
                 let view = tool.run(&runtime, &ToolCtx::without_private_scratch(conversation.id, None), json!({
-                    "repository":format!("acme/{name}"), "task":"Inspect the repository", "request_key":name
+                    "repository":format!("acme/{name}"), "task":"Inspect the repository", "request_key":name,
+                    "model":"explicit-child-model"
                 })).await.unwrap();
                 assert_eq!(view["location"], "sandbox");
+                let id = serde_json::from_value(view["session_id"].clone()).unwrap();
+                let child = runtime.get_session(&parent.owner, id).await.unwrap();
+                assert_eq!(child.model.as_deref(), Some("explicit-child-model"));
             }
         }
         for origin in ["acme/one", "acme/two"] {

--- a/crates/tidebreak-server/src/code/session_worker.rs
+++ b/crates/tidebreak-server/src/code/session_worker.rs
@@ -4200,6 +4200,7 @@ fn map_event(event: HarnessEvent, turn_id: Option<TurnId>) -> Option<Event> {
             harness_version,
             resume_ref,
         },
+        HarnessEvent::ModelReported { model } => Event::ModelReported { model },
         HarnessEvent::TurnStarted => Event::TurnStarted { turn_id: turn_id? },
         HarnessEvent::AssistantDelta { text } => Event::AssistantDelta { text },
         HarnessEvent::AssistantMessage {

--- a/crates/tidebreak-server/src/obo_gateway/external/tests.rs
+++ b/crates/tidebreak-server/src/obo_gateway/external/tests.rs
@@ -65,6 +65,14 @@ async fn gateway() -> (String, Gateway) {
                 "runtime_add_on": if body["audience"] == "runtime:tidebreak" { Some("tidebreak") } else { None },
             }))
         }))
+        .route("/compat/anthropic/v1/models", axum::routing::get(|headers: HeaderMap| async move {
+            assert!(headers.get("authorization").unwrap().to_str().unwrap().starts_with("Bearer llm-delegated-"));
+            Json(serde_json::json!({"data": [{"id": "claude-granted", "display_name": "Granted Claude"}]}))
+        }))
+        .route("/compat/openai/v1/models", axum::routing::get(|headers: HeaderMap| async move {
+            assert!(headers.get("authorization").unwrap().to_str().unwrap().starts_with("Bearer llm-delegated-"));
+            Json(serde_json::json!({"data": [{"id": "gpt-granted"}]}))
+        }))
         .route("/compat/openai/v1/responses", post(|headers: HeaderMap| async move {
             headers.get("authorization").unwrap().to_str().unwrap().to_owned()
         }))
@@ -434,6 +442,16 @@ async fn sandbox_admission_requires_durable_external_consent_before_accepting_wo
         panic!("completed consent must admit the session");
     };
     assert_eq!(state.mints.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        runtime
+            .get_session(&owner, binding.session_id)
+            .await
+            .unwrap()
+            .model
+            .as_deref(),
+        Some("claude-granted"),
+        "admission selects a model from the delegated catalog"
+    );
     tidebreak_core::db::code::record_external_message_with_context(
         &db,
         &owner,

--- a/crates/tidebreak-supervised-agent/src/drive.rs
+++ b/crates/tidebreak-supervised-agent/src/drive.rs
@@ -349,7 +349,9 @@ impl<E: Engine> Driver<E> {
             }
         }
 
+        let mut reported_model = None;
         let end = loop {
+            self.report_effective_model(handle.as_ref(), &mut reported_model);
             self.drain_steer_acks(handle.as_mut());
             let step = tokio::select! {
                 end = handle.wait() => TurnStep::End(end),
@@ -374,6 +376,7 @@ impl<E: Engine> Driver<E> {
         // Flush that evidence before reporting completion, then forget unresolved targets.
         self.drain_steer_acks(handle.as_mut());
         self.pending_steers.clear();
+        self.report_effective_model(handle.as_ref(), &mut reported_model);
         let record = handle.assistant_record();
         match end {
             TurnEnd::Interrupted => {
@@ -457,6 +460,17 @@ impl<E: Engine> Driver<E> {
         // Between turns the engine is momentarily idle; this poll flushes the
         // completion events and picks up anything the endpoint queued.
         self.poll(true).await
+    }
+
+    fn report_effective_model(&mut self, handle: &dyn TurnHandle, reported: &mut Option<String>) {
+        let Some(model) = handle.effective_model() else {
+            return;
+        };
+        if reported.as_ref() != Some(&model) {
+            self.outbox
+                .push("model_reported", serde_json::json!({ "model": model }));
+            *reported = Some(model);
+        }
     }
 
     /// Delivers pending inbox messages into a running turn, in order.
@@ -1024,6 +1038,7 @@ mod tests {
         ends: tokio::sync::Mutex<mpsc::UnboundedReceiver<TurnEnd>>,
         end_sender: mpsc::UnboundedSender<TurnEnd>,
         records: Mutex<VecDeque<Option<AssistantRecord>>>,
+        model: Mutex<Option<String>>,
     }
 
     #[derive(Clone)]
@@ -1046,6 +1061,7 @@ mod tests {
                     ends: tokio::sync::Mutex::new(ends),
                     end_sender,
                     records: Mutex::new(VecDeque::new()),
+                    model: Mutex::new(None),
                 }),
             }
         }
@@ -1119,6 +1135,10 @@ mod tests {
 
         fn drain_steer_acks(&mut self) -> Vec<uuid::Uuid> {
             std::mem::take(&mut *self.state.steer_acks.lock().unwrap())
+        }
+
+        fn effective_model(&self) -> Option<String> {
+            self.state.model.lock().unwrap().clone()
         }
 
         fn assistant_record(&mut self) -> Option<AssistantRecord> {
@@ -2078,6 +2098,33 @@ mod tests {
         let output_at = kinds.iter().position(|kind| kind == "task_output");
         let stopped_at = kinds.iter().position(|kind| kind == "supervisor_stopped");
         assert!(output_at < stopped_at);
+    }
+
+    #[tokio::test]
+    async fn reports_the_effective_model_before_completion() {
+        let (state, url) = start_supervisor().await;
+        let engine = MockEngine::new();
+        *engine.state.model.lock().unwrap() = Some("effective-model".into());
+        engine.finish(TurnEnd::Completed { success: true });
+        let run = tokio::spawn(driver(engine, &url, &inputs("turn", None)).run());
+        wait_for(&state, |supervisor| {
+            supervisor
+                .events
+                .iter()
+                .any(|(kind, _)| kind == "turn_completed")
+        })
+        .await;
+        assert_eq!(
+            event_payload(&state, "model_reported", 0)["model"],
+            "effective-model"
+        );
+        let kinds = event_kinds(&state);
+        assert!(
+            kinds.iter().position(|kind| kind == "model_reported")
+                < kinds.iter().position(|kind| kind == "turn_completed")
+        );
+        state.lock().unwrap().stop = Some("cancelled".into());
+        run.await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/crates/tidebreak-supervised-agent/src/engine.rs
+++ b/crates/tidebreak-supervised-agent/src/engine.rs
@@ -115,6 +115,11 @@ pub trait TurnHandle: Send {
     /// its own outcome.
     async fn interrupt(&mut self);
 
+    /// The parent engine's observed model, when its stream reports one.
+    fn effective_model(&self) -> Option<String> {
+        None
+    }
+
     /// The turn's assistant answer, when the engine surfaced one.
     ///
     /// Read once, after the turn ends: implementations may drain their

--- a/crates/tidebreak-supervised-agent/src/harness_engine.rs
+++ b/crates/tidebreak-supervised-agent/src/harness_engine.rs
@@ -391,6 +391,7 @@ enum Terminal {
 #[derive(Default)]
 struct TurnSink {
     last: Mutex<Option<Terminal>>,
+    model: Mutex<Option<String>>,
     assistant: Mutex<AssistantBuffer>,
     steer_acks: Mutex<Vec<uuid::Uuid>>,
 }
@@ -456,6 +457,9 @@ impl TurnSink {
 impl HarnessEventSink for TurnSink {
     async fn emit(&self, event: HarnessEvent) {
         match event {
+            HarnessEvent::ModelReported { model } => {
+                *self.model.lock().unwrap() = Some(model);
+            }
             HarnessEvent::TurnCompleted { .. } => {
                 *self.last.lock().unwrap() = Some(Terminal::Completed);
             }
@@ -606,6 +610,10 @@ impl TurnHandle for HarnessTurn {
 
     fn drain_steer_acks(&mut self) -> Vec<uuid::Uuid> {
         std::mem::take(&mut *self.sink.steer_acks.lock().unwrap())
+    }
+
+    fn effective_model(&self) -> Option<String> {
+        self.sink.model.lock().unwrap().clone()
     }
 
     fn assistant_record(&mut self) -> Option<AssistantRecord> {
@@ -1421,6 +1429,36 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"p
             text: text.to_owned(),
             parent_call_id: None,
         }
+    }
+
+    #[tokio::test]
+    async fn observed_model_survives_turn_boundaries_without_becoming_the_requested_model() {
+        let adapter = Arc::new(FakeAdapter::scripted(vec![
+            ScriptedTurn {
+                events: vec![
+                    HarnessEvent::ModelReported {
+                        model: "resolved-model".into(),
+                    },
+                    completed_event(),
+                ],
+                outcome: Ok(TurnOutcome::Clean),
+                waits_for_interrupt: false,
+            },
+            ScriptedTurn {
+                events: vec![completed_event()],
+                outcome: Ok(TurnOutcome::Clean),
+                waits_for_interrupt: false,
+            },
+        ]));
+        let mut engine = engine_over(adapter, probe(true));
+        engine.spec.model = None;
+        let mut first = engine.start_turn(request("first")).await.unwrap();
+        first.wait().await;
+        assert_eq!(first.effective_model().as_deref(), Some("resolved-model"));
+        let mut second = engine.start_turn(request("second")).await.unwrap();
+        second.wait().await;
+        assert_eq!(second.effective_model().as_deref(), Some("resolved-model"));
+        assert!(engine.spec.model.is_none());
     }
 
     #[tokio::test]

--- a/mobile/src/generated/wire.ts
+++ b/mobile/src/generated/wire.ts
@@ -2107,7 +2107,11 @@ harness_version: string,
 /**
  * Engine-native resume token, when the stream reported one.
  */
-resume_ref?: string, } | { "type": "turn_started",
+resume_ref?: string, } | { "type": "model_reported",
+/**
+ * Model identifier reported by the engine.
+ */
+model: string, } | { "type": "turn_started",
 /**
  * The turn being processed.
  */


### PR DESCRIPTION
Slack conversations without a repository cannot recover after their sandbox expires, and native harness sessions can omit their model or start with an unavailable bundled default. This change restores scratch sessions without a Git checkpoint, reports the model the harness uses, and selects a granted model before starting managed Claude Code or Codex sessions. Child-session tools also accept an explicit model. Standalone Git-only relays keep their existing behavior.

Recovery preserves repository checkpoint requirements, spend limits, terminal-output checks, manual pauses, and held backlog. A replacement scratch runtime receives bounded recent context and a notice that its previous temporary files are unavailable. Model reports remain separate from the saved selection, ignore nested Claude initialization, and persist through journal replay and Slack snapshots.

Validation: all 1,196 server-core library tests and all 713 server API library tests pass locally, with none skipped. Harness tests (417), remote runtime tests (55), remote service tests (26), and recovery tests (13) pass. Shared code-frame fixtures (5), CLI decoders (9), and web parsers (112) pass with the model-reported event. Targeted Clippy, rustfmt, and diff checks pass. The delegated-consent fixture verifies that model discovery uses delegated credentials and that admission persists the granted model. Live subscription billing and recovery verification follow deployment.