### PR TITLE
fix(slack): recover completed scratch sessions after idle shutdown

### DIFF
--- a/crates/tidebreak-code-remote/src/driver.rs
+++ b/crates/tidebreak-code-remote/src/driver.rs
@@ -1336,6 +1336,69 @@ impl RemoteDriver<'_> {
         Ok(report)
     }
 
+    /// Drain one bounded page for a stopped, fenced incarnation. Recovery
+    /// uses this after confirming an idle shutdown through fresh status.
+    /// This does not cancel, send messages, settle turns, or run host tools.
+    pub async fn drain_stopped_events(
+        &self,
+        session: &Session,
+        incarnation: tidebreak_core::CodeIncarnationId,
+    ) -> Result<bool, tidebreak_core::AgentError> {
+        let Some(row) = latest_incarnation(self.db, &session.owner, session.id).await? else {
+            return Ok(false);
+        };
+        if session.lifecycle != SessionLifecycle::Fenced
+            || row.id != incarnation
+            || row.state != IncarnationState::Stopped
+        {
+            return Ok(false);
+        }
+        let Some(sandbox_id) = row.sandbox_id.as_deref() else {
+            return Ok(false);
+        };
+        let read = self
+            .provisioner
+            .events(
+                &session.owner,
+                session.id,
+                sandbox_id,
+                EventCursor {
+                    after_seq: Some(row.events_cursor),
+                    limit: Some(100),
+                    wait_seconds: Some(0),
+                },
+            )
+            .await;
+        let Ok(read) = read else {
+            return Ok(false);
+        };
+        if read.sandbox_id != sandbox_id
+            || !read.state.is_terminal()
+            || read.events.iter().any(|event| {
+                matches!(
+                    event.kind.as_str(),
+                    "turn_started" | "turn_completed" | "turn_interrupted" | "host_tool_request"
+                )
+            })
+        {
+            return Ok(false);
+        }
+        let binding = IngestBinding {
+            owner: session.owner.clone(),
+            session_id: session.id,
+            spawn_epoch: session.spawn_epoch,
+            incarnation: row.id,
+            harness_kind: session.harness_kind,
+            turn_id: None,
+        };
+        ingest_events(self.db, self.bus, &binding, &read).await?;
+        Ok(latest_incarnation(self.db, &session.owner, session.id)
+            .await?
+            .is_some_and(|current| {
+                current.id == row.id && current.events_cursor >= read.latest_event_seq
+            }))
+    }
+
     /// Reap a fenced remote session: cancel whatever the environment still
     /// holds, close the incarnation record, and resolve the fence.
     ///

--- a/crates/tidebreak-core/src/db/ops/code/binding.rs
+++ b/crates/tidebreak-core/src/db/ops/code/binding.rs
@@ -225,6 +225,7 @@ async fn resolve_external_session_inner(
     context: Option<ExternalSessionChannelContext<'_>>,
 ) -> Result<ExternalSessionResolution> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    super::grant::acquire_external_grant_write_lock(&transaction, Some(owner), grant_id).await?;
     if let Some(hit) = entities::code_external_binding::Entity::find()
         .filter(entities::code_external_binding::Column::Owner.eq(owner.as_str()))
         .filter(entities::code_external_binding::Column::ChannelKind.eq(channel_kind))

--- a/crates/tidebreak-core/src/db/ops/code/grant.rs
+++ b/crates/tidebreak-core/src/db/ops/code/grant.rs
@@ -8,7 +8,9 @@
 //! discarded those tokens, so a replay is theft — revokes the grant in the
 //! same transaction that detects it.
 
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set, TransactionTrait,
+};
 
 use crate::code::{CodeExternalGrant, CodeGrantId, CodeGrantKind, GrantRotation};
 use crate::error::{AgentError, Result};
@@ -16,6 +18,26 @@ use crate::OwnerId;
 
 use super::super::super::{entities, store_err, DbStore};
 use super::super::agent_run::database_now;
+
+/// Take the writer before reading a grant or its bindings. SQLite cannot
+/// upgrade a read snapshot after another writer commits.
+pub(super) async fn acquire_external_grant_write_lock<C: ConnectionTrait>(
+    conn: &C,
+    owner: Option<&OwnerId>,
+    grant_id: CodeGrantId,
+) -> Result<()> {
+    let mut update = entities::code_external_grant::Entity::update_many()
+        .col_expr(
+            entities::code_external_grant::Column::Id,
+            sea_orm::sea_query::Expr::col(entities::code_external_grant::Column::Id),
+        )
+        .filter(entities::code_external_grant::Column::Id.eq(grant_id.0));
+    if let Some(owner) = owner {
+        update = update.filter(entities::code_external_grant::Column::Owner.eq(owner.as_str()));
+    }
+    update.exec(conn).await.map_err(store_err)?;
+    Ok(())
+}
 
 fn grant_from_model(model: entities::code_external_grant::Model) -> Result<CodeExternalGrant> {
     Ok(CodeExternalGrant {
@@ -271,6 +293,7 @@ pub async fn revoke_external_grant(
     reason: &str,
 ) -> Result<Option<CodeExternalGrant>> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_external_grant_write_lock(&transaction, Some(owner), grant_id).await?;
     let Some(row) = entities::code_external_grant::Entity::find_by_id(grant_id.0)
         .filter(entities::code_external_grant::Column::Owner.eq(owner.as_str()))
         .one(&transaction)
@@ -312,6 +335,7 @@ pub async fn revoke_external_grant_all_owners(
     reason: &str,
 ) -> Result<Option<CodeExternalGrant>> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_external_grant_write_lock(&transaction, None, grant_id).await?;
     let Some(row) = entities::code_external_grant::Entity::find_by_id(grant_id.0)
         .one(&transaction)
         .await

--- a/crates/tidebreak-core/src/db/tests/code.rs
+++ b/crates/tidebreak-core/src/db/tests/code.rs
@@ -8919,3 +8919,116 @@ async fn steer_recovery_delete_failure_rolls_back_without_poisoning_receipt() {
     assert_eq!(Some(rows[0].id), decision.retry_turn_id);
     assert_ne!(rows[0].id, original.id);
 }
+
+async fn external_mutation_waits_for_sqlite_writer(operation: &str) {
+    use sea_orm::{ActiveModelTrait, Set, TransactionTrait};
+    use std::time::Duration;
+
+    let (_dir, store) = super::temp_store_with_max_connections(4).await;
+    let store = std::sync::Arc::new(store);
+    let owner = OwnerId::local();
+    let grant = crate::db::code::mint_external_grant(
+        &store,
+        &owner,
+        crate::db::code::MintGrantSubject {
+            channel_kind: "slack",
+            external_identity: "U1",
+            workspace_identity: "T1",
+            kind: crate::code::CodeGrantKind::Person,
+        },
+        &fake_hash("writer-token"),
+        &fake_hash("writer-refresh"),
+    )
+    .await
+    .unwrap();
+    let (_, mut session) = external_pair(&owner, RepoId::new(), "writer-wait");
+    session.workspace_id = None;
+    let revoked_at = (operation != "create")
+        .then(|| chrono::DateTime::from_timestamp_millis(Utc::now().timestamp_millis()).unwrap());
+    let writer = store.conn.begin().await.unwrap();
+    entities::code_external_grant::ActiveModel {
+        id: Set(grant.id.0),
+        external_identity: Set("U1".to_owned()),
+        revoked_at: Set(revoked_at),
+        revoked_reason: Set((operation != "create").then(|| "first reason".to_owned())),
+        ..Default::default()
+    }
+    .update(&writer)
+    .await
+    .unwrap();
+    let task_store = store.clone();
+    let task_owner = owner.clone();
+    let operation = operation.to_owned();
+    let mut task = tokio::spawn(async move {
+        match operation.as_str() {
+            "create" => {
+                let result = crate::db::code::resolve_external_machine_session(
+                    &task_store,
+                    &task_owner,
+                    grant.id,
+                    "slack",
+                    "T1/C1/writer-wait",
+                    &session,
+                )
+                .await?;
+                assert!(matches!(
+                    result,
+                    crate::code::ExternalSessionResolution::Created(_)
+                ));
+            }
+            "revoke" => {
+                let result = crate::db::code::revoke_external_grant(
+                    &task_store,
+                    &task_owner,
+                    grant.id,
+                    "second reason",
+                )
+                .await?;
+                let revoked = result.unwrap();
+                assert_eq!(revoked.revoked_reason.as_deref(), Some("first reason"));
+                assert_eq!(revoked.revoked_at, revoked_at);
+            }
+            "admin-revoke" => {
+                let result = crate::db::code::revoke_external_grant_all_owners(
+                    &task_store,
+                    grant.id,
+                    "second reason",
+                )
+                .await?;
+                let revoked = result.unwrap();
+                assert_eq!(revoked.revoked_reason.as_deref(), Some("first reason"));
+                assert_eq!(revoked.revoked_at, revoked_at);
+            }
+            _ => unreachable!(),
+        }
+        Ok::<(), crate::AgentError>(())
+    });
+    // A read followed by a write fails immediately with SQLITE_BUSY here.
+    // Taking the writer before the first read instead waits for this commit.
+    let early = tokio::time::timeout(Duration::from_millis(100), &mut task).await;
+    writer.commit().await.unwrap();
+    assert!(
+        early.is_err(),
+        "the mutation must wait for the writer: {early:?}"
+    );
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+}
+
+#[tokio::test]
+async fn external_creation_waits_for_sqlite_writer() {
+    external_mutation_waits_for_sqlite_writer("create").await;
+}
+
+#[tokio::test]
+async fn grant_revocation_waits_for_sqlite_writer() {
+    external_mutation_waits_for_sqlite_writer("revoke").await;
+}
+
+#[tokio::test]
+async fn admin_grant_revocation_waits_for_sqlite_writer() {
+    external_mutation_waits_for_sqlite_writer("admin-revoke").await;
+}

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -484,6 +484,8 @@ mod tests {
         /// Every events read issued, scripted or not.
         event_reads_issued: StdMutex<usize>,
         cancels: StdMutex<Vec<String>>,
+        status_override: StdMutex<Option<SandboxStatus>>,
+        status_reads: StdMutex<usize>,
     }
 
     #[async_trait]
@@ -517,6 +519,10 @@ mod tests {
             _session: tidebreak_core::SessionId,
             sandbox_id: &str,
         ) -> Result<SandboxStatus, RemoteSandboxError> {
+            *self.status_reads.lock().unwrap() += 1;
+            if let Some(status) = self.status_override.lock().unwrap().clone() {
+                return Ok(status);
+            }
             Ok(SandboxStatus {
                 sandbox_id: sandbox_id.to_owned(),
                 state: SandboxState::Running,
@@ -1557,8 +1563,24 @@ mod tests {
         );
     }
 
+    fn idle_status(sandbox_id: &str, latest_event_seq: i64) -> SandboxStatus {
+        SandboxStatus {
+            sandbox_id: sandbox_id.into(),
+            state: SandboxState::Failed,
+            failure_reason: Some("idle_ceiling".into()),
+            termination_reason: None,
+            latest_event_seq,
+            pending_messages: 0,
+            spend_microusd: Some(100_000),
+            spend_ceiling_microusd: Some(5_000_000),
+            possibly_stalled: false,
+            repository_url: None,
+            completed_at: Some(chrono::Utc::now().to_rfc3339()),
+        }
+    }
+
     #[tokio::test]
-    async fn slack_message_after_reap_starts_without_replaying_queued_work() {
+    async fn slack_message_after_idle_recovery_preserves_history_and_held_queues() {
         for (pending, manual_pause) in [(false, false), (true, false), (false, true)] {
             let dir = tempfile::tempdir().unwrap();
             let (runtime, fake, owner, _) = runtime_with_remote(dir.path()).await;
@@ -1615,8 +1637,8 @@ mod tests {
             // reaped an active lease, which hid the stopped-checkpoint refusal.
             fake.event_reads.lock().unwrap().push_back(SandboxEvents {
                 sandbox_id: "sb-1".into(),
-                state: SandboxState::Failed,
-                latest_event_seq: 4,
+                state: SandboxState::Running,
+                latest_event_seq: 3,
                 events: vec![
                     event(1, "turn_started", serde_json::json!({ "turn": 1 })),
                     event(
@@ -1629,8 +1651,33 @@ mod tests {
                         "turn_completed",
                         serde_json::json!({ "turn": 1, "exit_code": 0 }),
                     ),
-                    event(4, "failed", serde_json::json!({ "reason": "idle_ceiling" })),
                 ],
+            });
+            runtime
+                .remote_sessions()
+                .unwrap()
+                .driver(&runtime.db, runtime.bus.as_ref())
+                .pump(&mut session, 0)
+                .await
+                .unwrap();
+            assert_eq!(
+                latest_turn(&runtime.db, &owner, session.id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .status,
+                TurnStatus::Completed
+            );
+            // Expiry arrives on a later read, after the successful turn settled.
+            fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                sandbox_id: "sb-1".into(),
+                state: SandboxState::Failed,
+                latest_event_seq: 4,
+                events: vec![event(
+                    4,
+                    "failed",
+                    serde_json::json!({ "reason": "idle_ceiling" }),
+                )],
             });
             runtime
                 .remote_sessions()
@@ -1656,12 +1703,55 @@ mod tests {
                     .await
                     .unwrap();
             }
-            runtime.reap(&owner, session.id).await.unwrap();
+            assert!(matches!(
+                runtime
+                    .get_session(&owner, session.id)
+                    .await
+                    .unwrap()
+                    .fence_reason,
+                Some(FenceReason::TerminalFlushMissing { .. })
+            ));
+            *fake.status_override.lock().unwrap() = Some(idle_status("sb-1", 5));
+            fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                sandbox_id: "sb-1".into(),
+                state: SandboxState::Failed,
+                latest_event_seq: 5,
+                events: vec![event(
+                    5,
+                    "container_output",
+                    serde_json::json!({ "body": "stopped" }),
+                )],
+            });
+            // Upgrade a persisted fence without an explicit reap or queue reset.
+            let runtime = Arc::new(
+                CodeRuntime::new(
+                    runtime.db.clone(),
+                    dir.path().to_path_buf(),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .with_remote_sessions(RemoteSessions::new(fake.clone(), settings())),
+            );
+            runtime.recover().await.unwrap();
+            assert_eq!(
+                runtime
+                    .get_session(&owner, session.id)
+                    .await
+                    .unwrap()
+                    .lifecycle,
+                SessionLifecycle::Idle
+            );
+            assert!(fake.cancels.lock().unwrap().is_empty());
             assert_eq!(
                 fake.spawns.lock().unwrap().len(),
                 1,
-                "clearing a fault must not start work"
+                "recovery must not start work"
             );
+            *fake.status_override.lock().unwrap() = None;
             let result = runtime
                 .external_submit_message(&owner, grant, session.id, message("fresh retry"))
                 .await
@@ -1679,7 +1769,7 @@ mod tests {
             } else {
                 assert!(
                     matches!(result, ExternalMessageOutcome::NewTurn(_)),
-                    "fresh input must start after clearing an empty queue: {result:?}"
+                    "fresh input must start after recovering an empty queue: {result:?}"
                 );
                 {
                     let spawns = fake.spawns.lock().unwrap();
@@ -1769,6 +1859,200 @@ mod tests {
                         .1
                 );
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn idle_recovery_requires_completed_drained_scratch_output() {
+        for case in [
+            "running_turn",
+            "interrupted_turn",
+            "pending_message",
+            "unread_events",
+            "wrong_sandbox",
+            "running_sandbox",
+            "other_failure",
+            "repository_status",
+            "repository_workspace",
+            "spend_stop",
+            "spent_budget",
+            "earlier_incarnation",
+            "tail_has_turn",
+            "tail_wrong_sandbox",
+            "tail_not_terminal",
+            "tail_partial",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
+            let repository = (case == "repository_workspace").then_some(repo.id);
+            let grant = tidebreak_core::CodeGrantId::new();
+            let (resolution, _) = runtime
+                .external_get_or_create(
+                    &owner,
+                    None,
+                    grant,
+                    "slack",
+                    "T1/C1/refusal",
+                    repository,
+                    None,
+                    HarnessKind::ClaudeCode,
+                    session_settings(),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
+                panic!("expected creation");
+            };
+            let mut session = runtime
+                .get_session(&owner, binding.session_id)
+                .await
+                .unwrap();
+            runtime
+                .submit_turn(&owner, session.id, "start".into(), None, None, vec![], None)
+                .await
+                .unwrap();
+            fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                sandbox_id: "sb-1".into(),
+                state: SandboxState::Failed,
+                latest_event_seq: 4,
+                events: vec![
+                    event(1, "turn_started", serde_json::json!({ "turn": 1 })),
+                    event(
+                        2,
+                        "assistant_record",
+                        serde_json::json!({ "body": "answer" }),
+                    ),
+                    event(
+                        3,
+                        "turn_completed",
+                        serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                    ),
+                    event(4, "failed", serde_json::json!({ "reason": "idle_ceiling" })),
+                ],
+            });
+            runtime
+                .remote_sessions()
+                .unwrap()
+                .driver(&runtime.db, runtime.bus.as_ref())
+                .pump(&mut session, 0)
+                .await
+                .unwrap();
+            let mut status = idle_status("sb-1", 4);
+            match case {
+                "pending_message" => status.pending_messages = 1,
+                "unread_events" => status.latest_event_seq = 5,
+                "wrong_sandbox" => status.sandbox_id = "another-sandbox".into(),
+                "running_sandbox" => status.state = SandboxState::Running,
+                "other_failure" => status.failure_reason = Some("wall_clock_ceiling".into()),
+                "repository_status" => {
+                    status.repository_url = Some("https://github.com/test/tools".into())
+                }
+                "spend_stop" => {
+                    status.state = SandboxState::CeilingExceeded;
+                    status.failure_reason = Some("spend_ceiling_exceeded".into());
+                }
+                "spent_budget" => status.spend_microusd = status.spend_ceiling_microusd,
+                "running_turn" | "interrupted_turn" => {
+                    let mut turn = latest_turn(&runtime.db, &owner, session.id)
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    turn.status = if case == "running_turn" {
+                        TurnStatus::Running
+                    } else {
+                        TurnStatus::Interrupted
+                    };
+                    tidebreak_core::db::code::save_turn(&runtime.db, &owner, &turn)
+                        .await
+                        .unwrap();
+                }
+                "earlier_incarnation" => {
+                    use tidebreak_core::db::code::{
+                        activate_incarnation, create_incarnation_intent, stop_incarnation,
+                    };
+                    let tidebreak_core::IncarnationAdmission::Admitted(row) =
+                        create_incarnation_intent(&runtime.db, &owner, session.id, 2, 2)
+                            .await
+                            .unwrap()
+                    else {
+                        panic!("expected incarnation")
+                    };
+                    activate_incarnation(&runtime.db, &owner, row.id, "sb-2")
+                        .await
+                        .unwrap();
+                    tidebreak_core::db::code::ingest_incarnation_event(
+                        &runtime.db,
+                        &owner,
+                        session.id,
+                        session.spawn_epoch,
+                        row.id,
+                        4,
+                        tidebreak_core::db::code::IncarnationSideEffects {
+                            journal: &[],
+                            task_output: None,
+                            wip_ref: None,
+                            terminal_events_journaled: false,
+                        },
+                    )
+                    .await
+                    .unwrap();
+                    stop_incarnation(&runtime.db, &owner, row.id, Some("failed"))
+                        .await
+                        .unwrap();
+                    status.sandbox_id = "sb-2".into();
+                }
+                "tail_has_turn" | "tail_wrong_sandbox" | "tail_not_terminal" | "tail_partial" => {
+                    status.latest_event_seq = 6;
+                    fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                        sandbox_id: if case == "tail_wrong_sandbox" {
+                            "sb-other"
+                        } else {
+                            "sb-1"
+                        }
+                        .into(),
+                        state: if case == "tail_not_terminal" {
+                            SandboxState::Running
+                        } else {
+                            SandboxState::Failed
+                        },
+                        latest_event_seq: 6,
+                        events: vec![event(
+                            5,
+                            if case == "tail_has_turn" {
+                                "turn_started"
+                            } else {
+                                "container_output"
+                            },
+                            serde_json::json!({ "body": "late diagnostic", "turn": 2 }),
+                        )],
+                    });
+                }
+                "repository_workspace" => {}
+                _ => unreachable!(),
+            }
+            *fake.status_override.lock().unwrap() = Some(status);
+            let status_reads = *fake.status_reads.lock().unwrap();
+            // Recovery sees the same persisted fence on subsequent sweeps.
+            runtime.recover().await.unwrap();
+            runtime.recover().await.unwrap();
+            if case == "other_failure" {
+                assert_eq!(
+                    *fake.status_reads.lock().unwrap(),
+                    status_reads + 1,
+                    "repeated sweeps must pace status probes"
+                );
+            }
+            let current = runtime.get_session(&owner, session.id).await.unwrap();
+            assert_eq!(current.lifecycle, SessionLifecycle::Fenced, "{case}");
+            let row = tidebreak_core::db::code::latest_incarnation(&runtime.db, &owner, session.id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(!row.terminal_events_journaled, "{case}");
+            assert_eq!(fake.spawns.lock().unwrap().len(), 1, "{case}");
+            assert!(fake.cancels.lock().unwrap().is_empty(), "{case}");
         }
     }
 

--- a/crates/tidebreak-server/src/code/remote/service.rs
+++ b/crates/tidebreak-server/src/code/remote/service.rs
@@ -1862,198 +1862,208 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn idle_recovery_requires_completed_drained_scratch_output() {
-        for case in [
-            "running_turn",
-            "interrupted_turn",
-            "pending_message",
-            "unread_events",
-            "wrong_sandbox",
-            "running_sandbox",
-            "other_failure",
-            "repository_status",
-            "repository_workspace",
-            "spend_stop",
-            "spent_budget",
-            "earlier_incarnation",
-            "tail_has_turn",
-            "tail_wrong_sandbox",
-            "tail_not_terminal",
-            "tail_partial",
-        ] {
-            let dir = tempfile::tempdir().unwrap();
-            let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
-            let repository = (case == "repository_workspace").then_some(repo.id);
-            let grant = tidebreak_core::CodeGrantId::new();
-            let (resolution, _) = runtime
-                .external_get_or_create(
+    async fn assert_idle_recovery_refuses(case: &str) {
+        let dir = tempfile::tempdir().unwrap();
+        let (runtime, fake, owner, repo) = runtime_with_remote(dir.path()).await;
+        let repository = (case == "repository_workspace").then_some(repo.id);
+        let grant = tidebreak_core::CodeGrantId::new();
+        let (resolution, _) = runtime
+            .external_get_or_create(
+                &owner,
+                None,
+                grant,
+                "slack",
+                "T1/C1/refusal",
+                repository,
+                None,
+                HarnessKind::ClaudeCode,
+                session_settings(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
+            panic!("expected creation");
+        };
+        let mut session = runtime
+            .get_session(&owner, binding.session_id)
+            .await
+            .unwrap();
+        runtime
+            .submit_turn(&owner, session.id, "start".into(), None, None, vec![], None)
+            .await
+            .unwrap();
+        fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+            sandbox_id: "sb-1".into(),
+            state: SandboxState::Failed,
+            latest_event_seq: 4,
+            events: vec![
+                event(1, "turn_started", serde_json::json!({ "turn": 1 })),
+                event(
+                    2,
+                    "assistant_record",
+                    serde_json::json!({ "body": "answer" }),
+                ),
+                event(
+                    3,
+                    "turn_completed",
+                    serde_json::json!({ "turn": 1, "exit_code": 0 }),
+                ),
+                event(4, "failed", serde_json::json!({ "reason": "idle_ceiling" })),
+            ],
+        });
+        runtime
+            .remote_sessions()
+            .unwrap()
+            .driver(&runtime.db, runtime.bus.as_ref())
+            .pump(&mut session, 0)
+            .await
+            .unwrap();
+        let mut status = idle_status("sb-1", 4);
+        match case {
+            "pending_message" => status.pending_messages = 1,
+            "unread_events" => status.latest_event_seq = 5,
+            "wrong_sandbox" => status.sandbox_id = "another-sandbox".into(),
+            "running_sandbox" => status.state = SandboxState::Running,
+            "other_failure" => status.failure_reason = Some("wall_clock_ceiling".into()),
+            "repository_status" => {
+                status.repository_url = Some("https://github.com/test/tools".into())
+            }
+            "spend_stop" => {
+                status.state = SandboxState::CeilingExceeded;
+                status.failure_reason = Some("spend_ceiling_exceeded".into());
+            }
+            "spent_budget" => status.spend_microusd = status.spend_ceiling_microusd,
+            "running_turn" | "interrupted_turn" => {
+                let mut turn = latest_turn(&runtime.db, &owner, session.id)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                turn.status = if case == "running_turn" {
+                    TurnStatus::Running
+                } else {
+                    TurnStatus::Interrupted
+                };
+                tidebreak_core::db::code::save_turn(&runtime.db, &owner, &turn)
+                    .await
+                    .unwrap();
+            }
+            "earlier_incarnation" => {
+                use tidebreak_core::db::code::{
+                    activate_incarnation, create_incarnation_intent, stop_incarnation,
+                };
+                let tidebreak_core::IncarnationAdmission::Admitted(row) =
+                    create_incarnation_intent(&runtime.db, &owner, session.id, 2, 2)
+                        .await
+                        .unwrap()
+                else {
+                    panic!("expected incarnation")
+                };
+                activate_incarnation(&runtime.db, &owner, row.id, "sb-2")
+                    .await
+                    .unwrap();
+                tidebreak_core::db::code::ingest_incarnation_event(
+                    &runtime.db,
                     &owner,
-                    None,
-                    grant,
-                    "slack",
-                    "T1/C1/refusal",
-                    repository,
-                    None,
-                    HarnessKind::ClaudeCode,
-                    session_settings(),
-                    None,
-                    None,
+                    session.id,
+                    session.spawn_epoch,
+                    row.id,
+                    4,
+                    tidebreak_core::db::code::IncarnationSideEffects {
+                        journal: &[],
+                        task_output: None,
+                        wip_ref: None,
+                        terminal_events_journaled: false,
+                    },
                 )
                 .await
                 .unwrap();
-            let tidebreak_core::ExternalSessionResolution::Created(binding) = resolution else {
-                panic!("expected creation");
-            };
-            let mut session = runtime
-                .get_session(&owner, binding.session_id)
-                .await
-                .unwrap();
-            runtime
-                .submit_turn(&owner, session.id, "start".into(), None, None, vec![], None)
-                .await
-                .unwrap();
-            fake.event_reads.lock().unwrap().push_back(SandboxEvents {
-                sandbox_id: "sb-1".into(),
-                state: SandboxState::Failed,
-                latest_event_seq: 4,
-                events: vec![
-                    event(1, "turn_started", serde_json::json!({ "turn": 1 })),
-                    event(
-                        2,
-                        "assistant_record",
-                        serde_json::json!({ "body": "answer" }),
-                    ),
-                    event(
-                        3,
-                        "turn_completed",
-                        serde_json::json!({ "turn": 1, "exit_code": 0 }),
-                    ),
-                    event(4, "failed", serde_json::json!({ "reason": "idle_ceiling" })),
-                ],
-            });
-            runtime
-                .remote_sessions()
-                .unwrap()
-                .driver(&runtime.db, runtime.bus.as_ref())
-                .pump(&mut session, 0)
-                .await
-                .unwrap();
-            let mut status = idle_status("sb-1", 4);
-            match case {
-                "pending_message" => status.pending_messages = 1,
-                "unread_events" => status.latest_event_seq = 5,
-                "wrong_sandbox" => status.sandbox_id = "another-sandbox".into(),
-                "running_sandbox" => status.state = SandboxState::Running,
-                "other_failure" => status.failure_reason = Some("wall_clock_ceiling".into()),
-                "repository_status" => {
-                    status.repository_url = Some("https://github.com/test/tools".into())
-                }
-                "spend_stop" => {
-                    status.state = SandboxState::CeilingExceeded;
-                    status.failure_reason = Some("spend_ceiling_exceeded".into());
-                }
-                "spent_budget" => status.spend_microusd = status.spend_ceiling_microusd,
-                "running_turn" | "interrupted_turn" => {
-                    let mut turn = latest_turn(&runtime.db, &owner, session.id)
-                        .await
-                        .unwrap()
-                        .unwrap();
-                    turn.status = if case == "running_turn" {
-                        TurnStatus::Running
-                    } else {
-                        TurnStatus::Interrupted
-                    };
-                    tidebreak_core::db::code::save_turn(&runtime.db, &owner, &turn)
-                        .await
-                        .unwrap();
-                }
-                "earlier_incarnation" => {
-                    use tidebreak_core::db::code::{
-                        activate_incarnation, create_incarnation_intent, stop_incarnation,
-                    };
-                    let tidebreak_core::IncarnationAdmission::Admitted(row) =
-                        create_incarnation_intent(&runtime.db, &owner, session.id, 2, 2)
-                            .await
-                            .unwrap()
-                    else {
-                        panic!("expected incarnation")
-                    };
-                    activate_incarnation(&runtime.db, &owner, row.id, "sb-2")
-                        .await
-                        .unwrap();
-                    tidebreak_core::db::code::ingest_incarnation_event(
-                        &runtime.db,
-                        &owner,
-                        session.id,
-                        session.spawn_epoch,
-                        row.id,
-                        4,
-                        tidebreak_core::db::code::IncarnationSideEffects {
-                            journal: &[],
-                            task_output: None,
-                            wip_ref: None,
-                            terminal_events_journaled: false,
-                        },
-                    )
+                stop_incarnation(&runtime.db, &owner, row.id, Some("failed"))
                     .await
                     .unwrap();
-                    stop_incarnation(&runtime.db, &owner, row.id, Some("failed"))
-                        .await
-                        .unwrap();
-                    status.sandbox_id = "sb-2".into();
-                }
-                "tail_has_turn" | "tail_wrong_sandbox" | "tail_not_terminal" | "tail_partial" => {
-                    status.latest_event_seq = 6;
-                    fake.event_reads.lock().unwrap().push_back(SandboxEvents {
-                        sandbox_id: if case == "tail_wrong_sandbox" {
-                            "sb-other"
+                status.sandbox_id = "sb-2".into();
+            }
+            "tail_has_turn" | "tail_wrong_sandbox" | "tail_not_terminal" | "tail_partial" => {
+                status.latest_event_seq = 6;
+                fake.event_reads.lock().unwrap().push_back(SandboxEvents {
+                    sandbox_id: if case == "tail_wrong_sandbox" {
+                        "sb-other"
+                    } else {
+                        "sb-1"
+                    }
+                    .into(),
+                    state: if case == "tail_not_terminal" {
+                        SandboxState::Running
+                    } else {
+                        SandboxState::Failed
+                    },
+                    latest_event_seq: 6,
+                    events: vec![event(
+                        5,
+                        if case == "tail_has_turn" {
+                            "turn_started"
                         } else {
-                            "sb-1"
-                        }
-                        .into(),
-                        state: if case == "tail_not_terminal" {
-                            SandboxState::Running
-                        } else {
-                            SandboxState::Failed
+                            "container_output"
                         },
-                        latest_event_seq: 6,
-                        events: vec![event(
-                            5,
-                            if case == "tail_has_turn" {
-                                "turn_started"
-                            } else {
-                                "container_output"
-                            },
-                            serde_json::json!({ "body": "late diagnostic", "turn": 2 }),
-                        )],
-                    });
-                }
-                "repository_workspace" => {}
-                _ => unreachable!(),
+                        serde_json::json!({ "body": "late diagnostic", "turn": 2 }),
+                    )],
+                });
             }
-            *fake.status_override.lock().unwrap() = Some(status);
-            let status_reads = *fake.status_reads.lock().unwrap();
-            // Recovery sees the same persisted fence on subsequent sweeps.
-            runtime.recover().await.unwrap();
-            runtime.recover().await.unwrap();
-            if case == "other_failure" {
-                assert_eq!(
-                    *fake.status_reads.lock().unwrap(),
-                    status_reads + 1,
-                    "repeated sweeps must pace status probes"
-                );
-            }
-            let current = runtime.get_session(&owner, session.id).await.unwrap();
-            assert_eq!(current.lifecycle, SessionLifecycle::Fenced, "{case}");
-            let row = tidebreak_core::db::code::latest_incarnation(&runtime.db, &owner, session.id)
-                .await
-                .unwrap()
-                .unwrap();
-            assert!(!row.terminal_events_journaled, "{case}");
-            assert_eq!(fake.spawns.lock().unwrap().len(), 1, "{case}");
-            assert!(fake.cancels.lock().unwrap().is_empty(), "{case}");
+            "repository_workspace" => {}
+            _ => unreachable!(),
         }
+        *fake.status_override.lock().unwrap() = Some(status);
+        let status_reads = *fake.status_reads.lock().unwrap();
+        // Recovery sees the same persisted fence on subsequent sweeps.
+        runtime.recover().await.unwrap();
+        runtime.recover().await.unwrap();
+        if case == "other_failure" {
+            assert_eq!(
+                *fake.status_reads.lock().unwrap(),
+                status_reads + 1,
+                "repeated sweeps must pace status probes"
+            );
+        }
+        let current = runtime.get_session(&owner, session.id).await.unwrap();
+        assert_eq!(current.lifecycle, SessionLifecycle::Fenced, "{case}");
+        let row = tidebreak_core::db::code::latest_incarnation(&runtime.db, &owner, session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!row.terminal_events_journaled, "{case}");
+        assert_eq!(fake.spawns.lock().unwrap().len(), 1, "{case}");
+        assert!(fake.cancels.lock().unwrap().is_empty(), "{case}");
+    }
+
+    macro_rules! idle_recovery_refusal_tests {
+        ($($name:ident => $case:literal),+ $(,)?) => {
+            $(
+                #[tokio::test]
+                async fn $name() {
+                    assert_idle_recovery_refuses($case).await;
+                }
+            )+
+        };
+    }
+
+    idle_recovery_refusal_tests! {
+        idle_recovery_refuses_running_turn => "running_turn",
+        idle_recovery_refuses_interrupted_turn => "interrupted_turn",
+        idle_recovery_refuses_pending_message => "pending_message",
+        idle_recovery_refuses_unread_events => "unread_events",
+        idle_recovery_refuses_wrong_sandbox => "wrong_sandbox",
+        idle_recovery_refuses_running_sandbox => "running_sandbox",
+        idle_recovery_refuses_other_failure => "other_failure",
+        idle_recovery_refuses_repository_status => "repository_status",
+        idle_recovery_refuses_repository_workspace => "repository_workspace",
+        idle_recovery_refuses_spend_stop => "spend_stop",
+        idle_recovery_refuses_spent_budget => "spent_budget",
+        idle_recovery_refuses_earlier_incarnation => "earlier_incarnation",
+        idle_recovery_refuses_tail_has_turn => "tail_has_turn",
+        idle_recovery_refuses_tail_wrong_sandbox => "tail_wrong_sandbox",
+        idle_recovery_refuses_tail_not_terminal => "tail_not_terminal",
+        idle_recovery_refuses_tail_partial => "tail_partial",
     }
 
     /// Stop on a remote session sends an interrupt to the sandbox instead of

--- a/crates/tidebreak-server/src/code/runtime/auto_recovery.rs
+++ b/crates/tidebreak-server/src/code/runtime/auto_recovery.rs
@@ -144,13 +144,31 @@ impl CodeRuntime {
                 ExecutionLocation::Machine,
                 Some(FenceReason::OrphanAlive | FenceReason::ResumeLost { .. }),
             ) => true,
-            (ExecutionLocation::Sandbox, Some(FenceReason::SandboxLost { .. })) => {
-                let row = tidebreak_core::db::code::latest_incarnation(
+            (
+                ExecutionLocation::Sandbox,
+                Some(FenceReason::SandboxLost { .. } | FenceReason::TerminalFlushMissing { .. }),
+            ) => {
+                let mut row = tidebreak_core::db::code::latest_incarnation(
                     &self.db,
                     &session.owner,
                     session.id,
                 )
                 .await?;
+                if let Some(stopped) = row.as_mut() {
+                    if !stopped.terminal_events_journaled
+                        && self
+                            .completed_idle_scratch_is_drained(&session, stopped)
+                            .await?
+                    {
+                        tidebreak_core::db::code::mark_incarnation_terminal_events_journaled(
+                            &self.db,
+                            &session.owner,
+                            stopped.id,
+                        )
+                        .await?;
+                        stopped.terminal_events_journaled = true;
+                    }
+                }
                 match row {
                     Some(row)
                         if row.state == IncarnationState::Stopped
@@ -323,6 +341,101 @@ impl CodeRuntime {
             }
         }
         Ok(())
+    }
+
+    // An idle shutdown can omit the supervisor's goodbye after a successful
+    // turn. Recover only scratch sessions whose complete output is durable.
+    async fn completed_idle_scratch_is_drained(
+        &self,
+        session: &Session,
+        row: &tidebreak_core::CodeSessionIncarnation,
+    ) -> Result<bool, ServerError> {
+        use crate::code::remote::wire::SandboxState;
+        use tidebreak_core::db::code::{latest_incarnation, latest_turn, record_incarnation_spend};
+
+        if session.workspace_id.is_some()
+            || row.state != IncarnationState::Stopped
+            || !matches!(row.stop_reason.as_deref(), Some("failed" | "expired"))
+            || row.events_cursor <= 0
+        {
+            return Ok(false);
+        }
+        let Some(turn) = latest_turn(&self.db, &session.owner, session.id).await? else {
+            return Ok(false);
+        };
+        if turn.status != tidebreak_core::TurnStatus::Completed
+            || turn.ordinal < i64::from(row.starting_turn)
+        {
+            return Ok(false);
+        }
+        let (Some(remote), Some(sandbox_id)) = (self.remote_sessions(), row.sandbox_id.as_deref())
+        else {
+            return Ok(false);
+        };
+        {
+            let now = Instant::now();
+            let mut probes = self.recovery_probe_times.lock().expect("recovery probes");
+            probes.retain(|_, next| *next > now);
+            if probes.contains_key(&row.id) {
+                return Ok(false);
+            }
+            probes.insert(row.id, now + RECOVERY_BACKOFF);
+        }
+        let status = tokio::time::timeout(
+            Duration::from_secs(5),
+            remote
+                .provisioner
+                .status(&session.owner, session.id, sandbox_id),
+        )
+        .await;
+        let Ok(Ok(status)) = status else {
+            return Ok(false);
+        };
+        if status.sandbox_id != sandbox_id
+            || !matches!(status.state, SandboxState::Failed | SandboxState::Expired)
+            || status.failure_reason.as_deref() != Some("idle_ceiling")
+            || status.pending_messages != 0
+            || status.repository_url.is_some()
+            || status.latest_event_seq <= 0
+            || status
+                .spend_microusd
+                .zip(status.spend_ceiling_microusd)
+                .is_some_and(|(spend, ceiling)| spend >= ceiling)
+        {
+            return Ok(false);
+        }
+        if row.events_cursor < status.latest_event_seq {
+            // Fenced sessions have no pump. Catch up one page per probe while
+            // keeping the fence and all queue holds in place.
+            let drain = tokio::time::timeout(
+                Duration::from_secs(5),
+                remote
+                    .driver(&self.db, self.bus.as_ref())
+                    .drain_stopped_events(session, row.id),
+            )
+            .await;
+            if !matches!(drain, Ok(Ok(true))) {
+                return Ok(false);
+            }
+        }
+        // Status is remote I/O. Recheck the durable identity and turn before
+        // accepting the drain; a newer incarnation cannot inherit this proof.
+        let current = latest_incarnation(&self.db, &session.owner, session.id).await?;
+        let latest = latest_turn(&self.db, &session.owner, session.id).await?;
+        if !current.is_some_and(|current| {
+            current.id == row.id
+                && current.state == IncarnationState::Stopped
+                && current.sandbox_id.as_deref() == Some(sandbox_id)
+                && current.events_cursor >= status.latest_event_seq
+        }) || !latest.is_some_and(|latest| {
+            latest.id == turn.id && latest.status == tidebreak_core::TurnStatus::Completed
+        }) {
+            return Ok(false);
+        }
+        if let Some(spend) = status.spend_microusd {
+            record_incarnation_spend(&self.db, &session.owner, row.id, spend).await?;
+        }
+        Ok(true)
     }
 
     pub(super) async fn retain_failed_recovery(

--- a/crates/tidebreak-server/src/code/runtime/mod.rs
+++ b/crates/tidebreak-server/src/code/runtime/mod.rs
@@ -273,6 +273,7 @@ pub struct CodeRuntime {
     workers: Mutex<HashMap<SessionId, WorkerHandle>>,
     recovery_locks: Mutex<HashMap<SessionId, std::sync::Weak<tokio::sync::Mutex<()>>>>,
     recovery_attempts: Mutex<HashMap<SessionId, auto_recovery::RecoveryAttempt>>,
+    recovery_probe_times: Mutex<HashMap<tidebreak_core::CodeIncarnationId, Instant>>,
     recovery_sweep: Mutex<Option<auto_recovery::RecoverySweepGuard>>,
     recovery_started: AtomicBool,
     /// Sessions whose worker must move to the selected engine binary once
@@ -553,6 +554,7 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             recovery_locks: Mutex::new(HashMap::new()),
             recovery_attempts: Mutex::new(HashMap::new()),
+            recovery_probe_times: Mutex::new(HashMap::new()),
             recovery_sweep: Mutex::new(None),
             recovery_started: AtomicBool::new(false),
             deferred_resyncs: Mutex::new(HashSet::new()),
@@ -731,6 +733,7 @@ impl CodeRuntime {
             workers: Mutex::new(HashMap::new()),
             recovery_locks: Mutex::new(HashMap::new()),
             recovery_attempts: Mutex::new(HashMap::new()),
+            recovery_probe_times: Mutex::new(HashMap::new()),
             recovery_sweep: Mutex::new(None),
             recovery_started: AtomicBool::new(false),
             deferred_resyncs: Mutex::new(HashSet::new()),


### PR DESCRIPTION
Slack threads can stay paused after a successful turn when an idle sandbox stops without a supervisor goodbye. Recover those scratch sessions after fresh Gateway status confirms the idle shutdown, no pending messages, a completed turn from that sandbox, and fully saved output.

Drain one bounded page of late events when needed. Keep unfinished turns, repository sessions, spend stops, and unread work fenced. Preserve manually paused queues and queued messages; only a fresh message starts the replacement sandbox with retained history.

Session creation and grant revocation also take the grant write lock before reading. This prevents SQLite from rejecting a read-to-write upgrade when another worker writes concurrently. Owner checks and the first revocation reason and timestamp remain intact.

Validation passed locally:
- All 17 focused idle-recovery regression tests, including the persisted-fence restart path and 16 refusal cases.
- All 55 tidebreak-code-remote library tests and all 13 automatic-recovery tests.
- All 48 focused core external/grant tests, including three pooled SQLite regressions that fail without the write lock.
- All 8 external model-selection API tests.
- Core Clippy with warnings denied, cargo fmt, and git diff --check.